### PR TITLE
Add Apache 2 license

### DIFF
--- a/.idea/copyright/Apache2.xml
+++ b/.idea/copyright/Apache2.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="&#10;/**&#10; * Copyright &amp;#36;today.year The MQTT Bee project.&#10; *&#10; * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10; * you may not use this file except in compliance with the License.&#10; * You may obtain a copy of the License at&#10; *&#10; *     http://www.apache.org/licenses/LICENSE-2.0&#10; *&#10; * Unless required by applicable law or agreed to in writing, software&#10; * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10; * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10; * See the License for the specific language governing permissions and&#10; * limitations under the License.&#10; */" />
+    <option name="myName" value="Apache2" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Apache2" />
+</component>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/main/java/org/mqttbee/annotations/DoNotImplement.java
+++ b/src/main/java/org/mqttbee/annotations/DoNotImplement.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.annotations;
 
 import java.lang.annotation.Documented;

--- a/src/main/java/org/mqttbee/annotations/NotNull.java
+++ b/src/main/java/org/mqttbee/annotations/NotNull.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.annotations;
 
 import java.lang.annotation.Documented;

--- a/src/main/java/org/mqttbee/annotations/Nullable.java
+++ b/src/main/java/org/mqttbee/annotations/Nullable.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.annotations;
 
 import java.lang.annotation.Documented;

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClient.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClient.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt;
 
 import io.reactivex.Scheduler;

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttClientIdentifier.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttClientIdentifier.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttQoS.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttQoS.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilter.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttUTF8String.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttUTF8String.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/AlreadyConnectedException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/AlreadyConnectedException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/ChannelClosedException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/ChannelClosedException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/MqttBinaryDataExceededException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/MqttBinaryDataExceededException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/MqttMaximumPacketSizeExceededException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/MqttMaximumPacketSizeExceededException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/MqttVariableByteIntegerExceededException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/MqttVariableByteIntegerExceededException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/NotConnectedException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/NotConnectedException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/exceptions/PacketIdentifiersExceededException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/exceptions/PacketIdentifiersExceededException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3;
 
 import io.reactivex.Completable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientConnectionData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientConnectionData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ServerConnectionData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ServerConnectionData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/Mqtt3Message.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/Mqtt3Message.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/Mqtt3MessageType.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/Mqtt3MessageType.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuth.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.auth;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.auth;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.connect;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.connect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/connack/Mqtt3ConnAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/connack/Mqtt3ConnAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.connect.connack;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/connack/Mqtt3ConnAckReturnCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/connack/Mqtt3ConnAckReturnCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.connect.connack;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/disconnect/Mqtt3Disconnect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/disconnect/Mqtt3Disconnect.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.disconnect;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/ping/Mqtt3PingReq.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/ping/Mqtt3PingReq.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.ping;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/ping/Mqtt3PingResp.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/ping/Mqtt3PingResp.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.ping;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishResult.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishResult.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/puback/Mqtt3PubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/puback/Mqtt3PubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish.puback;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/pubcomp/Mqtt3PubComp.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/pubcomp/Mqtt3PubComp.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish.pubcomp;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/pubrec/Mqtt3PubRec.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/pubrec/Mqtt3PubRec.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish.pubrec;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/pubrel/Mqtt3PubRel.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/pubrel/Mqtt3PubRel.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.publish.pubrel;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeResult.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeResult.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscription.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscription.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/suback/Mqtt3SubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/suback/Mqtt3SubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/suback/Mqtt3SubAckReturnCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/suback/Mqtt3SubAckReturnCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.unsubscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.unsubscribe;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/unsuback/Mqtt3UnsubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/unsuback/Mqtt3UnsubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.unsuback;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5;
 
 import io.reactivex.Completable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5;
 
 import dagger.internal.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientConnectionData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientConnectionData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ServerConnectionData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ServerConnectionData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.advanced;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientDataBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientDataBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.advanced;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5IncomingQoS1ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5IncomingQoS1ControlProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.advanced.qos1;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5OutgoingQoS1ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5OutgoingQoS1ControlProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.advanced.qos1;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5IncomingQoS2ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5IncomingQoS2ControlProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.advanced.qos2;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5OutgoingQoS2ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5OutgoingQoS2ControlProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.advanced.qos2;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/auth/Mqtt5EnhancedAuthProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/auth/Mqtt5EnhancedAuthProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.auth;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.datatypes;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperty.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.datatypes;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/exceptions/Mqtt5MessageException.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/exceptions/Mqtt5MessageException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.exceptions;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5Message.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5Message.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5MessageType.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5MessageType.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5ReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5ReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5Auth.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5Auth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5EnhancedAuth.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5EnhancedAuth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5EnhancedAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5EnhancedAuthBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuth.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.auth;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictions.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictions.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect.connack;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAckReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAckReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect.connack;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAckRestrictions.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAckRestrictions.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.connect.connack;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.disconnect;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.disconnect;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.disconnect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/ping/Mqtt5PingReq.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/ping/Mqtt5PingReq.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.ping;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/ping/Mqtt5PingResp.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/ping/Mqtt5PingResp.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.ping;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PayloadFormatIndicator.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PayloadFormatIndicator.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishResult.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishResult.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/TopicAliasUsage.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/TopicAliasUsage.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.puback;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.puback;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.puback;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubComp.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubComp.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRec.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRec.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRel.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRel.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5RetainHandling.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5RetainHandling.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeResult.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeResult.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscription.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscription.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/suback/Mqtt5SubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/suback/Mqtt5SubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/suback/Mqtt5SubAckReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/suback/Mqtt5SubAckReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/unsuback/Mqtt5UnsubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/unsuback/Mqtt5UnsubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/unsuback/Mqtt5UnsubAckReasonCode.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/unsuback/Mqtt5UnsubAckReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/MqttClientConnectionData.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientConnectionData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt/MqttClientData.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt;
 
 import io.reactivex.Scheduler;

--- a/src/main/java/org/mqttbee/mqtt/MqttServerConnectionData.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttServerConnectionData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt/MqttVersion.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttVersion.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt;
 
 /**

--- a/src/main/java/org/mqttbee/mqtt/advanced/MqttAdvancedClientData.java
+++ b/src/main/java/org/mqttbee/mqtt/advanced/MqttAdvancedClientData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.advanced;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttDecoderException.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttDecoderException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttDecoderModule.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttDecoderModule.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import dagger.Lazy;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoderUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoders.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoders.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttPingRespDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttPingRespDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ClientMessageDecoders.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ClientMessageDecoders.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ConnAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ConnAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3MessageDecoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3MessageDecoderUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import org.mqttbee.mqtt.codec.decoder.MqttDecoderException;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubCompDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubCompDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRecDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRecDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRelDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRelDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PublishDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3SubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3SubAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3UnsubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3UnsubAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ClientMessageDecoders.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ClientMessageDecoders.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import org.mqttbee.annotations.Nullable;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5MessageDecoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5MessageDecoderUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.base.Utf8;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttMessageEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttMessageEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttMessageEncoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttMessageEncoderUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttMessageEncoderWithMessage.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttMessageEncoderWithMessage.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttPingReqEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttPingReqEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttWrappedMessageEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/MqttWrappedMessageEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3DisconnectEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3DisconnectEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubAckEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubAckEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubCompEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubCompEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRecEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRecEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRelEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRelEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PublishEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PublishEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3SubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3SubscribeEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3UnsubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3UnsubscribeEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3WrappedMessageEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3WrappedMessageEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5DisconnectEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5DisconnectEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5MessageWithUserPropertiesEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5MessageWithUserPropertiesEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubAckEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubAckEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubCompEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubCompEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRecEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRecEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRelEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRelEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.primitives.ImmutableIntArray;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5WrappedMessageEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5WrappedMessageEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageEncoderApplier.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageEncoderApplier.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageEncoderProvider.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageEncoderProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageWrapperEncoderApplier.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageWrapperEncoderApplier.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageWrapperEncoderProvider.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttMessageWrapperEncoderProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttPubRecEncoderProvider.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttPubRecEncoderProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttPubRelEncoderProvider.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttPubRelEncoderProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttPublishEncoderProvider.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttPublishEncoderProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttWrappedMessageEncoderApplier.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttWrappedMessageEncoderApplier.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttWrappedMessageEncoderProvider.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/provider/MqttWrappedMessageEncoderProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.provider;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttBinaryData.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttBinaryData.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttClientIdentifierImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttClientIdentifierImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicLevel.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicLevel.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUTF8StringImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUTF8StringImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.base.Utf8;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertyImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertyImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttVariableByteInteger.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttVariableByteInteger.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttCommonReasonCode.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttCommonReasonCode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5ReasonCode;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttMessage.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttMessage.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithEncoder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithUserProperties.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithUserProperties.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttMessageWrapper.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttMessageWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 /**

--- a/src/main/java/org/mqttbee/mqtt/message/MqttWrappedMessage.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttWrappedMessage.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuth.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuth.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuthBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttSimpleAuth.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttSimpleAuth.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/auth/mqtt3/Mqtt3SimpleAuthView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/mqtt3/Mqtt3SimpleAuthView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.auth.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnect.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectRestrictions.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectRestrictions.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectWrapper.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect.connack;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect.connack;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckRestrictions.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckRestrictions.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect.connack;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/mqtt3/Mqtt3ConnAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/mqtt3/Mqtt3ConnAckView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect.connack.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.connect.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnect.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.disconnect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnectProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnectProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.disconnect;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/mqtt3/Mqtt3DisconnectView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/mqtt3/Mqtt3DisconnectView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.disconnect.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingReq.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingReq.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.ping;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingResp.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingResp.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.ping;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingReqView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingReqView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.ping.mqtt3;
 
 import org.mqttbee.api.mqtt.mqtt3.message.ping.Mqtt3PingReq;

--- a/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingRespView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingRespView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.ping.mqtt3;
 
 import org.mqttbee.api.mqtt.mqtt3.message.ping.Mqtt3PingResp;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import com.google.common.primitives.ImmutableIntArray;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishResult.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishResult.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishWrapper.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import com.google.common.primitives.ImmutableIntArray;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttQoSMessage.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttQoSMessage.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 /**

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttTopicAliasMapping.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttTopicAliasMapping.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublishProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublishProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishResultView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishResultView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.puback;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.puback;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.puback;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/mqtt3/Mqtt3PubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/mqtt3/Mqtt3PubAckView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.puback.mqtt3;
 
 import org.mqttbee.api.mqtt.mqtt3.message.publish.puback.Mqtt3PubAck;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubComp.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubComp.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubcomp;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubcomp;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubcomp;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/mqtt3/Mqtt3PubCompView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/mqtt3/Mqtt3PubCompView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubcomp.mqtt3;
 
 import org.mqttbee.api.mqtt.mqtt3.message.publish.pubcomp.Mqtt3PubComp;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRec.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRec.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrec;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrec;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrec;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/mqtt3/Mqtt3PubRecView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/mqtt3/Mqtt3PubRecView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrec.mqtt3;
 
 import org.mqttbee.api.mqtt.mqtt3.message.publish.pubrec.Mqtt3PubRec;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRel.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRel.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrel;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrel;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrel;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/mqtt3/Mqtt3PubRelView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/mqtt3/Mqtt3PubRelView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.publish.pubrel.mqtt3;
 
 import org.mqttbee.api.mqtt.mqtt3.message.publish.pubrel.Mqtt3PubRel;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeWrapper.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscription.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscription.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe.suback;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAckProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAckProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe.suback;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.subscribe.suback.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeWrapper.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAck.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe.unsuback;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAckProperty.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAckProperty.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe.unsuback;
 
 import org.mqttbee.mqtt.message.MqttProperty;

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe.unsuback.mqtt3;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientDataView.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientDataView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientView.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientView.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.mqtt3;
 
 import io.reactivex.Completable;

--- a/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.util;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
+++ b/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5;
 
 import io.netty.bootstrap.Bootstrap;

--- a/src/main/java/org/mqttbee/mqtt5/handler/Mqtt5ChannelInitializer.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/Mqtt5ChannelInitializer.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler;
 
 import io.netty.channel.ChannelInitializer;

--- a/src/main/java/org/mqttbee/mqtt5/handler/Mqtt5ChannelInitializerProvider.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/Mqtt5ChannelInitializerProvider.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler;
 
 import io.reactivex.SingleEmitter;

--- a/src/main/java/org/mqttbee/mqtt5/handler/auth/AbstractMqtt5AuthHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/auth/AbstractMqtt5AuthHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.auth;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5AuthHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5AuthHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.auth;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5DisconnectOnAuthHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5DisconnectOnAuthHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.auth;
 
 import io.netty.channel.ChannelDuplexHandler;

--- a/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5ReAuthEvent.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5ReAuthEvent.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.auth;
 
 import io.reactivex.CompletableEmitter;

--- a/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5ReAuthHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/auth/Mqtt5ReAuthHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.auth;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/org/mqttbee/mqtt5/handler/connect/Mqtt5ConnectHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/connect/Mqtt5ConnectHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.connect;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/connect/Mqtt5DisconnectOnConnAckHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/connect/Mqtt5DisconnectOnConnAckHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.connect;
 
 import io.netty.channel.ChannelHandler;

--- a/src/main/java/org/mqttbee/mqtt5/handler/disconnect/ChannelCloseEvent.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/disconnect/ChannelCloseEvent.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.disconnect;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/disconnect/Mqtt3Disconnecter.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/disconnect/Mqtt3Disconnecter.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.disconnect;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/disconnect/Mqtt5DisconnectHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/disconnect/Mqtt5DisconnectHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.disconnect;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/disconnect/Mqtt5Disconnecter.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/disconnect/Mqtt5Disconnecter.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.disconnect;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/disconnect/MqttDisconnectUtil.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/disconnect/MqttDisconnectUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.disconnect;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/disconnect/MqttDisconnecter.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/disconnect/MqttDisconnecter.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.disconnect;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/ping/Mqtt5PingHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/ping/Mqtt5PingHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.ping;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/Mqtt5IncomingQoSHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/Mqtt5IncomingQoSHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/Mqtt5OutgoingQoSHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/Mqtt5OutgoingQoSHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttGlobalIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttGlobalIncomingPublishFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttGlobalIncomingPublishFlowable.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttGlobalIncomingPublishFlowable.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Flowable;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingAckFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingAckFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Emitter;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingAckFlowable.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingAckFlowable.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Flowable;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Emitter;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishFlows.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishFlows.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishFlowsWithId.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishFlowsWithId.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishService.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttIncomingPublishService.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.netty.channel.EventLoop;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttOutgoingPublishService.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttOutgoingPublishService.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Flowable;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttPublishFlowables.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttPublishFlowables.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Flowable;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttPublishWithFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttPublishWithFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlowList.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlowList.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlowTree.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlowTree.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlowable.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlowable.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import io.reactivex.Flowable;

--- a/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlows.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/publish/MqttSubscriptionFlows.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.publish;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/subscribe/MqttSubscribeWithFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/subscribe/MqttSubscribeWithFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.subscribe;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/handler/subscribe/MqttSubscriptionHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/subscribe/MqttSubscriptionHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.subscribe;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/org/mqttbee/mqtt5/handler/subscribe/MqttUnsubscribeWithFlow.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/subscribe/MqttUnsubscribeWithFlow.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.subscribe;
 
 import io.reactivex.SingleEmitter;

--- a/src/main/java/org/mqttbee/mqtt5/handler/util/ChannelInboundHandlerWithTimeout.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/util/ChannelInboundHandlerWithTimeout.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.util;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/org/mqttbee/mqtt5/handler/util/DefaultChannelOutboundHandler.java
+++ b/src/main/java/org/mqttbee/mqtt5/handler/util/DefaultChannelOutboundHandler.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.handler.util;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/org/mqttbee/mqtt5/ioc/ChannelComponent.java
+++ b/src/main/java/org/mqttbee/mqtt5/ioc/ChannelComponent.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.ioc;
 
 import dagger.BindsInstance;

--- a/src/main/java/org/mqttbee/mqtt5/ioc/ChannelModule.java
+++ b/src/main/java/org/mqttbee/mqtt5/ioc/ChannelModule.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.ioc;
 
 import dagger.Binds;

--- a/src/main/java/org/mqttbee/mqtt5/ioc/ChannelScope.java
+++ b/src/main/java/org/mqttbee/mqtt5/ioc/ChannelScope.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.ioc;
 
 import javax.inject.Scope;

--- a/src/main/java/org/mqttbee/mqtt5/ioc/MqttBeeComponent.java
+++ b/src/main/java/org/mqttbee/mqtt5/ioc/MqttBeeComponent.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.ioc;
 
 import dagger.Component;

--- a/src/main/java/org/mqttbee/mqtt5/netty/ChannelAttributes.java
+++ b/src/main/java/org/mqttbee/mqtt5/netty/ChannelAttributes.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.netty;
 
 import io.netty.channel.Channel;

--- a/src/main/java/org/mqttbee/mqtt5/netty/NettyBootstrap.java
+++ b/src/main/java/org/mqttbee/mqtt5/netty/NettyBootstrap.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.netty;
 
 import io.netty.bootstrap.Bootstrap;

--- a/src/main/java/org/mqttbee/mqtt5/netty/NettyEpollBootstrap.java
+++ b/src/main/java/org/mqttbee/mqtt5/netty/NettyEpollBootstrap.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.netty;
 
 import io.netty.channel.MultithreadEventLoopGroup;

--- a/src/main/java/org/mqttbee/mqtt5/netty/NettyModule.java
+++ b/src/main/java/org/mqttbee/mqtt5/netty/NettyModule.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.netty;
 
 import dagger.Lazy;

--- a/src/main/java/org/mqttbee/mqtt5/netty/NettyNioBootstrap.java
+++ b/src/main/java/org/mqttbee/mqtt5/netty/NettyNioBootstrap.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.netty;
 
 import io.netty.channel.MultithreadEventLoopGroup;

--- a/src/main/java/org/mqttbee/mqtt5/netty/NettyThreadLocals.java
+++ b/src/main/java/org/mqttbee/mqtt5/netty/NettyThreadLocals.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.netty;
 
 import io.netty.channel.EventLoopGroup;

--- a/src/main/java/org/mqttbee/mqtt5/persistence/IncomingQoSFlowPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt5/persistence/IncomingQoSFlowPersistence.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.persistence;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/persistence/Mqtt5PersistenceModule.java
+++ b/src/main/java/org/mqttbee/mqtt5/persistence/Mqtt5PersistenceModule.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.persistence;
 
 import dagger.Lazy;

--- a/src/main/java/org/mqttbee/mqtt5/persistence/OutgoingQoSFlowPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt5/persistence/OutgoingQoSFlowPersistence.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.persistence;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/persistence/memory/IncomingQoSFlowMemoryPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt5/persistence/memory/IncomingQoSFlowMemoryPersistence.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.persistence.memory;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/mqtt5/persistence/memory/OutgoingQoSFlowMemoryPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt5/persistence/memory/OutgoingQoSFlowMemoryPersistence.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt5.persistence.memory;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/rx/FlowableWithSingle.java
+++ b/src/main/java/org/mqttbee/rx/FlowableWithSingle.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.rx;
 
 import io.reactivex.Flowable;

--- a/src/main/java/org/mqttbee/util/ByteArray.java
+++ b/src/main/java/org/mqttbee/util/ByteArray.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/util/ByteArrayUtil.java
+++ b/src/main/java/org/mqttbee/util/ByteArrayUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/util/ByteBufferUtil.java
+++ b/src/main/java/org/mqttbee/util/ByteBufferUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/util/MustNotBeImplementedException.java
+++ b/src/main/java/org/mqttbee/util/MustNotBeImplementedException.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 import org.mqttbee.annotations.DoNotImplement;

--- a/src/main/java/org/mqttbee/util/MustNotBeImplementedUtil.java
+++ b/src/main/java/org/mqttbee/util/MustNotBeImplementedUtil.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/org/mqttbee/util/Ranges.java
+++ b/src/main/java/org/mqttbee/util/Ranges.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/util/UnsignedDataTypes.java
+++ b/src/main/java/org/mqttbee/util/UnsignedDataTypes.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util;
 
 /**

--- a/src/main/java/org/mqttbee/util/collections/IntMap.java
+++ b/src/main/java/org/mqttbee/util/collections/IntMap.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util.collections;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/util/collections/ScListNode.java
+++ b/src/main/java/org/mqttbee/util/collections/ScListNode.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util.collections;
 
 /**

--- a/src/main/java/org/mqttbee/util/collections/ScNodeList.java
+++ b/src/main/java/org/mqttbee/util/collections/ScNodeList.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util.collections;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/main/java/org/mqttbee/util/collections/SpscIterableChunkedArrayQueue.java
+++ b/src/main/java/org/mqttbee/util/collections/SpscIterableChunkedArrayQueue.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.util.collections;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/test/java/demonstration/Mqtt3ClientTest.java
+++ b/src/test/java/demonstration/Mqtt3ClientTest.java
@@ -1,0 +1,143 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package demonstration;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import org.junit.jupiter.api.Test;
+import org.mqttbee.api.mqtt.MqttClient;
+import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.mqtt3.Mqtt3Client;
+import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
+import org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAck;
+import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3PublishBuilder;
+import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3PublishResult;
+import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
+import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscription;
+import org.mqttbee.util.ByteBufferUtil;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class Mqtt3ClientTest {
+
+    @Test
+    void subscriber() {
+        // create a client with id "sub" and connect to "localhost" at port 1883
+        final Mqtt3Client client = MqttClient.builder()
+                .withIdentifier("sub")
+                .forServerHost("broker.hivemq.com")
+                .forServerPort(1883)
+                .usingMqtt3()
+                .reactive();
+
+        // create a CONNECT message with keep alive of 10 seconds
+        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().withKeepAlive(10).build();
+        // define what to do on connect, this does not connect yet
+        final Single<Mqtt3ConnAck> connectScenario =
+                client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected subscriber"));
+
+        // create a SUBSCRIBE message for the topics a/b and a/b/c with different QoS
+        final Mqtt3Subscribe subscribeMessage = Mqtt3Subscribe.builder()
+                .addSubscription(
+                        Mqtt3Subscription.builder().withTopicFilter("a/b").withQoS(MqttQoS.EXACTLY_ONCE).build())
+                .addSubscription(
+                        Mqtt3Subscription.builder().withTopicFilter("a/b/c").withQoS(MqttQoS.AT_LEAST_ONCE).build())
+                .build();
+        // define what to do with the publishes, that match the subscription, this does not subscribe yet
+        final Flowable<Mqtt3Publish> subscribeScenario = client.subscribe(subscribeMessage).doOnNext(publish -> {
+            final Optional<ByteBuffer> payload = publish.getPayload();
+            if (payload.isPresent()) {
+                final String message = new String(ByteBufferUtil.getBytes(payload.get()));
+                System.out.println(
+                        "received message with payload '" + message + "' on topic '" + publish.getTopic() + "'");
+            } else {
+                System.out.println("received message without payload on topic '" + publish.getTopic() + "'");
+            }
+        });
+
+        // now say we want to connect first and then subscribe, this does not connect and subscribe yet
+        final Flowable<Mqtt3Publish> connectAndSubscribeScenario =
+                connectScenario.toCompletable().andThen(subscribeScenario);
+
+        // now we want to execute our "scenario"
+        connectAndSubscribeScenario.blockingSubscribe();
+    }
+
+    @Test
+    void publisherAB() {
+        publisher("pub1", "a/b");
+    }
+
+    @Test
+    void publisherABC() {
+        publisher("pub2", "a/b/c");
+    }
+
+    private void publisher(final String clientIdentifier, final String topic) {
+        // create a client with id "pub" and connect to "localhost" at port 1883
+        final Mqtt3Client client = MqttClient.builder()
+                .withIdentifier(clientIdentifier)
+                .forServerHost("broker.hivemq.com")
+                .forServerPort(1883)
+                .usingMqtt3()
+                .reactive();
+
+        // create a CONNECT message with keep alive of 10 seconds
+        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().withKeepAlive(10).build();
+        // define what to do on connect, this does not connect yet
+        final Single<Mqtt3ConnAck> connectScenario =
+                client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected publisher"));
+
+        // create a stub publish and a counter
+        final Mqtt3PublishBuilder publishMessageBuilder =
+                Mqtt3Publish.builder().withTopic(topic).withQos(MqttQoS.AT_LEAST_ONCE);
+        final AtomicInteger counter = new AtomicInteger();
+        // fake a stream of random messages, actually not random, but an incrementing counter ;-)
+        final Flowable<Mqtt3Publish> publishFlowable = Flowable.generate(emitter -> {
+            if (counter.get() < 100) {
+                emitter.onNext(
+                        publishMessageBuilder.withPayload(("test " + counter.getAndIncrement()).getBytes()).build());
+            } else {
+                emitter.onComplete();
+            }
+        });
+
+        // define what to publish and what to do when we published a message (e.g. PUBACK received), this does not publish yet
+        final Flowable<Mqtt3PublishResult> publishScenario =
+                client.publish(publishFlowable).doOnNext(publishResult -> System.out.println("published" + publishResult.getPublish().getPayload().toString()));
+
+        // define what to do when we disconnect, this does not disconnect yet
+        final Completable disconnectScenario =
+                client.disconnect().doOnComplete(() -> System.out.println("disconnected"));
+
+        // now we want to connect, then publish and if we did not publish anything for 10 seconds disconnect
+        connectScenario.toCompletable()
+                .andThen(publishScenario)
+                .timeout(10, TimeUnit.SECONDS)
+                .onErrorResumeNext(disconnectScenario.toFlowable())
+                .blockingSubscribe();
+    }
+
+}

--- a/src/test/java/org/mqttbee/api/mqtt/datatypes/MqttQoSTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/datatypes/MqttQoSTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.junit.Test;

--- a/src/test/java/org/mqttbee/api/mqtt/exceptions/MqttMaximumPacketSizeExceededExceptionTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/exceptions/MqttMaximumPacketSizeExceededExceptionTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.exceptions;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5MessageTypeTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/Mqtt5MessageTypeTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message;
 
 import org.junit.Test;

--- a/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectReasonCodeTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectReasonCodeTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.disconnect;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckReasonCodeTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckReasonCodeTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.publish.puback;
 
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5RetainHandlingTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5RetainHandlingTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/AbstractMqttDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/AbstractMqttDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder;
 
 import io.netty.channel.embedded.EmbeddedChannel;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/AbstractMqtt3DecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/AbstractMqtt3DecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ClientMessageDecodersTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ClientMessageDecodersTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ConnAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3ConnAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubCompDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubCompDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRecDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRecDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRelDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PubRelDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PublishDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3SubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3SubAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3UnsubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3UnsubAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/AbstractMqtt5DecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/AbstractMqtt5DecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import org.mqttbee.annotations.NotNull;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ClientMessageDecodersTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ClientMessageDecodersTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5MessageDecoderUtilTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5MessageDecoderUtilTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PingRespDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PingRespDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/AbstractMqtt5EncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/AbstractMqtt5EncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/MqttPingReqEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/MqttPingReqEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import com.google.common.primitives.Bytes;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PingReqEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PingReqEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubAckEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubAckEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubCompEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubCompEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRecEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRecEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRelEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRelEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderWithUserPropertiesTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderWithUserPropertiesTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5DisconnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5DisconnectEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubAckEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubAckEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubCompEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubCompEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRecEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRecEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRelEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubRelEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttBinaryDataTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttBinaryDataTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttClientIdentifierImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttClientIdentifierImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableSet;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttUTF8StringImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttUTF8StringImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.base.Charsets;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttUserPropertyImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttUserPropertyImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttVariableByteIntegerTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttVariableByteIntegerTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.datatypes;
 
 import io.netty.buffer.ByteBuf;

--- a/src/test/java/org/mqttbee/mqtt/message/MqttCommonReasonCodeTest.java
+++ b/src/test/java/org/mqttbee/mqtt/message/MqttCommonReasonCodeTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/mqttbee/mqtt/message/MqttPropertyTest.java
+++ b/src/test/java/org/mqttbee/mqtt/message/MqttPropertyTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message;
 
 import org.junit.Test;

--- a/src/test/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAckTest.java
+++ b/src/test/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAckTest.java
@@ -1,3 +1,22 @@
+/*
+ *
+ * *
+ *  * Copyright 2018 The MQTT Bee project.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
 package org.mqttbee.mqtt.message.unsubscribe.unsuback;
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
Adds the Apache 2 license file to the project. Also updates all class files and adds IntelliJ meta-file for automatic Apache 2 license headers for all project files