### PR TITLE
Feature/incoming ack flow on complete

### DIFF
--- a/src/main/java/org/mqttbee/annotations/CallByThread.java
+++ b/src/main/java/org/mqttbee/annotations/CallByThread.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Documents that a method should only be called by the specified thread.
+ *
+ * @author Silvio Giebl
+ */
+@Documented
+@Retention(CLASS)
+@Target(METHOD)
+public @interface CallByThread {
+
+    String value();
+
+}

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
@@ -25,14 +25,13 @@ import org.reactivestreams.Subscriber;
 /**
  * @author Silvio Giebl
  */
-public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow {
+public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subscriber<? super Mqtt5Publish>> {
 
     public static final int TYPE_ALL_SUBSCRIPTIONS = 0;
     public static final int TYPE_ALL_PUBLISHES = 1;
     public static final int TYPE_REMAINING_PUBLISHES = 2;
     static final int TYPE_COUNT = 3;
 
-    private final Subscriber<? super Mqtt5Publish> subscriber;
     private final int type;
     private ScNodeList.Handle<MqttGlobalIncomingPublishFlow> handle;
 
@@ -40,15 +39,8 @@ public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow {
             @NotNull final Subscriber<? super Mqtt5Publish> subscriber,
             @NotNull final MqttIncomingPublishService incomingPublishService, final int type) {
 
-        super(incomingPublishService);
-        this.subscriber = subscriber;
+        super(incomingPublishService, subscriber);
         this.type = type;
-    }
-
-    @NotNull
-    @Override
-    Subscriber<? super Mqtt5Publish> getSubscriber() {
-        return subscriber;
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingAckFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingAckFlow.java
@@ -87,7 +87,7 @@ public class MqttIncomingAckFlow implements Subscription, Runnable {
                 queued = false;
             } else {
                 queue.offer(result);
-                queued = false;
+                queued = true;
             }
 
             final int wip = this.wip.get();

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingAckFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingAckFlow.java
@@ -85,7 +85,6 @@ public class MqttIncomingAckFlow implements Subscription, Runnable {
                 subscriber.onNext(result);
                 emitted++;
                 queued = false;
-                break;
             } else {
                 queue.offer(result);
                 queued = false;
@@ -173,6 +172,9 @@ public class MqttIncomingAckFlow implements Subscription, Runnable {
     @Override
     public void run() {
         int missed = wip.get();
+        if (missed == 0) {
+            return;
+        }
 
         long emitted = 0;
         while (true) {
@@ -187,7 +189,6 @@ public class MqttIncomingAckFlow implements Subscription, Runnable {
             }
             if (queue.isEmpty()) {
                 queued = false;
-                break;
             }
 
             final int wip = this.wip.get();

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingAckFlowable.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingAckFlowable.java
@@ -57,7 +57,7 @@ public class MqttIncomingAckFlowable extends Flowable<Mqtt5PublishResult> {
 
             final MqttIncomingAckFlow incomingAckFlow = new MqttIncomingAckFlow(s, outgoingPublishService);
             s.onSubscribe(incomingAckFlow);
-            publishFlowables.add(publishFlowable.map(publish -> new MqttPublishWithFlow(publish, incomingAckFlow)));
+            publishFlowables.add(new MqttPublishFlowableAckLink(publishFlowable, incomingAckFlow));
         }
     }
 

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttPublishFlowableAckLink.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttPublishFlowableAckLink.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.mqtt.handler.publish;
+
+import io.reactivex.Flowable;
+import io.reactivex.internal.fuseable.ConditionalSubscriber;
+import io.reactivex.plugins.RxJavaPlugins;
+import org.mqttbee.annotations.NotNull;
+import org.mqttbee.mqtt.message.publish.MqttPublish;
+import org.mqttbee.rx.FuseableSubscriber;
+import org.reactivestreams.Subscriber;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Silvio Giebl
+ */
+public class MqttPublishFlowableAckLink extends Flowable<MqttPublishWithFlow> {
+
+    private final Flowable<MqttPublish> source;
+    private final MqttIncomingAckFlow ackFlow;
+
+    MqttPublishFlowableAckLink(
+            @NotNull final Flowable<MqttPublish> source, @NotNull final MqttIncomingAckFlow ackFlow) {
+
+        this.source = source;
+        this.ackFlow = ackFlow;
+    }
+
+    @Override
+    protected void subscribeActual(final Subscriber<? super MqttPublishWithFlow> s) {
+        final AbstractAckLinkSubscriber<? extends Subscriber<? super MqttPublishWithFlow>> ackLinkSubscriber;
+        if (s instanceof ConditionalSubscriber) {
+            @SuppressWarnings("unchecked") final ConditionalSubscriber<? super MqttPublishWithFlow> cs =
+                    (ConditionalSubscriber<? super MqttPublishWithFlow>) s;
+            ackLinkSubscriber = new AckLinkConditionalSubscriber(cs, ackFlow);
+        } else {
+            ackLinkSubscriber = new AckLinkSubscriber(s, ackFlow);
+        }
+        source.subscribe(ackLinkSubscriber);
+        ackFlow.link(ackLinkSubscriber);
+    }
+
+
+    interface LinkCancellable {
+
+        void cancelLink();
+
+    }
+
+
+    static abstract class AbstractAckLinkSubscriber<S extends Subscriber<? super MqttPublishWithFlow>>
+            extends FuseableSubscriber<MqttPublish, MqttPublishWithFlow, S> implements LinkCancellable {
+
+        static final int STATE_NONE = 0;
+        static final int STATE_EMITTING = 1;
+        static final int STATE_DONE = 2;
+
+        final MqttIncomingAckFlow ackFlow;
+        private final AtomicInteger state = new AtomicInteger();
+        long published;
+
+        AbstractAckLinkSubscriber(@NotNull final S subscriber, @NotNull final MqttIncomingAckFlow ackFlow) {
+            super(subscriber);
+            this.ackFlow = ackFlow;
+        }
+
+        @Override
+        public void onComplete() {
+            if (state.compareAndSet(STATE_NONE, STATE_DONE)) {
+                subscriber.onComplete();
+                ackFlow.onComplete(published);
+            }
+        }
+
+        @Override
+        public void onError(final Throwable t) {
+            if (state.compareAndSet(STATE_NONE, STATE_DONE)) {
+                subscriber.onComplete();
+                ackFlow.onError(t, published);
+            } else {
+                RxJavaPlugins.onError(t);
+            }
+        }
+
+        @Override
+        public MqttPublishWithFlow poll() throws Exception {
+            if (state.get() == STATE_DONE) {
+                subscription.cancel();
+                return null;
+            }
+            final MqttPublish publish = queueSubscription.poll();
+            if (publish == null) {
+                return null;
+            }
+            published++;
+            return new MqttPublishWithFlow(publish, ackFlow);
+        }
+
+        @Override
+        public void cancelLink() {
+            if (state.getAndSet(STATE_DONE) == STATE_NONE) {
+                if (sourceMode != SYNC) {
+                    subscription.cancel();
+                    subscriber.onComplete();
+                }
+            }
+        }
+
+        boolean startEmitting() {
+            return state.compareAndSet(STATE_NONE, STATE_EMITTING);
+        }
+
+        void stopEmitting() {
+            if (!state.compareAndSet(STATE_EMITTING, STATE_NONE)) {
+                subscription.cancel();
+                subscriber.onComplete();
+            }
+        }
+
+    }
+
+
+    private static class AckLinkSubscriber extends AbstractAckLinkSubscriber<Subscriber<? super MqttPublishWithFlow>> {
+
+        AckLinkSubscriber(
+                @NotNull final Subscriber<? super MqttPublishWithFlow> subscriber,
+                @NotNull final MqttIncomingAckFlow ackFlow) {
+
+            super(subscriber, ackFlow);
+        }
+
+        @Override
+        public void onNext(final MqttPublish publish) {
+            if (startEmitting()) {
+                if (sourceMode == ASYNC) {
+                    subscriber.onNext(null);
+                } else {
+                    subscriber.onNext(new MqttPublishWithFlow(publish, ackFlow));
+                    published++;
+                }
+                stopEmitting();
+            }
+        }
+
+    }
+
+
+    private static class AckLinkConditionalSubscriber
+            extends AbstractAckLinkSubscriber<ConditionalSubscriber<? super MqttPublishWithFlow>>
+            implements ConditionalSubscriber<MqttPublish> {
+
+        AckLinkConditionalSubscriber(
+                @NotNull final ConditionalSubscriber<? super MqttPublishWithFlow> subscriber,
+                @NotNull final MqttIncomingAckFlow ackFlow) {
+
+            super(subscriber, ackFlow);
+        }
+
+        @Override
+        public void onNext(final MqttPublish publish) {
+            if (!tryOnNext(publish)) {
+                subscription.request(1);
+            }
+        }
+
+        @Override
+        public boolean tryOnNext(final MqttPublish publish) {
+            if (startEmitting()) {
+                final boolean consumed;
+                if (sourceMode == ASYNC) {
+                    consumed = subscriber.tryOnNext(null);
+                } else {
+                    if (consumed = subscriber.tryOnNext(new MqttPublishWithFlow(publish, ackFlow))) {
+                        published++;
+                    }
+                }
+                stopEmitting();
+                return consumed;
+            }
+            return true;
+        }
+
+    }
+
+}

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttPublishFlowables.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttPublishFlowables.java
@@ -53,11 +53,12 @@ public class MqttPublishFlowables extends Flowable<Flowable<MqttPublishWithFlow>
 
     public void add(@NotNull final Flowable<MqttPublishWithFlow> publishFlowable) {
         synchronized (this) {
-            if (requested.get() == 0) {
+            while (requested.get() == 0) {
                 try {
                     this.wait();
                 } catch (final InterruptedException e) {
                     LOGGER.error("thread interrupted while waiting to publish.", e);
+                    return;
                 }
             }
             subscriber.onNext(publishFlowable);

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttPublishFlowables.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttPublishFlowables.java
@@ -18,133 +18,65 @@
 package org.mqttbee.mqtt.handler.publish;
 
 import io.reactivex.Flowable;
-import io.reactivex.Scheduler;
 import io.reactivex.internal.util.BackpressureHelper;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * @author Silvio Giebl
  */
 @ChannelScope
-public class MqttPublishFlowables extends Flowable<Flowable<MqttPublishWithFlow>> implements Subscription, Runnable {
+public class MqttPublishFlowables extends Flowable<Flowable<MqttPublishWithFlow>> implements Subscription {
 
-    private static final int MAX_CONCURRENT_PUBLISH_FLOWABLES = 100;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MqttPublishFlowables.class);
 
-    private final Scheduler.Worker rxEventLoop;
-
-    private Subscriber<? super Flowable<MqttPublishWithFlow>> actual;
-
+    private Subscriber<? super Flowable<MqttPublishWithFlow>> subscriber;
     private final AtomicLong requested = new AtomicLong();
-    private final AtomicBoolean cancelled = new AtomicBoolean();
-
-    private final LinkedBlockingQueue<Flowable<MqttPublishWithFlow>> queue;
-    private final AtomicInteger wip = new AtomicInteger();
 
     @Inject
-    MqttPublishFlowables(@Named("outgoingPublishFlows") final Scheduler.Worker rxEventLoop) {
-        this.rxEventLoop = rxEventLoop;
-
-        queue = new LinkedBlockingQueue<>(MAX_CONCURRENT_PUBLISH_FLOWABLES);
+    MqttPublishFlowables() {
     }
 
     @Override
     protected void subscribeActual(final Subscriber<? super Flowable<MqttPublishWithFlow>> s) {
-        assert actual == null;
-
-        actual = s;
+        assert subscriber == null;
+        subscriber = s;
         s.onSubscribe(this);
     }
 
     public void add(@NotNull final Flowable<MqttPublishWithFlow> publishFlowable) {
-        try {
-            queue.put(publishFlowable);
-            trySchedule();
-        } catch (final InterruptedException e) {
-            // TODO log error
+        synchronized (this) {
+            if (requested.get() == 0) {
+                try {
+                    this.wait();
+                } catch (final InterruptedException e) {
+                    LOGGER.error("thread interrupted while waiting to publish.", e);
+                }
+            }
+            subscriber.onNext(publishFlowable);
         }
     }
 
     @Override
     public void request(final long n) {
         BackpressureHelper.add(requested, n);
-        trySchedule();
+        if (requested.get() == n) {
+            synchronized (this) {
+                this.notifyAll();
+            }
+        }
     }
 
     @Override
     public void cancel() {
-        if (cancelled.compareAndSet(false, true)) {
-            trySchedule();
-        }
-    }
-
-    private void trySchedule() {
-        if (wip.getAndIncrement() == 0) {
-            rxEventLoop.schedule(this);
-        }
-    }
-
-    @Override
-    public void run() {
-        int missed = 1;
-
-        final Subscriber<? super Flowable<MqttPublishWithFlow>> actual = this.actual;
-        final LinkedBlockingQueue<Flowable<MqttPublishWithFlow>> queue = this.queue;
-
-        long emitted = 0;
-
-        while (true) {
-            final long requested = this.requested.get();
-
-            while (emitted != requested) {
-                if (checkCancelled()) {
-                    return;
-                }
-
-                final Flowable<MqttPublishWithFlow> publishFlowable = queue.poll();
-                if (publishFlowable == null) {
-                    break;
-                }
-                actual.onNext(publishFlowable);
-                emitted++;
-            }
-
-            if ((emitted == requested) && checkCancelled()) {
-                return;
-            }
-
-            final int wip = this.wip.get();
-            if (missed == wip) {
-                missed = this.wip.addAndGet(-missed);
-                if (missed == 0) {
-                    break;
-                }
-            } else {
-                missed = wip;
-            }
-        }
-        if (emitted > 0) {
-            if (requested.get() != Long.MAX_VALUE) {
-                requested.addAndGet(-emitted);
-            }
-        }
-    }
-
-    private boolean checkCancelled() {
-        if (cancelled.get()) {
-            queue.clear();
-            return true;
-        }
-        return false;
+        LOGGER.error("MqttPublishFlowables is global and should never be cancelled.");
     }
 
 }

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlow.java
@@ -29,9 +29,9 @@ import org.reactivestreams.Subscriber;
 /**
  * @author Silvio Giebl
  */
-public class MqttSubscriptionFlow extends MqttIncomingPublishFlow implements SingleFlow<Mqtt5SubAck> {
+public class MqttSubscriptionFlow extends MqttIncomingPublishFlow<Subscriber<? super Mqtt5SubscribeResult>>
+        implements SingleFlow<Mqtt5SubAck> {
 
-    private final Subscriber<? super Mqtt5SubscribeResult> subscriber;
     private final ScNodeList<MqttTopicFilterImpl> topicFilters;
     private int subscriptionIdentifier = MqttStatefulSubscribe.DEFAULT_NO_SUBSCRIPTION_IDENTIFIER;
 
@@ -39,15 +39,8 @@ public class MqttSubscriptionFlow extends MqttIncomingPublishFlow implements Sin
             @NotNull final Subscriber<? super Mqtt5SubscribeResult> subscriber,
             @NotNull final MqttIncomingPublishService incomingPublishService) {
 
-        super(incomingPublishService);
-        this.subscriber = subscriber;
+        super(incomingPublishService, subscriber);
         this.topicFilters = new ScNodeList<>();
-    }
-
-    @NotNull
-    @Override
-    Subscriber<? super Mqtt5SubscribeResult> getSubscriber() {
-        return subscriber;
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/ioc/ChannelModule.java
+++ b/src/main/java/org/mqttbee/mqtt/ioc/ChannelModule.java
@@ -60,13 +60,6 @@ public abstract class ChannelModule {
         return clientData.getExecutorConfig().getRxJavaScheduler().createWorker();
     }
 
-    @Provides
-    @ChannelScope
-    @Named("outgoingPublishFlows")
-    static Scheduler.Worker provideOutgoingPublishFlowsRxEventLoop(final MqttClientData clientData) {
-        return clientData.getExecutorConfig().getRxJavaScheduler().createWorker();
-    }
-
     @Binds
     abstract MqttSubscriptionFlows provideSubscriptionFlows(final MqttSubscriptionFlowTree tree);
 

--- a/src/main/java/org/mqttbee/mqtt/ioc/ChannelModule.java
+++ b/src/main/java/org/mqttbee/mqtt/ioc/ChannelModule.java
@@ -62,13 +62,6 @@ public abstract class ChannelModule {
 
     @Provides
     @ChannelScope
-    @Named("outgoingPublish")
-    static Scheduler.Worker provideOutgoingPublishRxEventLoop(final MqttClientData clientData) {
-        return clientData.getExecutorConfig().getRxJavaScheduler().createWorker();
-    }
-
-    @Provides
-    @ChannelScope
     @Named("outgoingPublishFlows")
     static Scheduler.Worker provideOutgoingPublishFlowsRxEventLoop(final MqttClientData clientData) {
         return clientData.getExecutorConfig().getRxJavaScheduler().createWorker();

--- a/src/main/java/org/mqttbee/rx/FuseableSubscriber.java
+++ b/src/main/java/org/mqttbee/rx/FuseableSubscriber.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.rx;
+
+import io.reactivex.FlowableSubscriber;
+import io.reactivex.internal.fuseable.QueueSubscription;
+import io.reactivex.plugins.RxJavaPlugins;
+import org.mqttbee.annotations.NotNull;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Base for {@link io.reactivex.Flowable} operators that allow fusion.
+ *
+ * @param <U> the type of the upstream Flowable.
+ * @param <D> the type of the downstream Flowable.
+ * @param <S> the type of the downstream subscriber.
+ * @author Silvio Giebl
+ */
+public abstract class FuseableSubscriber<U, D, S extends Subscriber<? super D>>
+        implements FlowableSubscriber<U>, QueueSubscription<D> {
+
+    protected final S subscriber;
+
+    protected Subscription subscription;
+    protected QueueSubscription<U> queueSubscription;
+    protected int sourceMode;
+    protected boolean done;
+
+    public FuseableSubscriber(@NotNull final S subscriber) {
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public void onSubscribe(final Subscription s) {
+        this.subscription = s;
+        if (s instanceof QueueSubscription) {
+            @SuppressWarnings("unchecked") final QueueSubscription<U> qs = (QueueSubscription<U>) s;
+            this.queueSubscription = qs;
+        }
+        subscriber.onSubscribe(this);
+    }
+
+    @Override
+    public void onComplete() {
+        if (done) {
+            return;
+        }
+        done = true;
+        subscriber.onComplete();
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+        if (done) {
+            RxJavaPlugins.onError(t);
+            return;
+        }
+        done = true;
+        subscriber.onError(t);
+    }
+
+    @Override
+    public void request(final long n) {
+        subscription.request(n);
+    }
+
+    @Override
+    public void cancel() {
+        subscription.cancel();
+    }
+
+    @Override
+    public int requestFusion(final int mode) {
+        if (queueSubscription != null) {
+            if ((mode & BOUNDARY) == 0) {
+                final int m = queueSubscription.requestFusion(mode);
+                if (m != NONE) {
+                    sourceMode = m;
+                }
+                return m;
+            }
+        }
+        return NONE;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return queueSubscription.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        queueSubscription.clear();
+    }
+
+    @Override
+    public final boolean offer(final D value) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+    @Override
+    public final boolean offer(final D v1, final D v2) {
+        throw new UnsupportedOperationException("Should not be called!");
+    }
+
+}

--- a/src/main/java/org/mqttbee/util/collections/ChunkedArrayQueue.java
+++ b/src/main/java/org/mqttbee/util/collections/ChunkedArrayQueue.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+@NotThreadSafe
+public class ChunkedArrayQueue<E> {
+
+    private final int chunkSize;
+    private Chunk<E> producerChunk;
+    private Chunk<E> consumerChunk;
+    private int producerIndex;
+    private int consumerIndex;
+    private int size;
+
+    public ChunkedArrayQueue(final int chunkSize) {
+        this.chunkSize = chunkSize;
+        producerChunk = consumerChunk = new Chunk<>(chunkSize);
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    public void offer(@NotNull final E e) {
+        Chunk<E> producerChunk = this.producerChunk;
+        int producerIndex = this.producerIndex;
+        if ((producerIndex == chunkSize) ||
+                ((producerChunk == consumerChunk) && (producerChunk.values[producerIndex] != null))) {
+            if (size >= chunkSize) {
+                final Chunk<E> chunk = new Chunk<>(chunkSize);
+                producerChunk.jumpIndex = producerIndex - 1;
+                producerChunk.next = chunk;
+                producerChunk = chunk;
+                this.producerChunk = chunk;
+            }
+            producerIndex = 0;
+        }
+        producerChunk.values[producerIndex] = e;
+        this.producerIndex = producerIndex + 1;
+        size++;
+    }
+
+    @Nullable
+    public E poll() {
+        final Chunk<E> consumerChunk = this.consumerChunk;
+        int consumerIndex = this.consumerIndex;
+        final E e = consumerChunk.values[consumerIndex];
+        if (e == null) {
+            return null;
+        }
+        consumerChunk.values[consumerIndex] = null;
+        size--;
+        if (consumerIndex == consumerChunk.jumpIndex) {
+            consumerIndex = 0;
+            this.consumerChunk = consumerChunk.next;
+        } else {
+            consumerIndex++;
+            if (consumerIndex == chunkSize) {
+                consumerIndex = 0;
+            }
+        }
+        this.consumerIndex = consumerIndex;
+        return e;
+    }
+
+    @Nullable
+    public E peek() {
+        return consumerChunk.values[consumerIndex];
+    }
+
+
+    private static class Chunk<E> {
+
+        final E[] values;
+        int jumpIndex = -1;
+        Chunk<E> next;
+
+        @SuppressWarnings("unchecked")
+        Chunk(final int chunkSize) {
+            values = (E[]) new Object[chunkSize];
+        }
+
+    }
+
+}

--- a/src/test/java/org/mqttbee/util/collections/ChunkedArrayQueueTest.java
+++ b/src/test/java/org/mqttbee/util/collections/ChunkedArrayQueueTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Silvio Giebl
+ */
+class ChunkedArrayQueueTest {
+
+    @Test
+    void poll_not_present() {
+        final ChunkedArrayQueue<String> queue = new ChunkedArrayQueue<>(8);
+        assertNull(queue.poll());
+        queue.offer("test");
+        assertEquals("test", queue.poll());
+        assertNull(queue.poll());
+    }
+
+    @CsvSource({"0, 1", "0, 4", "2, 4", "0, 8", "3, 8", "12, 20"})
+    @ParameterizedTest
+    void producer_consumer(final int minFill, final int iteration) {
+        final ChunkedArrayQueue<String> queue = new ChunkedArrayQueue<>(8);
+        int produced = 0;
+        int consumed = 0;
+        assertEquals(0, queue.size());
+        assertTrue(queue.isEmpty());
+        while (produced < minFill) {
+            queue.offer("test" + produced++);
+        }
+        assertEquals(minFill, queue.size());
+        assertEquals(minFill == 0, queue.isEmpty());
+        for (int i = iteration; i <= iteration * 100; i += iteration) {
+            while (produced < i + minFill) {
+                queue.offer("test" + produced++);
+            }
+            assertEquals(iteration + minFill, queue.size());
+            assertFalse(queue.isEmpty());
+            while (consumed < i) {
+                assertEquals("test" + consumed, queue.peek());
+                assertEquals("test" + consumed++, queue.poll());
+            }
+            assertEquals(minFill, queue.size());
+            assertEquals(minFill == 0, queue.isEmpty());
+        }
+        while (consumed < iteration * 100 + minFill) {
+            assertEquals("test" + consumed, queue.peek());
+            assertEquals("test" + consumed++, queue.poll());
+        }
+        assertEquals(0, queue.size());
+        assertTrue(queue.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Motivation
- If a outgoing publish flow completes or errors, the corresponding incoming acknowledge flow should complete or error as well
- If a incoming acknowledge flow is cancelled, the corresponding outgoing publish flow should be cancelled as well

Changes
- Added PublishFlowableAckLink to link a outgoing publish flow with its incoming acknoweldge flow
- Emitting in incoming acknowledge flow now done in Netty EventLoop (removed corresponding RxJava Worker)
- Adding of new outgoing publish flows blocks now directly if more than 64 publish flows added concurrently (removed corresponding RxJava Worker)