### PR TITLE
Feature/cleanup builders

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -79,12 +79,12 @@ public class MqttClientBuilder {
     }
 
     @NotNull
-    public MqttClientBuilder useWebSockets() {
-        return useWebSockets(MqttWebsocketConfigImpl.DEFAULT);
+    public MqttClientBuilder useWebSocket() {
+        return useWebSocket(MqttWebsocketConfigImpl.DEFAULT);
     }
 
     @NotNull
-    public MqttClientBuilder useWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
+    public MqttClientBuilder useWebSocket(@NotNull final MqttWebsocketConfig websocketConfig) {
         this.websocketConfig = websocketConfig;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -44,65 +44,65 @@ public class MqttClientBuilder {
     }
 
     @NotNull
-    public MqttClientBuilder withIdentifier(@NotNull final String identifier) {
+    public MqttClientBuilder identifier(@NotNull final String identifier) {
         this.identifier = MqttBuilderUtil.clientIdentifier(identifier);
         return this;
     }
 
     @NotNull
-    public MqttClientBuilder withIdentifier(@NotNull final MqttClientIdentifier identifier) {
+    public MqttClientBuilder identifier(@NotNull final MqttClientIdentifier identifier) {
         this.identifier = MqttBuilderUtil.clientIdentifier(identifier);
         return this;
     }
 
     @NotNull
-    public MqttClientBuilder withServerHost(@NotNull final String host) {
+    public MqttClientBuilder serverHost(@NotNull final String host) {
         this.serverHost = host;
         return this;
     }
 
     @NotNull
-    public MqttClientBuilder withServerPort(final int port) {
+    public MqttClientBuilder serverPort(final int port) {
         this.serverPort = port;
         return this;
     }
 
     @NotNull
-    public MqttClientBuilder usingSsl() {
-        return usingSsl(MqttClientSslConfigImpl.DEFAULT);
+    public MqttClientBuilder useSsl() {
+        return useSsl(MqttClientSslConfigImpl.DEFAULT);
     }
 
     @NotNull
-    public MqttClientBuilder usingSsl(@NotNull final MqttClientSslConfig sslConfig) {
+    public MqttClientBuilder useSsl(@NotNull final MqttClientSslConfig sslConfig) {
         this.sslConfig = sslConfig;
         return this;
     }
 
     @NotNull
-    public MqttClientBuilder usingWebSockets() {
-        return usingWebSockets(MqttWebsocketConfigImpl.DEFAULT);
+    public MqttClientBuilder useWebSockets() {
+        return useWebSockets(MqttWebsocketConfigImpl.DEFAULT);
     }
 
     @NotNull
-    public MqttClientBuilder usingWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
+    public MqttClientBuilder useWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
         this.websocketConfig = websocketConfig;
         return this;
     }
 
     @NotNull
-    public MqttClientBuilder usingExecutorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
+    public MqttClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
         this.executorConfig =
                 MustNotBeImplementedUtil.checkNotImplemented(executorConfig, MqttClientExecutorConfigImpl.class);
         return this;
     }
 
     @NotNull
-    public Mqtt3ClientBuilder usingMqtt3() {
+    public Mqtt3ClientBuilder useMqttVersion3() {
         return new Mqtt3ClientBuilder(identifier, serverHost, serverPort, sslConfig, websocketConfig, executorConfig);
     }
 
     @NotNull
-    public Mqtt5ClientBuilder usingMqtt5() {
+    public Mqtt5ClientBuilder useMqttVersion5() {
         return new Mqtt5ClientBuilder(identifier, serverHost, serverPort, sslConfig, websocketConfig, executorConfig);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -33,14 +33,14 @@ import org.mqttbee.util.MustNotBeImplementedUtil;
  */
 public class MqttClientBuilder {
 
-    private MqttClientIdentifierImpl identifier = MqttClientIdentifierImpl.REQUEST_CLIENT_IDENTIFIER_FROM_SERVER;
-    private String serverHost = "localhost";
-    private int serverPort = 1883;
-    private MqttClientSslConfig sslConfig = null;
-    private MqttWebsocketConfig websocketConfig = null;
-    private MqttClientExecutorConfigImpl executorConfig = MqttClientExecutorConfigImpl.DEFAULT;
+    protected MqttClientIdentifierImpl identifier = MqttClientIdentifierImpl.REQUEST_CLIENT_IDENTIFIER_FROM_SERVER;
+    protected String serverHost = "localhost";
+    protected int serverPort = 1883;
+    protected MqttClientSslConfig sslConfig = null;
+    protected MqttWebsocketConfig websocketConfig = null;
+    protected MqttClientExecutorConfigImpl executorConfig = MqttClientExecutorConfigImpl.DEFAULT;
 
-    MqttClientBuilder() {
+    protected MqttClientBuilder() {
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -34,21 +34,21 @@ public class MqttClientExecutorConfigBuilder {
     private Scheduler rxJavaScheduler = MqttClientExecutorConfigImpl.DEFAULT_RX_JAVA_SCHEDULER;
 
     @NotNull
-    public MqttClientExecutorConfigBuilder usingNettyExecutor(@NotNull final Executor nettyExecutor) {
+    public MqttClientExecutorConfigBuilder nettyExecutor(@NotNull final Executor nettyExecutor) {
         Preconditions.checkNotNull(nettyExecutor);
         this.nettyExecutor = nettyExecutor;
         return this;
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder usingNettyThreads(final int nettyThreads) {
+    public MqttClientExecutorConfigBuilder nettyThreads(final int nettyThreads) {
         Preconditions.checkArgument(nettyThreads > 0);
         this.nettyThreads = nettyThreads;
         return this;
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder usingRxJavaScheduler(@NotNull final Scheduler rxJavaScheduler) {
+    public MqttClientExecutorConfigBuilder rxJavaScheduler(@NotNull final Scheduler rxJavaScheduler) {
         Preconditions.checkNotNull(rxJavaScheduler);
         this.rxJavaScheduler = rxJavaScheduler;
         return this;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -33,8 +33,8 @@ public class MqttSharedTopicFilterBuilder extends MqttTopicFilterBuilder {
 
     @NotNull
     @Override
-    public MqttSharedTopicFilterBuilder sub(@NotNull final String subTopic) {
-        return (MqttSharedTopicFilterBuilder) super.sub(subTopic);
+    public MqttSharedTopicFilterBuilder subTopic(@NotNull final String subTopic) {
+        return (MqttSharedTopicFilterBuilder) super.subTopic(subTopic);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
@@ -32,7 +32,7 @@ public class MqttTopicBuilder {
     }
 
     @NotNull
-    public MqttTopicBuilder sub(@NotNull final String subTopic) {
+    public MqttTopicBuilder subTopic(@NotNull final String subTopic) {
         Preconditions.checkNotNull(subTopic);
         stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(subTopic);
         return this;

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -32,7 +32,7 @@ public class MqttTopicFilterBuilder {
     }
 
     @NotNull
-    public MqttTopicFilterBuilder sub(@NotNull final String subTopic) {
+    public MqttTopicFilterBuilder subTopic(@NotNull final String subTopic) {
         Preconditions.checkNotNull(subTopic);
         stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(subTopic);
         return this;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -25,6 +25,7 @@ import org.mqttbee.api.mqtt.MqttClientExecutorConfig;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
 import org.mqttbee.api.mqtt.MqttWebsocketConfig;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
+import org.mqttbee.api.mqtt.mqtt5.Mqtt5ClientBuilder;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
 import org.mqttbee.mqtt.MqttVersion;
@@ -115,6 +116,19 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
     public Mqtt3ClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
         super.executorConfig(executorConfig);
         return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useMqttVersion3() {
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useMqttVersion5() {
+        throw new UnsupportedOperationException(
+                "Switching MQTT Version is not allowed. Please call useMqttVersion3/5 only once.");
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -20,8 +20,11 @@ package org.mqttbee.api.mqtt.mqtt3;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
+import org.mqttbee.api.mqtt.MqttClientBuilder;
+import org.mqttbee.api.mqtt.MqttClientExecutorConfig;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
 import org.mqttbee.api.mqtt.MqttWebsocketConfig;
+import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
 import org.mqttbee.mqtt.MqttVersion;
@@ -32,14 +35,7 @@ import org.mqttbee.mqtt5.Mqtt5ClientImpl;
 /**
  * @author Silvio Giebl
  */
-public class Mqtt3ClientBuilder {
-
-    private final MqttClientIdentifierImpl identifier;
-    private final String serverHost;
-    private final int serverPort;
-    private final MqttClientSslConfig sslConfig;
-    private final MqttWebsocketConfig websocketConfig;
-    private final MqttClientExecutorConfigImpl executorConfig;
+public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     public Mqtt3ClientBuilder(
             @NotNull final MqttClientIdentifierImpl identifier, @NotNull final String serverHost, final int serverPort,
@@ -56,6 +52,69 @@ public class Mqtt3ClientBuilder {
         this.sslConfig = sslConfig;
         this.websocketConfig = websocketConfig;
         this.executorConfig = executorConfig;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder identifier(@NotNull final String identifier) {
+        super.identifier(identifier);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder identifier(@NotNull final MqttClientIdentifier identifier) {
+        super.identifier(identifier);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder serverHost(@NotNull final String host) {
+        super.serverHost(host);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder serverPort(final int port) {
+        super.serverPort(port);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useSsl() {
+        super.useSsl();
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useSsl(@NotNull final MqttClientSslConfig sslConfig) {
+        super.useSsl(sslConfig);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useWebSockets() {
+        super.useWebSockets();
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
+        super.useWebSockets(websocketConfig);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
+        super.executorConfig(executorConfig);
+        return this;
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -98,15 +98,15 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt3ClientBuilder useWebSockets() {
-        super.useWebSockets();
+    public Mqtt3ClientBuilder useWebSocket() {
+        super.useWebSocket();
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt3ClientBuilder useWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
-        super.useWebSockets(websocketConfig);
+    public Mqtt3ClientBuilder useWebSocket(@NotNull final MqttWebsocketConfig websocketConfig) {
+        super.useWebSocket(websocketConfig);
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -59,7 +59,7 @@ public class Mqtt3ClientBuilder {
     }
 
     @NotNull
-    public Mqtt3Client reactive() {
+    public Mqtt3Client buildReactive() {
         return new Mqtt3ClientView(new Mqtt5ClientImpl(buildClientData()));
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
@@ -39,25 +39,25 @@ public class Mqtt3SimpleAuthBuilder {
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder withUsername(@NotNull final String username) {
+    public Mqtt3SimpleAuthBuilder username(@NotNull final String username) {
         this.username = MqttBuilderUtil.string(username);
         return this;
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder withUsername(@NotNull final MqttUTF8String username) {
+    public Mqtt3SimpleAuthBuilder username(@NotNull final MqttUTF8String username) {
         this.username = MqttBuilderUtil.string(username);
         return this;
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder withPassword(@Nullable final byte[] password) {
+    public Mqtt3SimpleAuthBuilder password(@Nullable final byte[] password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder withPassword(@Nullable final ByteBuffer password) {
+    public Mqtt3SimpleAuthBuilder password(@Nullable final ByteBuffer password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -51,19 +51,19 @@ public class Mqtt3ConnectBuilder {
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder withKeepAlive(final int keepAlive) {
+    public Mqtt3ConnectBuilder keepAlive(final int keepAlive) {
         this.keepAlive = keepAlive;
         return this;
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder withCleanSession(final boolean isCleanSession) {
+    public Mqtt3ConnectBuilder cleanSession(final boolean isCleanSession) {
         this.isCleanSession = isCleanSession;
         return this;
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder withSimpleAuth(@Nullable final Mqtt3SimpleAuth simpleAuth) {
+    public Mqtt3ConnectBuilder simpleAuth(@Nullable final Mqtt3SimpleAuth simpleAuth) {
         final Mqtt3SimpleAuthView simpleAuthView =
                 MustNotBeImplementedUtil.checkNullOrNotImplemented(simpleAuth, Mqtt3SimpleAuthView.class);
         this.simpleAuth = (simpleAuthView == null) ? null : simpleAuthView.getDelegate();
@@ -71,7 +71,7 @@ public class Mqtt3ConnectBuilder {
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder withWillPublish(@Nullable final Mqtt3Publish willPublish) {
+    public Mqtt3ConnectBuilder willPublish(@Nullable final Mqtt3Publish willPublish) {
         final Mqtt3PublishView publishView =
                 MustNotBeImplementedUtil.checkNullOrNotImplemented(willPublish, Mqtt3PublishView.class);
         this.willPublish = (publishView == null) ? null : publishView.getWillDelegate();

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -53,37 +53,37 @@ public class Mqtt3PublishBuilder {
     }
 
     @NotNull
-    public Mqtt3PublishBuilder withTopic(@NotNull final String topic) {
+    public Mqtt3PublishBuilder topic(@NotNull final String topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder withTopic(@NotNull final MqttTopic topic) {
+    public Mqtt3PublishBuilder topic(@NotNull final MqttTopic topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder withPayload(@Nullable final byte[] payload) {
+    public Mqtt3PublishBuilder payload(@Nullable final byte[] payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.wrap(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder withPayload(@Nullable final ByteBuffer payload) {
+    public Mqtt3PublishBuilder payload(@Nullable final ByteBuffer payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.slice(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder withQos(@NotNull final MqttQoS qos) {
+    public Mqtt3PublishBuilder qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder withRetain(final boolean retain) {
+    public Mqtt3PublishBuilder retain(final boolean retain) {
         this.retain = retain;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -37,19 +37,19 @@ public class Mqtt3SubscriptionBuilder {
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder withTopicFilter(@NotNull final String topicFilter) {
+    public Mqtt3SubscriptionBuilder topicFilter(@NotNull final String topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder withTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
+    public Mqtt3SubscriptionBuilder topicFilter(@NotNull final MqttTopicFilter topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder withQoS(@NotNull final MqttQoS qos) {
+    public Mqtt3SubscriptionBuilder qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -50,7 +50,7 @@ public class Mqtt3UnsubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt3UnsubscribeBuilder copyTopicFiltersFrom(@NotNull final Mqtt3Subscribe subscribe) {
+    public Mqtt3UnsubscribeBuilder reverse(@NotNull final Mqtt3Subscribe subscribe) {
         final ImmutableList<? extends Mqtt3Subscription> subscriptions = subscribe.getSubscriptions();
         for (final Mqtt3Subscription subscription : subscriptions) {
             addTopicFilter(subscription.getTopicFilter());

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -50,7 +50,7 @@ public class Mqtt3UnsubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt3UnsubscribeBuilder counter(@NotNull final Mqtt3Subscribe subscribe) {
+    public Mqtt3UnsubscribeBuilder copyTopicFiltersFrom(@NotNull final Mqtt3Subscribe subscribe) {
         final ImmutableList<? extends Mqtt3Subscription> subscriptions = subscribe.getSubscriptions();
         for (final Mqtt3Subscription subscription : subscriptions) {
             addTopicFilter(subscription.getTopicFilter());

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -65,26 +65,26 @@ public class Mqtt5ClientBuilder {
     }
 
     @NotNull
-    public Mqtt5ClientBuilder followingRedirects(final boolean followsRedirects) {
+    public Mqtt5ClientBuilder followsRedirects(final boolean followsRedirects) {
         this.followsRedirects = followsRedirects;
         return this;
     }
 
     @NotNull
-    public Mqtt5ClientBuilder allowingServerReAuth(final boolean allowsServerReAuth) {
+    public Mqtt5ClientBuilder allowsServerReAuth(final boolean allowsServerReAuth) {
         this.allowsServerReAuth = allowsServerReAuth;
         return this;
     }
 
     @NotNull
-    public Mqtt5ClientBuilder withAdvanced(@Nullable final Mqtt5AdvancedClientData advancedClientData) {
+    public Mqtt5ClientBuilder advancedClientData(@Nullable final Mqtt5AdvancedClientData advancedClientData) {
         this.advancedClientData =
                 MustNotBeImplementedUtil.checkNullOrNotImplemented(advancedClientData, MqttAdvancedClientData.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5Client reactive() {
+    public Mqtt5Client buildReactive() {
         return new Mqtt5ClientImpl(buildClientData());
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -25,6 +25,7 @@ import org.mqttbee.api.mqtt.MqttClientExecutorConfig;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
 import org.mqttbee.api.mqtt.MqttWebsocketConfig;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
+import org.mqttbee.api.mqtt.mqtt3.Mqtt3ClientBuilder;
 import org.mqttbee.api.mqtt.mqtt5.advanced.Mqtt5AdvancedClientData;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
@@ -127,6 +128,19 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
     @Override
     public Mqtt5ClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
         super.executorConfig(executorConfig);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useMqttVersion3() {
+        throw new UnsupportedOperationException(
+                "Switching MQTT Version is not allowed. Please call useMqttVersion3/5 only once.");
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useMqttVersion5() {
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -20,8 +20,11 @@ package org.mqttbee.api.mqtt.mqtt5;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
+import org.mqttbee.api.mqtt.MqttClientBuilder;
+import org.mqttbee.api.mqtt.MqttClientExecutorConfig;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
 import org.mqttbee.api.mqtt.MqttWebsocketConfig;
+import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.api.mqtt.mqtt5.advanced.Mqtt5AdvancedClientData;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
@@ -34,7 +37,7 @@ import org.mqttbee.util.MustNotBeImplementedUtil;
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5ClientBuilder {
+public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     private final MqttClientIdentifierImpl identifier;
     private final String serverHost;
@@ -62,6 +65,69 @@ public class Mqtt5ClientBuilder {
         this.sslConfig = sslConfig;
         this.websocketConfig = websocketConfig;
         this.executorConfig = executorConfig;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder identifier(@NotNull final String identifier) {
+        super.identifier(identifier);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder identifier(@NotNull final MqttClientIdentifier identifier) {
+        super.identifier(identifier);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder serverHost(@NotNull final String host) {
+        super.serverHost(host);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder serverPort(final int port) {
+        super.serverPort(port);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useSsl() {
+        super.useSsl();
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useSsl(@NotNull final MqttClientSslConfig sslConfig) {
+        super.useSsl(sslConfig);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useWebSockets() {
+        super.useWebSockets();
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
+        super.useWebSockets(websocketConfig);
+        return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
+        super.executorConfig(executorConfig);
+        return this;
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -111,15 +111,15 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt5ClientBuilder useWebSockets() {
-        super.useWebSockets();
+    public Mqtt5ClientBuilder useWebSocket() {
+        super.useWebSocket();
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5ClientBuilder useWebSockets(@NotNull final MqttWebsocketConfig websocketConfig) {
-        super.useWebSockets(websocketConfig);
+    public Mqtt5ClientBuilder useWebSocket(@NotNull final MqttWebsocketConfig websocketConfig) {
+        super.useWebSocket(websocketConfig);
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -46,8 +46,8 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
     private final MqttWebsocketConfig websocketConfig;
     private final MqttClientExecutorConfigImpl executorConfig;
 
-    private boolean followsRedirects = false;
-    private boolean allowsServerReAuth = false;
+    private boolean followRedirects = false;
+    private boolean allowServerReAuth = false;
     private MqttAdvancedClientData advancedClientData;
 
     public Mqtt5ClientBuilder(
@@ -131,14 +131,14 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
     }
 
     @NotNull
-    public Mqtt5ClientBuilder followsRedirects(final boolean followsRedirects) {
-        this.followsRedirects = followsRedirects;
+    public Mqtt5ClientBuilder followRedirects(final boolean followRedirects) {
+        this.followRedirects = followRedirects;
         return this;
     }
 
     @NotNull
-    public Mqtt5ClientBuilder allowsServerReAuth(final boolean allowsServerReAuth) {
-        this.allowsServerReAuth = allowsServerReAuth;
+    public Mqtt5ClientBuilder allowServerReAuth(final boolean allowServerReAuth) {
+        this.allowServerReAuth = allowServerReAuth;
         return this;
     }
 
@@ -156,7 +156,7 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     private MqttClientData buildClientData() {
         return new MqttClientData(MqttVersion.MQTT_5_0, identifier, serverHost, serverPort, sslConfig, websocketConfig,
-                followsRedirects, allowsServerReAuth, executorConfig, advancedClientData);
+                followRedirects, allowServerReAuth, executorConfig, advancedClientData);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientDataBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientDataBuilder.java
@@ -35,7 +35,7 @@ public class Mqtt5AdvancedClientDataBuilder {
     private Mqtt5OutgoingQoS2ControlProvider outgoingQoS2ControlProvider;
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder withIncomingQoS1ControlProvider(
+    public Mqtt5AdvancedClientDataBuilder incomingQoS1ControlProvider(
             @NotNull final Mqtt5IncomingQoS1ControlProvider incomingQoS1ControlProvider) {
 
         this.incomingQoS1ControlProvider = incomingQoS1ControlProvider;
@@ -43,7 +43,7 @@ public class Mqtt5AdvancedClientDataBuilder {
     }
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder getOutgoingQoS1ControlProvider(
+    public Mqtt5AdvancedClientDataBuilder outgoingQoS1ControlProvider(
             @NotNull final Mqtt5OutgoingQoS1ControlProvider outgoingQoS1ControlProvider) {
 
         this.outgoingQoS1ControlProvider = outgoingQoS1ControlProvider;
@@ -51,7 +51,7 @@ public class Mqtt5AdvancedClientDataBuilder {
     }
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder getIncomingQoS2ControlProvider(
+    public Mqtt5AdvancedClientDataBuilder incomingQoS2ControlProvider(
             @NotNull final Mqtt5IncomingQoS2ControlProvider incomingQoS2ControlProvider) {
 
         this.incomingQoS2ControlProvider = incomingQoS2ControlProvider;
@@ -59,7 +59,7 @@ public class Mqtt5AdvancedClientDataBuilder {
     }
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder getOutgoingQoS2ControlProvider(
+    public Mqtt5AdvancedClientDataBuilder outgoingQoS2ControlProvider(
             @NotNull final Mqtt5OutgoingQoS2ControlProvider outgoingQoS2ControlProvider) {
 
         this.outgoingQoS2ControlProvider = outgoingQoS2ControlProvider;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
@@ -32,18 +32,18 @@ import java.nio.ByteBuffer;
 public interface Mqtt5AuthBuilder {
 
     @NotNull
-    Mqtt5AuthBuilder withData(@Nullable byte[] data);
+    Mqtt5AuthBuilder data(@Nullable byte[] data);
 
     @NotNull
-    Mqtt5AuthBuilder withData(@Nullable ByteBuffer data);
+    Mqtt5AuthBuilder data(@Nullable ByteBuffer data);
 
     @NotNull
-    Mqtt5AuthBuilder withReasonString(@Nullable String reasonString);
+    Mqtt5AuthBuilder reasonString(@Nullable String reasonString);
 
     @NotNull
-    Mqtt5AuthBuilder withReasonString(@Nullable MqttUTF8String reasonString);
+    Mqtt5AuthBuilder reasonString(@Nullable MqttUTF8String reasonString);
 
     @NotNull
-    Mqtt5AuthBuilder withUserProperties(@NotNull Mqtt5UserProperties userProperties);
+    Mqtt5AuthBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5EnhancedAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5EnhancedAuthBuilder.java
@@ -30,9 +30,9 @@ import java.nio.ByteBuffer;
 public interface Mqtt5EnhancedAuthBuilder {
 
     @NotNull
-    Mqtt5EnhancedAuthBuilder withData(@Nullable byte[] data);
+    Mqtt5EnhancedAuthBuilder data(@Nullable byte[] data);
 
     @NotNull
-    Mqtt5EnhancedAuthBuilder withData(@Nullable ByteBuffer data);
+    Mqtt5EnhancedAuthBuilder data(@Nullable ByteBuffer data);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
@@ -39,25 +39,25 @@ public class Mqtt5SimpleAuthBuilder {
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder withUsername(@Nullable final String username) {
+    public Mqtt5SimpleAuthBuilder username(@Nullable final String username) {
         this.username = MqttBuilderUtil.stringOrNull(username);
         return this;
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder withUsername(@Nullable final MqttUTF8String username) {
+    public Mqtt5SimpleAuthBuilder username(@Nullable final MqttUTF8String username) {
         this.username = MqttBuilderUtil.stringOrNull(username);
         return this;
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder withPassword(@Nullable final byte[] password) {
+    public Mqtt5SimpleAuthBuilder password(@Nullable final byte[] password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder withPassword(@Nullable final ByteBuffer password) {
+    public Mqtt5SimpleAuthBuilder password(@Nullable final ByteBuffer password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -66,62 +66,62 @@ public class Mqtt5ConnectBuilder {
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withKeepAlive(final int keepAlive) {
+    public Mqtt5ConnectBuilder keepAlive(final int keepAlive) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAlive));
         this.keepAlive = keepAlive;
         return this;
     }
 
-    public Mqtt5ConnectBuilder withCleanStart(final boolean isCleanStart) {
+    public Mqtt5ConnectBuilder cleanStart(final boolean isCleanStart) {
         this.isCleanStart = isCleanStart;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withSessionExpiryInterval(final long sessionExpiryInterval) {
+    public Mqtt5ConnectBuilder sessionExpiryInterval(final long sessionExpiryInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryInterval));
         this.sessionExpiryInterval = sessionExpiryInterval;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withResponseInformationRequested(final boolean isResponseInformationRequested) {
+    public Mqtt5ConnectBuilder responseInformationRequested(final boolean isResponseInformationRequested) {
         this.isResponseInformationRequested = isResponseInformationRequested;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withProblemInformationRequested(final boolean isProblemInformationRequested) {
+    public Mqtt5ConnectBuilder problemInformationRequested(final boolean isProblemInformationRequested) {
         this.isProblemInformationRequested = isProblemInformationRequested;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withRestrictions(@NotNull final Mqtt5ConnectRestrictions restrictions) {
+    public Mqtt5ConnectBuilder restrictions(@NotNull final Mqtt5ConnectRestrictions restrictions) {
         this.restrictions = MustNotBeImplementedUtil.checkNotImplemented(restrictions, MqttConnectRestrictions.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withSimpleAuth(@Nullable final Mqtt5SimpleAuth simpleAuth) {
+    public Mqtt5ConnectBuilder simpleAuth(@Nullable final Mqtt5SimpleAuth simpleAuth) {
         this.simpleAuth = MustNotBeImplementedUtil.checkNullOrNotImplemented(simpleAuth, MqttSimpleAuth.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withEnhancedAuth(@Nullable final Mqtt5EnhancedAuthProvider enhancedAuthProvider) {
+    public Mqtt5ConnectBuilder enhancedAuth(@Nullable final Mqtt5EnhancedAuthProvider enhancedAuthProvider) {
         this.enhancedAuthProvider = enhancedAuthProvider;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withWillPublish(@Nullable final Mqtt5WillPublish willPublish) {
+    public Mqtt5ConnectBuilder willPublish(@Nullable final Mqtt5WillPublish willPublish) {
         this.willPublish = MustNotBeImplementedUtil.checkNullOrNotImplemented(willPublish, MqttWillPublish.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5ConnectBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
@@ -35,21 +35,21 @@ public class Mqtt5ConnectRestrictionsBuilder {
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder withReceiveMaximum(final int receiveMaximum) {
+    public Mqtt5ConnectRestrictionsBuilder receiveMaximum(final int receiveMaximum) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(receiveMaximum));
         this.receiveMaximum = receiveMaximum;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder withTopicAliasMaximum(final int topicAliasMaximum) {
+    public Mqtt5ConnectRestrictionsBuilder topicAliasMaximum(final int topicAliasMaximum) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(topicAliasMaximum));
         this.topicAliasMaximum = topicAliasMaximum;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder withMaximumPacketSize(final int maximumPacketSize) {
+    public Mqtt5ConnectRestrictionsBuilder maximumPacketSize(final int maximumPacketSize) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(maximumPacketSize));
         this.maximumPacketSize = maximumPacketSize;
         return this;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -46,44 +46,44 @@ public class Mqtt5DisconnectBuilder {
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withWillMessage(final boolean withWillMessage) {
+    public Mqtt5DisconnectBuilder willMessage(final boolean withWillMessage) {
         this.withWillMessage = withWillMessage;
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withSessionExpiryInterval(final long sessionExpiryInterval) {
+    public Mqtt5DisconnectBuilder sessionExpiryInterval(final long sessionExpiryInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryInterval));
         this.sessionExpiryInterval = sessionExpiryInterval;
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withServerReference(@Nullable final String serverReference) {
+    public Mqtt5DisconnectBuilder serverReference(@Nullable final String serverReference) {
         this.serverReference = MqttBuilderUtil.stringOrNull(serverReference);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withServerReference(@Nullable final MqttUTF8String serverReference) {
+    public Mqtt5DisconnectBuilder serverReference(@Nullable final MqttUTF8String serverReference) {
         this.serverReference = MqttBuilderUtil.stringOrNull(serverReference);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withReasonString(@Nullable final String reasonString) {
+    public Mqtt5DisconnectBuilder reasonString(@Nullable final String reasonString) {
         this.reasonString = MqttBuilderUtil.stringOrNull(reasonString);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withReasonString(@Nullable final MqttUTF8String reasonString) {
+    public Mqtt5DisconnectBuilder reasonString(@Nullable final MqttUTF8String reasonString) {
         this.reasonString = MqttBuilderUtil.stringOrNull(reasonString);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5DisconnectBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -74,50 +74,50 @@ public class Mqtt5PublishBuilder {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withTopic(@NotNull final String topic) {
+    public Mqtt5PublishBuilder topic(@NotNull final String topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withTopic(@NotNull final MqttTopic topic) {
+    public Mqtt5PublishBuilder topic(@NotNull final MqttTopic topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withPayload(@Nullable final byte[] payload) {
+    public Mqtt5PublishBuilder payload(@Nullable final byte[] payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.wrap(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withPayload(@Nullable final ByteBuffer payload) {
+    public Mqtt5PublishBuilder payload(@Nullable final ByteBuffer payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.slice(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withQos(@NotNull final MqttQoS qos) {
+    public Mqtt5PublishBuilder qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withRetain(final boolean retain) {
+    public Mqtt5PublishBuilder retain(final boolean retain) {
         this.retain = retain;
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withMessageExpiryInterval(final long messageExpiryInterval) {
+    public Mqtt5PublishBuilder messageExpiryInterval(final long messageExpiryInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(messageExpiryInterval));
         this.messageExpiryInterval = messageExpiryInterval;
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withPayloadFormatIndicator(
+    public Mqtt5PublishBuilder payloadFormatIndicator(
             @Nullable final Mqtt5PayloadFormatIndicator payloadFormatIndicator) {
 
         this.payloadFormatIndicator = payloadFormatIndicator;
@@ -125,50 +125,50 @@ public class Mqtt5PublishBuilder {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withContentType(@Nullable final String contentType) {
+    public Mqtt5PublishBuilder contentType(@Nullable final String contentType) {
         this.contentType = MqttBuilderUtil.stringOrNull(contentType);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withContentType(@Nullable final MqttUTF8String contentType) {
+    public Mqtt5PublishBuilder contentType(@Nullable final MqttUTF8String contentType) {
         this.contentType = MqttBuilderUtil.stringOrNull(contentType);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withResponseTopic(@Nullable final String responseTopic) {
+    public Mqtt5PublishBuilder responseTopic(@Nullable final String responseTopic) {
         this.responseTopic = MqttBuilderUtil.topicOrNull(responseTopic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withResponseTopic(@Nullable final MqttTopic responseTopic) {
+    public Mqtt5PublishBuilder responseTopic(@Nullable final MqttTopic responseTopic) {
         this.responseTopic = MqttBuilderUtil.topicOrNull(responseTopic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withCorrelationData(@Nullable final byte[] correlationData) {
+    public Mqtt5PublishBuilder correlationData(@Nullable final byte[] correlationData) {
         this.correlationData = MqttBuilderUtil.binaryDataOrNull(correlationData);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withCorrelationData(@Nullable final ByteBuffer correlationData) {
+    public Mqtt5PublishBuilder correlationData(@Nullable final ByteBuffer correlationData) {
         this.correlationData = MqttBuilderUtil.binaryDataOrNull(correlationData);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withTopicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
+    public Mqtt5PublishBuilder topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
         Preconditions.checkNotNull(topicAliasUsage);
         this.topicAliasUsage = topicAliasUsage;
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5PublishBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -53,108 +53,108 @@ public class Mqtt5WillPublishBuilder extends Mqtt5PublishBuilder {
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withTopic(@NotNull final String topic) {
-        super.withTopic(topic);
+    public Mqtt5WillPublishBuilder topic(@NotNull final String topic) {
+        super.topic(topic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withTopic(@NotNull final MqttTopic topic) {
-        super.withTopic(topic);
+    public Mqtt5WillPublishBuilder topic(@NotNull final MqttTopic topic) {
+        super.topic(topic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withPayload(@Nullable final byte[] payload) {
+    public Mqtt5WillPublishBuilder payload(@Nullable final byte[] payload) {
         this.payload = MqttBuilderUtil.binaryDataOrNull(payload);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withPayload(@Nullable final ByteBuffer payload) {
+    public Mqtt5WillPublishBuilder payload(@Nullable final ByteBuffer payload) {
         this.payload = MqttBuilderUtil.binaryDataOrNull(payload);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withQos(@NotNull final MqttQoS qos) {
-        super.withQos(qos);
+    public Mqtt5WillPublishBuilder qos(@NotNull final MqttQoS qos) {
+        super.qos(qos);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withRetain(final boolean retain) {
-        super.withRetain(retain);
+    public Mqtt5WillPublishBuilder retain(final boolean retain) {
+        super.retain(retain);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withPayloadFormatIndicator(
+    public Mqtt5WillPublishBuilder payloadFormatIndicator(
             @Nullable final Mqtt5PayloadFormatIndicator payloadFormatIndicator) {
 
-        super.withPayloadFormatIndicator(payloadFormatIndicator);
+        super.payloadFormatIndicator(payloadFormatIndicator);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withContentType(@Nullable final String contentType) {
-        super.withContentType(contentType);
+    public Mqtt5WillPublishBuilder contentType(@Nullable final String contentType) {
+        super.contentType(contentType);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withContentType(@Nullable final MqttUTF8String contentType) {
-        super.withContentType(contentType);
+    public Mqtt5WillPublishBuilder contentType(@Nullable final MqttUTF8String contentType) {
+        super.contentType(contentType);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withResponseTopic(@Nullable final String responseTopic) {
-        super.withResponseTopic(responseTopic);
+    public Mqtt5WillPublishBuilder responseTopic(@Nullable final String responseTopic) {
+        super.responseTopic(responseTopic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withResponseTopic(@Nullable final MqttTopic responseTopic) {
-        super.withResponseTopic(responseTopic);
+    public Mqtt5WillPublishBuilder responseTopic(@Nullable final MqttTopic responseTopic) {
+        super.responseTopic(responseTopic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withCorrelationData(@Nullable final byte[] correlationData) {
-        super.withCorrelationData(correlationData);
+    public Mqtt5WillPublishBuilder correlationData(@Nullable final byte[] correlationData) {
+        super.correlationData(correlationData);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withCorrelationData(@Nullable final ByteBuffer correlationData) {
-        super.withCorrelationData(correlationData);
+    public Mqtt5WillPublishBuilder correlationData(@Nullable final ByteBuffer correlationData) {
+        super.correlationData(correlationData);
         return this;
     }
 
     @NotNull
     @Override
     @Deprecated
-    public Mqtt5WillPublishBuilder withTopicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
+    public Mqtt5WillPublishBuilder topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
-        super.withUserProperties(userProperties);
+    public Mqtt5WillPublishBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+        super.userProperties(userProperties);
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
@@ -28,6 +28,6 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 public interface Mqtt5PubAckBuilder {
 
     @NotNull
-    Mqtt5PubAckBuilder withUserProperties(@NotNull Mqtt5UserProperties userProperties);
+    Mqtt5PubAckBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
@@ -28,6 +28,6 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 public interface Mqtt5PubCompBuilder {
 
     @NotNull
-    Mqtt5PubCompBuilder withUserProperties(@NotNull Mqtt5UserProperties userProperties);
+    Mqtt5PubCompBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
@@ -28,6 +28,6 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 public interface Mqtt5PubRecBuilder {
 
     @NotNull
-    Mqtt5PubRecBuilder withUserProperties(@NotNull Mqtt5UserProperties userProperties);
+    Mqtt5PubRecBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
@@ -28,6 +28,6 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 public interface Mqtt5PubRelBuilder {
 
     @NotNull
-    Mqtt5PubRelBuilder withUserProperties(@NotNull Mqtt5UserProperties userProperties);
+    Mqtt5PubRelBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -45,7 +45,7 @@ public class Mqtt5SubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt5SubscribeBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5SubscribeBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -40,37 +40,37 @@ public class Mqtt5SubscriptionBuilder {
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder withTopicFilter(@NotNull final String topicFilter) {
+    public Mqtt5SubscriptionBuilder topicFilter(@NotNull final String topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder withTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
+    public Mqtt5SubscriptionBuilder topicFilter(@NotNull final MqttTopicFilter topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder withQoS(@NotNull final MqttQoS qos) {
+    public Mqtt5SubscriptionBuilder qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder withNoLocal(final boolean noLocal) {
+    public Mqtt5SubscriptionBuilder noLocal(final boolean noLocal) {
         this.noLocal = noLocal;
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder withRetainHandling(@NotNull final Mqtt5RetainHandling retainHandling) {
+    public Mqtt5SubscriptionBuilder retainHandling(@NotNull final Mqtt5RetainHandling retainHandling) {
         this.retainHandling = Preconditions.checkNotNull(retainHandling);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder withRetainAsPublished(final boolean retainAsPublished) {
+    public Mqtt5SubscriptionBuilder retainAsPublished(final boolean retainAsPublished) {
         this.retainAsPublished = retainAsPublished;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -53,7 +53,7 @@ public class Mqtt5UnsubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder copyTopicFiltersFrom(@NotNull final Mqtt5Subscribe subscribe) {
+    public Mqtt5UnsubscribeBuilder reverse(@NotNull final Mqtt5Subscribe subscribe) {
         final ImmutableList<? extends Mqtt5Subscription> subscriptions = subscribe.getSubscriptions();
         for (final Mqtt5Subscription subscription : subscriptions) {
             addTopicFilter(subscription.getTopicFilter());

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -53,7 +53,7 @@ public class Mqtt5UnsubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder counter(@NotNull final Mqtt5Subscribe subscribe) {
+    public Mqtt5UnsubscribeBuilder copyTopicFiltersFrom(@NotNull final Mqtt5Subscribe subscribe) {
         final ImmutableList<? extends Mqtt5Subscription> subscriptions = subscribe.getSubscriptions();
         for (final Mqtt5Subscription subscription : subscriptions) {
             addTopicFilter(subscription.getTopicFilter());
@@ -62,7 +62,7 @@ public class Mqtt5UnsubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5UnsubscribeBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
@@ -52,35 +52,35 @@ public class MqttAuthBuilder implements Mqtt5AuthBuilder {
 
     @NotNull
     @Override
-    public MqttAuthBuilder withData(@Nullable final byte[] data) {
+    public MqttAuthBuilder data(@Nullable final byte[] data) {
         this.data = MqttBuilderUtil.binaryDataOrNull(data);
         return this;
     }
 
     @NotNull
     @Override
-    public MqttAuthBuilder withData(@Nullable final ByteBuffer data) {
+    public MqttAuthBuilder data(@Nullable final ByteBuffer data) {
         this.data = MqttBuilderUtil.binaryDataOrNull(data);
         return this;
     }
 
     @NotNull
     @Override
-    public MqttAuthBuilder withReasonString(@Nullable final String reasonString) {
+    public MqttAuthBuilder reasonString(@Nullable final String reasonString) {
         this.reasonString = MqttBuilderUtil.stringOrNull(reasonString);
         return this;
     }
 
     @NotNull
     @Override
-    public MqttAuthBuilder withReasonString(@Nullable final MqttUTF8String reasonString) {
+    public MqttAuthBuilder reasonString(@Nullable final MqttUTF8String reasonString) {
         this.reasonString = MqttBuilderUtil.stringOrNull(reasonString);
         return this;
     }
 
     @NotNull
     @Override
-    public MqttAuthBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public MqttAuthBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuthBuilder.java
@@ -41,14 +41,14 @@ public class MqttEnhancedAuthBuilder implements Mqtt5EnhancedAuthBuilder {
 
     @NotNull
     @Override
-    public MqttEnhancedAuthBuilder withData(@Nullable final byte[] data) {
+    public MqttEnhancedAuthBuilder data(@Nullable final byte[] data) {
         this.data = MqttBuilderUtil.binaryDataOrNull(data);
         return this;
     }
 
     @NotNull
     @Override
-    public MqttEnhancedAuthBuilder withData(@Nullable final ByteBuffer data) {
+    public MqttEnhancedAuthBuilder data(@Nullable final ByteBuffer data) {
         this.data = MqttBuilderUtil.binaryDataOrNull(data);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckBuilder.java
@@ -43,7 +43,7 @@ public class MqttPubAckBuilder implements Mqtt5PubAckBuilder {
 
     @NotNull
     @Override
-    public MqttPubAckBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public MqttPubAckBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
@@ -43,7 +43,7 @@ public class MqttPubCompBuilder implements Mqtt5PubCompBuilder {
 
     @NotNull
     @Override
-    public MqttPubCompBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public MqttPubCompBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
@@ -43,7 +43,7 @@ public class MqttPubRecBuilder implements Mqtt5PubRecBuilder {
 
     @NotNull
     @Override
-    public MqttPubRecBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public MqttPubRecBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
@@ -43,7 +43,7 @@ public class MqttPubRelBuilder implements Mqtt5PubRelBuilder {
 
     @NotNull
     @Override
-    public MqttPubRelBuilder withUserProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public MqttPubRelBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -181,13 +181,13 @@ class Mqtt3ClientExample {
                 client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected publisher"));
 
         // create a stub publish and a counter
-        final Mqtt3PublishBuilder publishMessageBuilder = Mqtt3Publish.builder().withTopic(topic).withQos(qos);
+        final Mqtt3PublishBuilder publishMessageBuilder = Mqtt3Publish.builder().topic(topic).qos(qos);
         final AtomicInteger counter = new AtomicInteger();
         // fake a stream of random messages, actually not random, but an incrementing counter ;-)
         final Flowable<Mqtt3Publish> publishFlowable = Flowable.generate(emitter -> {
             if (counter.get() < countToPublish) {
                 emitter.onNext(
-                        publishMessageBuilder.withPayload(("test " + counter.getAndIncrement()).getBytes()).build());
+                        publishMessageBuilder.payload(("test " + counter.getAndIncrement()).getBytes()).build());
             } else {
                 emitter.onComplete();
             }

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -226,7 +226,7 @@ class Mqtt3ClientExample {
         }
 
         if (isNotUsingMqttPort(port)) {
-            mqttClientBuilder.useWebSockets(MqttWebsocketConfig.builder().serverPath(serverPath).build());
+            mqttClientBuilder.useWebSocket(MqttWebsocketConfig.builder().serverPath(serverPath).build());
         }
 
         return mqttClientBuilder.useMqttVersion3().buildReactive();

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -136,7 +136,7 @@ class Mqtt3ClientExample {
 
         // create a SUBSCRIBE message for the topic with QoS
         final Mqtt3Subscribe subscribeMessage = Mqtt3Subscribe.builder()
-                .addSubscription(Mqtt3Subscription.builder().withTopicFilter(topic).withQoS(qos).build())
+                .addSubscription(Mqtt3Subscription.builder().topicFilter(topic).qos(qos).build())
                 .build();
         // define what to do with the publishes that match the subscription. This does not subscribe until rxJava's subscribe is called
         // NOTE: you can also subscribe without the stream, and then handle the incoming publishes on client.allPublishes()

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -214,22 +214,22 @@ class Mqtt3ClientExample {
 
     private Mqtt3Client getClient() {
         final MqttClientBuilder mqttClientBuilder = MqttClient.builder()
-                .withIdentifier(UUID.randomUUID().toString())
-                .withServerHost(server)
-                .withServerPort(port);
+                .identifier(UUID.randomUUID().toString())
+                .serverHost(server)
+                .serverPort(port);
 
         if (usesSsl) {
-            mqttClientBuilder.usingSsl(MqttClientSslConfig.builder()
+            mqttClientBuilder.useSsl(MqttClientSslConfig.builder()
                     .keyManagerFactory(keyManagerFactory)
                     .trustManagerFactory(trustManagerFactory)
                     .build());
         }
 
         if (isNotUsingMqttPort(port)) {
-            mqttClientBuilder.usingWebSockets(MqttWebsocketConfig.builder().serverPath(serverPath).build());
+            mqttClientBuilder.useWebSockets(MqttWebsocketConfig.builder().serverPath(serverPath).build());
         }
 
-        return mqttClientBuilder.usingMqtt3().reactive();
+        return mqttClientBuilder.useMqttVersion3().buildReactive();
     }
 
     private static String getProperty(final String key, final String defaultValue) {

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -129,7 +129,7 @@ class Mqtt3ClientExample {
         final Mqtt3Client client = getClient();
 
         // create a CONNECT message with keep alive of 10 seconds
-        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().withKeepAlive(10).build();
+        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().keepAlive(10).build();
         // define what to do on connect, this does not connect yet
         final Single<Mqtt3ConnAck> connectScenario =
                 client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected subscriber"));
@@ -175,7 +175,7 @@ class Mqtt3ClientExample {
         final Mqtt3Client client = getClient();
 
         // create a CONNECT message with keep alive of 10 seconds
-        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().withKeepAlive(10).build();
+        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().keepAlive(10).build();
         // define what to do on connect, this does not connect yet
         final Single<Mqtt3ConnAck> connectScenario =
                 client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected publisher"));

--- a/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
+++ b/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
@@ -72,7 +72,7 @@ class Mqtt3ClientViewExceptionsTest {
 
         final Mqtt3Subscribe subscribe = Mqtt3Subscribe.builder()
                 .addSubscription(
-                        Mqtt3Subscription.builder().withTopicFilter("topic").withQoS(MqttQoS.AT_LEAST_ONCE).build())
+                        Mqtt3Subscription.builder().topicFilter("topic").qos(MqttQoS.AT_LEAST_ONCE).build())
                 .build();
         assertMqtt3Exception(() -> mqtt3Client.subscribe(subscribe).toCompletable().blockingAwait(),
                 mqtt5MessageException);
@@ -88,7 +88,7 @@ class Mqtt3ClientViewExceptionsTest {
 
         final Mqtt3Subscribe subscribe = Mqtt3Subscribe.builder()
                 .addSubscription(
-                        Mqtt3Subscription.builder().withTopicFilter("topic").withQoS(MqttQoS.AT_LEAST_ONCE).build())
+                        Mqtt3Subscription.builder().topicFilter("topic").qos(MqttQoS.AT_LEAST_ONCE).build())
                 .build();
         assertMqtt3Exception(() -> mqtt3Client.subscribeWithStream(subscribe).blockingSubscribe(),
                 mqtt5MessageException);

--- a/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
+++ b/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
@@ -129,7 +129,7 @@ class Mqtt3ClientViewExceptionsTest {
         given(mqtt5Client.publish(any())).willReturn(Flowable.error(mqtt5MessageException));
 
         final Flowable<Mqtt3Publish> publish =
-                Flowable.just(Mqtt3Publish.builder().withTopic("topic").withQos(MqttQoS.AT_LEAST_ONCE).build());
+                Flowable.just(Mqtt3Publish.builder().topic("topic").qos(MqttQoS.AT_LEAST_ONCE).build());
         assertMqtt3Exception(() -> mqtt3Client.publish(publish).blockingSubscribe(), mqtt5MessageException);
     }
 


### PR DESCRIPTION
**Motivation**
Builder methods have prefixes which blow the code up.

**Changes**
Remove prefixes from builder methods where possible.
