### PR TITLE
Improved memory footprint of IntMap #85

### DIFF
--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlowsWithId.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlowsWithId.java
@@ -24,11 +24,11 @@ import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode
 import org.mqttbee.mqtt.MqttClientConnectionData;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
+import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.mqtt.message.publish.MqttPublishWrapper;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribeWrapper;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
-import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.util.collections.IntMap;
 import org.mqttbee.util.collections.ScNodeList;
 
@@ -59,7 +59,7 @@ public class MqttIncomingPublishFlowsWithId extends MqttIncomingPublishFlows {
         final MqttClientConnectionData clientConnectionData = clientData.getRawClientConnectionData();
         assert clientConnectionData != null;
 
-        flowsWithIdsMap = new IntMap<>(clientConnectionData.getSubscriptionIdentifierMaximum());
+        flowsWithIdsMap = new IntMap<>(1, clientConnectionData.getSubscriptionIdentifierMaximum());
         this.flowsWithIds = flowsWithIds;
         flowWithIdUnsubscribedCallback = this::unsubscribed;
     }

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingQoSHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingQoSHandler.java
@@ -26,13 +26,13 @@ import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5IncomingQoS2ControlProvider
 import org.mqttbee.mqtt.MqttClientConnectionData;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.advanced.MqttAdvancedClientData;
+import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.mqtt.message.publish.MqttPublishWrapper;
 import org.mqttbee.mqtt.message.publish.puback.MqttPubAckBuilder;
 import org.mqttbee.mqtt.message.publish.pubcomp.MqttPubCompBuilder;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRecBuilder;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
-import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.util.collections.IntMap;
 
 import javax.inject.Inject;
@@ -68,9 +68,9 @@ public class MqttIncomingQoSHandler extends ChannelInboundHandlerAdapter {
 
         this.incomingPublishServiceLazy = incomingPublishServiceLazy;
         final int receiveMaximum = clientConnectionData.getReceiveMaximum();
-        pubRecs = new IntMap<>(receiveMaximum);
-        pubRels = new IntMap<>(receiveMaximum);
-        pubComps = new IntMap<>(receiveMaximum);
+        pubRecs = new IntMap<>(1, receiveMaximum);
+        pubRels = new IntMap<>(1, receiveMaximum);
+        pubComps = new IntMap<>(1, receiveMaximum);
         ackQueue = new SpscChunkedArrayQueue<>(64, receiveMaximum);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttOutgoingQoSHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttOutgoingQoSHandler.java
@@ -31,6 +31,8 @@ import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttServerConnectionData;
 import org.mqttbee.mqtt.advanced.MqttAdvancedClientData;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
+import org.mqttbee.mqtt.handler.subscribe.MqttSubscriptionHandler;
+import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttPublishResult;
 import org.mqttbee.mqtt.message.publish.MqttPublishResult.MqttQoS1Result;
@@ -42,8 +44,6 @@ import org.mqttbee.mqtt.message.publish.pubcomp.MqttPubComp;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRelBuilder;
-import org.mqttbee.mqtt.handler.subscribe.MqttSubscriptionHandler;
-import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.util.Ranges;
 import org.mqttbee.util.UnsignedDataTypes;
 import org.mqttbee.util.collections.IntMap;
@@ -82,7 +82,7 @@ public class MqttOutgoingQoSHandler extends ChannelInboundHandlerAdapter {
         final int pubReceiveMaximum = getPubReceiveMaximum(serverConnectionData.getReceiveMaximum());
         publishQueue = new SpscChunkedArrayQueue<>(64, pubReceiveMaximum);
         packetIdentifiers = new Ranges(1, pubReceiveMaximum);
-        qos1Or2Publishes = new IntMap<>(pubReceiveMaximum);
+        qos1Or2Publishes = new IntMap<>(1, pubReceiveMaximum);
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/persistence/memory/OutgoingQoSFlowMemoryPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt/persistence/memory/OutgoingQoSFlowMemoryPersistence.java
@@ -20,10 +20,10 @@ package org.mqttbee.mqtt.persistence.memory;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.mqtt.MqttClientConnectionData;
 import org.mqttbee.mqtt.MqttClientData;
+import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.mqtt.message.publish.MqttPublishWrapper;
 import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
-import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.mqtt.persistence.OutgoingQoSFlowPersistence;
 import org.mqttbee.util.collections.IntMap;
 
@@ -42,7 +42,7 @@ public class OutgoingQoSFlowMemoryPersistence implements OutgoingQoSFlowPersiste
     OutgoingQoSFlowMemoryPersistence(final MqttClientData clientData) {
         final MqttClientConnectionData clientConnectionData = clientData.getRawClientConnectionData();
         assert clientConnectionData != null;
-        this.messages = new IntMap<>(clientConnectionData.getReceiveMaximum());
+        this.messages = new IntMap<>(1, clientConnectionData.getReceiveMaximum());
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/util/collections/IntMap.java
+++ b/src/main/java/org/mqttbee/util/collections/IntMap.java
@@ -21,7 +21,6 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 
 import javax.annotation.concurrent.NotThreadSafe;
-import java.util.ArrayDeque;
 
 /**
  * @author Silvio Giebl
@@ -29,75 +28,79 @@ import java.util.ArrayDeque;
 @NotThreadSafe
 public class IntMap<E> {
 
+    private final int minKey;
     private final int capacity;
     private final int chunkShift;
     private final int chunkMask;
     private final int hashMask;
 
-    private final Chunk<E>[] chunks;
-    private final int chunkBatchCount;
-    private ChunkBatch<E> chunkBatch;
+    private final Chunk[] chunks;
 
-    @SuppressWarnings("unchecked")
-    public IntMap(final int maxKey) {
-        final int pow2Bit = 32 - Integer.numberOfLeadingZeros(maxKey - 1);
+    private Chunk freeChunk;
+
+    public IntMap(final int minKey, final int maxKey) {
+        this.minKey = minKey;
+        final int pow2Bit = 32 - Integer.numberOfLeadingZeros(maxKey - minKey);
         capacity = 1 << pow2Bit;
         chunkShift = (pow2Bit + 1) >> 1;
         hashMask = (1 << chunkShift) - 1;
         chunkMask = capacity - 1 - hashMask;
 
-        chunks = new Chunk[(chunkMask >> chunkShift) + 1];
-        chunkBatchCount = 1 << (pow2Bit >> 2);
-        chunkBatch = new ChunkBatch<>(hashMask + 1, chunkBatchCount);
+        chunks = new Chunk[1 << (pow2Bit - chunkShift)];
     }
 
     @Nullable
+    @SuppressWarnings("unchecked")
     public E put(final int key, @NotNull final E value) {
-        checkKey(key);
-        final int index = index(key);
-        Chunk<E> chunk = chunks[index];
+        final int actualKey = checkKey(key);
+        final int index = index(actualKey);
+        Chunk chunk = chunks[index];
         if (chunk == null) {
-            chunk = chunkBatch.getChunk();
-            if (chunk == null) {
-                chunkBatch = new ChunkBatch<>(hashMask + 1, chunkBatchCount);
-                chunk = chunkBatch.getChunk();
-                assert chunk != null;
+            if (freeChunk == null) {
+                chunk = new Chunk(hashMask + 1);
+            } else {
+                chunk = freeChunk;
+                freeChunk = null;
             }
             chunks[index] = chunk;
         }
-        return chunk.put(key, hashMask, value);
+        return (E) chunk.put(actualKey, hashMask, value);
     }
 
     @Nullable
+    @SuppressWarnings("unchecked")
     public E get(final int key) {
-        checkKey(key);
-        final Chunk<E> chunk = chunks[index(key)];
+        final int actualKey = checkKey(key);
+        final Chunk chunk = chunks[index(actualKey)];
         if (chunk == null) {
             return null;
         }
-        return chunk.get(key, hashMask);
+        return (E) chunk.get(actualKey, hashMask);
     }
 
     @Nullable
+    @SuppressWarnings("unchecked")
     public E remove(final int key) {
-        checkKey(key);
-        final int index = index(key);
-        final Chunk<E> chunk = chunks[index];
+        final int actualKey = checkKey(key);
+        final int index = index(actualKey);
+        final Chunk chunk = chunks[index];
         if (chunk == null) {
             return null;
         }
-        final E value = chunk.remove(key, hashMask);
-        if (chunk.size() == 0) {
+        final E value = (E) chunk.remove(actualKey, hashMask);
+        if (chunk.count == 0) {
+            freeChunk = chunk;
             chunks[index] = null;
-            chunk.returnToBatch();
         }
         return value;
     }
 
-    private void checkKey(final int key) {
-        if (key > capacity || key < 0) {
+    private int checkKey(final int key) {
+        final int actualKey = key - minKey;
+        if (actualKey > capacity - 1 || actualKey < 0) {
             throw new IllegalArgumentException();
         }
+        return actualKey;
     }
 
     private int index(final int key) {
@@ -105,82 +108,44 @@ public class IntMap<E> {
     }
 
 
-    private static class Chunk<E> {
+    private static class Chunk {
 
-        private final ChunkBatch<E> chunkBatch;
-        private final int offset;
-        private int size;
+        private final Object[] values;
+        private int count;
 
-        private Chunk(@NotNull final ChunkBatch<E> chunkBatch, final int offset) {
-            this.chunkBatch = chunkBatch;
-            this.offset = offset;
+        private Chunk(final int size) {
+            this.values = new Object[size];
         }
 
         @Nullable
-        private E put(final int key, final int hashMask, @NotNull final E value) {
+        Object put(final int key, final int hashMask, @NotNull final Object value) {
             final int index = index(key, hashMask);
-            final E[] values = chunkBatch.values;
-            final E previousValue = values[index];
+            final Object previousValue = values[index];
             values[index] = value;
             if (previousValue == null) {
-                size++;
+                count++;
             }
             return previousValue;
         }
 
         @Nullable
-        private E get(final int key, final int hashMask) {
-            return chunkBatch.values[index(key, hashMask)];
+        Object get(final int key, final int hashMask) {
+            return values[index(key, hashMask)];
         }
 
         @Nullable
-        private E remove(final int key, final int hashMask) {
+        Object remove(final int key, final int hashMask) {
             final int index = index(key, hashMask);
-            final E[] values = chunkBatch.values;
-            final E previousValue = values[index];
+            final Object previousValue = values[index];
             values[index] = null;
             if (previousValue != null) {
-                size--;
+                count--;
             }
             return previousValue;
         }
 
         private int index(final int key, final int hashMask) {
-            return offset + (key & hashMask);
-        }
-
-        private int size() {
-            return size;
-        }
-
-        private void returnToBatch() {
-            chunkBatch.returnChunk(this);
-        }
-
-    }
-
-
-    private static class ChunkBatch<E> {
-
-        private final E[] values;
-        private final ArrayDeque<Chunk<E>> availableChunks;
-
-        @SuppressWarnings("unchecked")
-        private ChunkBatch(final int chunkSize, final int chunkCount) {
-            values = (E[]) new Object[chunkCount * chunkSize];
-            availableChunks = new ArrayDeque<>(chunkCount);
-            for (int i = 0, offset = 0; i < chunkCount; i++, offset += chunkSize) {
-                availableChunks.offer(new Chunk<>(this, offset));
-            }
-        }
-
-        @Nullable
-        private Chunk<E> getChunk() {
-            return availableChunks.poll();
-        }
-
-        private void returnChunk(@NotNull final Chunk<E> chunk) {
-            availableChunks.offer(chunk);
+            return key & hashMask;
         }
 
     }

--- a/src/test/java/org/mqttbee/util/collections/IntMapTest.java
+++ b/src/test/java/org/mqttbee/util/collections/IntMapTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Silvio Giebl
+ */
+class IntMapTest {
+
+    @Test
+    void put_present() {
+        final IntMap<String> map = new IntMap<>(0, 12);
+        map.put(10, "test10");
+        map.put(10, "test10_2");
+        assertEquals("test10_2", map.get(10));
+    }
+
+    @Test
+    void get_present() {
+        final IntMap<String> map = new IntMap<>(0, 12);
+        map.put(9, "test9");
+        map.put(10, "test10");
+        assertEquals("test10", map.get(10));
+    }
+
+    @Test
+    void get_not_present() {
+        final IntMap<String> map = new IntMap<>(0, 12);
+        map.put(9, "test9");
+        assertNull(map.get(10));
+    }
+
+    @Test
+    void remove_present() {
+        final IntMap<String> map = new IntMap<>(0, 12);
+        map.put(9, "test9");
+        map.put(10, "test10");
+        map.remove(10);
+        assertEquals("test9", map.get(9));
+        assertNull(map.get(10));
+    }
+
+    @Test
+    void remove_not_present() {
+        final IntMap<String> map = new IntMap<>(0, 12);
+        map.put(9, "test9");
+        map.remove(10);
+        assertEquals("test9", map.get(9));
+        assertNull(map.get(10));
+    }
+
+    @Test
+    void put_get_max_size() {
+        final IntMap<String> map = new IntMap<>(0, Integer.MAX_VALUE);
+        map.put(Integer.MAX_VALUE, "max_value");
+        assertEquals("max_value", map.get(Integer.MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {8, 12})
+    void put_boundaries(final int size) {
+        final IntMap<String> map = new IntMap<>(0, size);
+        assertThrows(IllegalArgumentException.class, () -> map.put(-1, "test-1"));
+        map.put(0, "test0");
+        map.put(15, "test15");
+        assertThrows(IllegalArgumentException.class, () -> map.put(16, "test16"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {11, 15})
+    void put_boundaries_minKey(final int size) {
+        final IntMap<String> map = new IntMap<>(3, size);
+        assertThrows(IllegalArgumentException.class, () -> map.put(2, "test2"));
+        map.put(3, "test3");
+        map.put(18, "test18");
+        assertThrows(IllegalArgumentException.class, () -> map.put(19, "test19"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {8, 12})
+    void get_boundaries(final int size) {
+        final IntMap<String> map = new IntMap<>(0, size);
+        assertThrows(IllegalArgumentException.class, () -> map.get(-1));
+        map.get(0);
+        map.get(15);
+        assertThrows(IllegalArgumentException.class, () -> map.get(16));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {11, 15})
+    void get_boundaries_minKey(final int size) {
+        final IntMap<String> map = new IntMap<>(3, size);
+        assertThrows(IllegalArgumentException.class, () -> map.get(2));
+        map.get(3);
+        map.get(18);
+        assertThrows(IllegalArgumentException.class, () -> map.get(19));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {8, 12})
+    void remove_boundaries(final int size) {
+        final IntMap<String> map = new IntMap<>(0, size);
+        assertThrows(IllegalArgumentException.class, () -> map.remove(-1));
+        map.remove(0);
+        map.remove(15);
+        assertThrows(IllegalArgumentException.class, () -> map.remove(16));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {11, 15})
+    void remove_boundaries_minKey(final int size) {
+        final IntMap<String> map = new IntMap<>(3, size);
+        assertThrows(IllegalArgumentException.class, () -> map.remove(2));
+        map.remove(3);
+        map.remove(18);
+        assertThrows(IllegalArgumentException.class, () -> map.remove(19));
+    }
+
+    @Test
+    void put_remove_sequential() {
+        final IntMap<String> map = new IntMap<>(1, 16);
+        for (int i = 1; i <= 8; i++) {
+            map.put(i, "test" + i);
+        }
+        for (int i = 1; i <= 4; i++) {
+            assertEquals("test" + i, map.remove(i));
+        }
+        for (int i = 9; i <= 12; i++) {
+            map.put(i, "test" + i);
+        }
+        for (int i = 5; i <= 12; i++) {
+            assertEquals("test" + i, map.remove(i));
+        }
+    }
+
+}


### PR DESCRIPTION
**Motivation**
- Motivation for IntMap in general:
  - Java HashMap does grow but never shrink in size
  - Java HashMap produces a lot of garbage with Integer as a key
- Motivation for improvement:
Fastest mapping of int -> Object would be an array Object[maxkey]. This would use a lot of memory even if mostly unused.
IntMap instead allocates only the chunks it needs. Each chunk contains an array Object[chunksize].
Before this PR each IntMap allocated a batch of chunks and so used a lot more memory than needed.
Use of ThreadLocal + SoftReference for caching did not perform very good, so removed the caching.

**Changes**
- Removed ChunkBatch
- Only caching 1 chunk
- Also improved freeing of ThreadLocals of Netty threads