### PR TITLE
Improvement/fluent builders

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/MqttClient.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClient.java
@@ -21,6 +21,8 @@ import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
 
 /**
+ * Common interface for MQTT clients.
+ *
  * @author Silvio Giebl
  */
 @DoNotImplement
@@ -31,6 +33,9 @@ public interface MqttClient {
         return new MqttClientBuilder();
     }
 
+    /**
+     * @return the client specific data.
+     */
     @NotNull
     MqttClientData getClientData();
 

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClient.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClient.java
@@ -28,6 +28,12 @@ import org.mqttbee.annotations.NotNull;
 @DoNotImplement
 public interface MqttClient {
 
+    String DEFAULT_SERVER_HOST = "localhost";
+    int DEFAULT_SERVER_PORT = 1883;
+    int DEFAULT_SERVER_PORT_SSL = 8883;
+    int DEFAULT_SERVER_PORT_WEBSOCKET = 80;
+    int DEFAULT_SERVER_PORT_WEBSOCKET_SSL = 443;
+
     @NotNull
     static MqttClientBuilder builder() {
         return new MqttClientBuilder();

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -17,6 +17,7 @@
 
 package org.mqttbee.api.mqtt;
 
+import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.api.mqtt.mqtt3.Mqtt3ClientBuilder;
@@ -57,7 +58,7 @@ public class MqttClientBuilder {
 
     @NotNull
     public MqttClientBuilder serverHost(@NotNull final String host) {
-        this.serverHost = host;
+        this.serverHost = Preconditions.checkNotNull(host);
         return this;
     }
 
@@ -74,7 +75,7 @@ public class MqttClientBuilder {
 
     @NotNull
     public MqttClientBuilder useSsl(@NotNull final MqttClientSslConfig sslConfig) {
-        this.sslConfig = sslConfig;
+        this.sslConfig = Preconditions.checkNotNull(sslConfig);
         return this;
     }
 
@@ -85,7 +86,7 @@ public class MqttClientBuilder {
 
     @NotNull
     public MqttClientBuilder useWebSocket(@NotNull final MqttWebsocketConfig websocketConfig) {
-        this.websocketConfig = websocketConfig;
+        this.websocketConfig = Preconditions.checkNotNull(websocketConfig);
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -29,14 +29,17 @@ import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
 import org.mqttbee.util.MustNotBeImplementedUtil;
 
+import static org.mqttbee.api.mqtt.MqttClient.*;
+
 /**
  * @author Silvio Giebl
  */
 public class MqttClientBuilder {
 
     protected MqttClientIdentifierImpl identifier = MqttClientIdentifierImpl.REQUEST_CLIENT_IDENTIFIER_FROM_SERVER;
-    protected String serverHost = "localhost";
-    protected int serverPort = 1883;
+    protected String serverHost = DEFAULT_SERVER_HOST;
+    protected int serverPort = DEFAULT_SERVER_PORT;
+    private boolean customServerPort = false;
     protected MqttClientSslConfig sslConfig = null;
     protected MqttWebsocketConfig websocketConfig = null;
     protected MqttClientExecutorConfigImpl executorConfig = MqttClientExecutorConfigImpl.DEFAULT;
@@ -65,6 +68,7 @@ public class MqttClientBuilder {
     @NotNull
     public MqttClientBuilder serverPort(final int port) {
         this.serverPort = port;
+        customServerPort = true;
         return this;
     }
 
@@ -75,6 +79,13 @@ public class MqttClientBuilder {
 
     @NotNull
     public MqttClientBuilder useSsl(@NotNull final MqttClientSslConfig sslConfig) {
+        if (!customServerPort) {
+            if (websocketConfig == null) {
+                serverPort = DEFAULT_SERVER_PORT_SSL;
+            } else {
+                serverPort = DEFAULT_SERVER_PORT_WEBSOCKET_SSL;
+            }
+        }
         this.sslConfig = Preconditions.checkNotNull(sslConfig);
         return this;
     }
@@ -91,6 +102,13 @@ public class MqttClientBuilder {
 
     @NotNull
     public MqttClientBuilder useWebSocket(@NotNull final MqttWebsocketConfig websocketConfig) {
+        if (!customServerPort) {
+            if (sslConfig == null) {
+                serverPort = DEFAULT_SERVER_PORT_WEBSOCKET;
+            } else {
+                serverPort = DEFAULT_SERVER_PORT_WEBSOCKET_SSL;
+            }
+        }
         this.websocketConfig = Preconditions.checkNotNull(websocketConfig);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -73,7 +73,7 @@ public class MqttClientBuilder {
     }
 
     @NotNull
-    public MqttClientBuilder useSslDefaults() {
+    public MqttClientBuilder useSslWithDefaultConfig() {
         return useSsl(MqttClientSslConfigImpl.DEFAULT);
     }
 
@@ -96,7 +96,7 @@ public class MqttClientBuilder {
     }
 
     @NotNull
-    public MqttClientBuilder useWebSocketDefaults() {
+    public MqttClientBuilder useWebSocketWithDefaultConfig() {
         return useWebSocket(MqttWebsocketConfigImpl.DEFAULT);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -69,7 +69,7 @@ public class MqttClientBuilder {
     }
 
     @NotNull
-    public MqttClientBuilder useSsl() {
+    public MqttClientBuilder useSslDefaults() {
         return useSsl(MqttClientSslConfigImpl.DEFAULT);
     }
 
@@ -80,7 +80,12 @@ public class MqttClientBuilder {
     }
 
     @NotNull
-    public MqttClientBuilder useWebSocket() {
+    public MqttClientSslConfigBuilder<? extends MqttClientBuilder> useSsl() {
+        return new MqttClientSslConfigBuilder<>(this::useSsl);
+    }
+
+    @NotNull
+    public MqttClientBuilder useWebSocketDefaults() {
         return useWebSocket(MqttWebsocketConfigImpl.DEFAULT);
     }
 
@@ -91,10 +96,20 @@ public class MqttClientBuilder {
     }
 
     @NotNull
+    public MqttWebsocketConfigBuilder<? extends MqttClientBuilder> useWebSocket() {
+        return new MqttWebsocketConfigBuilder<>(this::useWebSocket);
+    }
+
+    @NotNull
     public MqttClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
         this.executorConfig =
                 MustNotBeImplementedUtil.checkNotImplemented(executorConfig, MqttClientExecutorConfigImpl.class);
         return this;
+    }
+
+    @NotNull
+    public MqttClientExecutorConfigBuilder<? extends MqttClientBuilder> executorConfig() {
+        return new MqttClientExecutorConfigBuilder<>(this::executorConfig);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
@@ -31,8 +31,8 @@ import java.util.concurrent.Executor;
 public interface MqttClientExecutorConfig {
 
     @NotNull
-    static MqttClientExecutorConfigBuilder builder() {
-        return new MqttClientExecutorConfigBuilder();
+    static MqttClientExecutorConfigBuilder<Void> builder() {
+        return new MqttClientExecutorConfigBuilder<>(null);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -20,40 +20,51 @@ package org.mqttbee.api.mqtt;
 import com.google.common.base.Preconditions;
 import io.reactivex.Scheduler;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
+import org.mqttbee.util.FluentBuilder;
 
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class MqttClientExecutorConfigBuilder {
+public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClientExecutorConfig, P> {
 
     private Executor nettyExecutor;
     private int nettyThreads = MqttClientExecutorConfigImpl.DEFAULT_NETTY_THREADS;
     private Scheduler rxJavaScheduler = MqttClientExecutorConfigImpl.DEFAULT_RX_JAVA_SCHEDULER;
 
+    public MqttClientExecutorConfigBuilder(
+            @Nullable final Function<? super MqttClientExecutorConfig, P> parentConsumer) {
+
+        super(parentConsumer);
+    }
+
     @NotNull
-    public MqttClientExecutorConfigBuilder nettyExecutor(@NotNull final Executor nettyExecutor) {
+    public MqttClientExecutorConfigBuilder<P> nettyExecutor(@NotNull final Executor nettyExecutor) {
         Preconditions.checkNotNull(nettyExecutor);
         this.nettyExecutor = nettyExecutor;
         return this;
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder nettyThreads(final int nettyThreads) {
+    public MqttClientExecutorConfigBuilder<P> nettyThreads(final int nettyThreads) {
         Preconditions.checkArgument(nettyThreads > 0);
         this.nettyThreads = nettyThreads;
         return this;
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder rxJavaScheduler(@NotNull final Scheduler rxJavaScheduler) {
+    public MqttClientExecutorConfigBuilder<P> rxJavaScheduler(@NotNull final Scheduler rxJavaScheduler) {
         Preconditions.checkNotNull(rxJavaScheduler);
         this.rxJavaScheduler = rxJavaScheduler;
         return this;
     }
 
+    @NotNull
+    @Override
     public MqttClientExecutorConfig build() {
         return new MqttClientExecutorConfigImpl(nettyExecutor, nettyThreads, rxJavaScheduler);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientSslConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientSslConfig.java
@@ -31,8 +31,8 @@ public interface MqttClientSslConfig {
     long DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 
     @NotNull
-    static MqttClientSslConfigBuilder builder() {
-        return new MqttClientSslConfigBuilder();
+    static MqttClientSslConfigBuilder<Void> builder() {
+        return new MqttClientSslConfigBuilder<>(null);
     }
 
     @Nullable

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientSslConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientSslConfigBuilder.java
@@ -20,16 +20,18 @@ import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.mqtt.MqttClientSslConfigImpl;
+import org.mqttbee.util.FluentBuilder;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * @author Christian Hoff
  */
-public class MqttClientSslConfigBuilder {
+public class MqttClientSslConfigBuilder<P> extends FluentBuilder<MqttClientSslConfig, P> {
 
     private KeyManagerFactory keyManagerFactory = null;
     private TrustManagerFactory trustManagerFactory = null;
@@ -37,14 +39,18 @@ public class MqttClientSslConfigBuilder {
     private ImmutableList<String> protocols = null;
     private long handshakeTimeoutMs = MqttClientSslConfig.DEFAULT_HANDSHAKE_TIMEOUT_MS;
 
+    public MqttClientSslConfigBuilder(@Nullable final Function<? super MqttClientSslConfig, P> parentConsumer) {
+        super(parentConsumer);
+    }
+
     @NotNull
-    public MqttClientSslConfigBuilder keyManagerFactory(@Nullable final KeyManagerFactory keyManagerFactory) {
+    public MqttClientSslConfigBuilder<P> keyManagerFactory(@Nullable final KeyManagerFactory keyManagerFactory) {
         this.keyManagerFactory = keyManagerFactory;
         return this;
     }
 
     @NotNull
-    public MqttClientSslConfigBuilder trustManagerFactory(@Nullable final TrustManagerFactory trustManagerFactory) {
+    public MqttClientSslConfigBuilder<P> trustManagerFactory(@Nullable final TrustManagerFactory trustManagerFactory) {
         this.trustManagerFactory = trustManagerFactory;
         return this;
     }
@@ -53,7 +59,7 @@ public class MqttClientSslConfigBuilder {
      * @param cipherSuites if <code>null</code>, netty's default cipher suites will be used
      */
     @NotNull
-    public MqttClientSslConfigBuilder cipherSuites(@Nullable final List<String> cipherSuites) {
+    public MqttClientSslConfigBuilder<P> cipherSuites(@Nullable final List<String> cipherSuites) {
         this.cipherSuites = (cipherSuites == null) ? null : ImmutableList.copyOf(cipherSuites);
         return this;
     }
@@ -62,18 +68,19 @@ public class MqttClientSslConfigBuilder {
      * @param protocols if <code>null</code>, netty's default protocols will be used
      */
     @NotNull
-    public MqttClientSslConfigBuilder protocols(@Nullable final List<String> protocols) {
+    public MqttClientSslConfigBuilder<P> protocols(@Nullable final List<String> protocols) {
         this.protocols = (protocols == null) ? null : ImmutableList.copyOf(protocols);
         return this;
     }
 
     @NotNull
-    public MqttClientSslConfigBuilder handshakeTimeout(final long timeout, @NotNull final TimeUnit timeUnit) {
+    public MqttClientSslConfigBuilder<P> handshakeTimeout(final long timeout, @NotNull final TimeUnit timeUnit) {
         this.handshakeTimeoutMs = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
         return this;
     }
 
     @NotNull
+    @Override
     public MqttClientSslConfig build() {
         return new MqttClientSslConfigImpl(
                 keyManagerFactory, trustManagerFactory, cipherSuites, protocols, handshakeTimeoutMs);

--- a/src/main/java/org/mqttbee/api/mqtt/MqttWebsocketConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttWebsocketConfig.java
@@ -17,7 +17,6 @@
 package org.mqttbee.api.mqtt;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.mqtt.MqttWebsocketConfigImpl;
 
 /**
  * @author Christian Hoff
@@ -25,13 +24,8 @@ import org.mqttbee.mqtt.MqttWebsocketConfigImpl;
 public interface MqttWebsocketConfig {
 
     @NotNull
-    static MqttWebsocketConfigBuilder builder() {
-        return new MqttWebsocketConfigBuilder();
-    }
-
-    @NotNull
-    static MqttWebsocketConfig create(@NotNull final String serverPath) {
-        return new MqttWebsocketConfigImpl(serverPath);
+    static MqttWebsocketConfigBuilder<Void> builder() {
+        return new MqttWebsocketConfigBuilder<>(null);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/MqttWebsocketConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttWebsocketConfigBuilder.java
@@ -17,23 +17,32 @@
 package org.mqttbee.api.mqtt;
 
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.mqtt.MqttWebsocketConfigImpl;
+import org.mqttbee.util.FluentBuilder;
+
+import java.util.function.Function;
 
 /**
  * @author Christian Hoff
  */
-public class MqttWebsocketConfigBuilder {
+public class MqttWebsocketConfigBuilder<P> extends FluentBuilder<MqttWebsocketConfig, P> {
 
     private String serverPath = "";
 
+    public MqttWebsocketConfigBuilder(@Nullable final Function<? super MqttWebsocketConfig, P> parentConsumer) {
+        super(parentConsumer);
+    }
+
     @NotNull
-    public MqttWebsocketConfigBuilder serverPath(@NotNull final String serverPath) {
+    public MqttWebsocketConfigBuilder<P> serverPath(@NotNull final String serverPath) {
         // remove any leading slashes
         this.serverPath = serverPath.replaceAll("^/+", "");
         return this;
     }
 
     @NotNull
+    @Override
     public MqttWebsocketConfig build() {
         return new MqttWebsocketConfigImpl(serverPath);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilter.java
@@ -54,25 +54,26 @@ public interface MqttSharedTopicFilter extends MqttTopicFilter {
     }
 
     @NotNull
-    static MqttSharedTopicFilterBuilder builder(@NotNull final String shareName, @NotNull final String topTopic) {
-        return new MqttSharedTopicFilterBuilder(shareName, topTopic);
+    static MqttSharedTopicFilterBuilder<Void> builder(@NotNull final String shareName, @NotNull final String topTopic) {
+        return new MqttSharedTopicFilterBuilder<>(shareName, topTopic, null);
     }
 
     @NotNull
-    static MqttSharedTopicFilterBuilder extend(@NotNull final MqttSharedTopicFilter sharedTopicFilter) {
-        return new MqttSharedTopicFilterBuilder(sharedTopicFilter.getShareName(), sharedTopicFilter.getTopicFilter());
+    static MqttSharedTopicFilterBuilder<Void> extend(@NotNull final MqttSharedTopicFilter sharedTopicFilter) {
+        return new MqttSharedTopicFilterBuilder<>(
+                sharedTopicFilter.getShareName(), sharedTopicFilter.getTopicFilter(), null);
     }
 
     @NotNull
-    static MqttSharedTopicFilterBuilder share(
+    static MqttSharedTopicFilterBuilder<Void> share(
             @NotNull final String shareName, @NotNull final MqttTopicFilter topicFilter) {
 
-        return new MqttSharedTopicFilterBuilder(shareName, topicFilter.toString());
+        return new MqttSharedTopicFilterBuilder<>(shareName, topicFilter.toString(), null);
     }
 
     @NotNull
-    static MqttSharedTopicFilterBuilder share(@NotNull final String shareName, @NotNull final MqttTopic topic) {
-        return new MqttSharedTopicFilterBuilder(shareName, topic.toString());
+    static MqttSharedTopicFilterBuilder<Void> share(@NotNull final String shareName, @NotNull final MqttTopic topic) {
+        return new MqttSharedTopicFilterBuilder<>(shareName, topic.toString(), null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -18,35 +18,53 @@
 package org.mqttbee.api.mqtt.datatypes;
 
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class MqttSharedTopicFilterBuilder extends MqttTopicFilterBuilder {
+public class MqttSharedTopicFilterBuilder<P> extends MqttTopicFilterBuilder<P> {
+
+    private final Function<? super MqttSharedTopicFilter, P> parentConsumer;
 
     private final String shareName;
 
-    MqttSharedTopicFilterBuilder(@NotNull final String shareName, @NotNull final String base) {
-        super(base);
+    public MqttSharedTopicFilterBuilder(
+            @NotNull final String shareName, @NotNull final String base,
+            @Nullable final Function<? super MqttSharedTopicFilter, P> parentConsumer) {
+
+        super(base, null);
+        this.parentConsumer = parentConsumer;
         this.shareName = shareName;
     }
 
     @NotNull
     @Override
-    public MqttSharedTopicFilterBuilder subTopic(@NotNull final String subTopic) {
-        return (MqttSharedTopicFilterBuilder) super.subTopic(subTopic);
+    public MqttSharedTopicFilterBuilder<P> addLevel(@NotNull final String subTopic) {
+        super.addLevel(subTopic);
+        return this;
     }
 
     @NotNull
     @Override
-    public MqttSharedTopicFilterBuilder singleLevelWildcard() {
-        return (MqttSharedTopicFilterBuilder) super.singleLevelWildcard();
+    public MqttSharedTopicFilterBuilder<P> singleLevelWildcard() {
+        super.singleLevelWildcard();
+        return this;
     }
 
     @NotNull
     @Override
-    public MqttSharedTopicFilter multiLevelWildcard() {
-        return (MqttSharedTopicFilter) super.multiLevelWildcard();
+    public MqttSharedTopicFilter multiLevelWildcardAndBuild() {
+        super.multiLevelWildcardAndBuild();
+        return build();
+    }
+
+    @NotNull
+    @Override
+    public P done() {
+        return done(build(), parentConsumer);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
  */
 public class MqttSharedTopicFilterBuilder<P> extends MqttTopicFilterBuilder<P> {
 
+    @NotNull
     public static <P> MqttSharedTopicFilterBuilder<P> create(
             @NotNull final String shareName, @NotNull final String base,
             @Nullable final Function<? super MqttSharedTopicFilter, P> parentConsumer) {
@@ -67,6 +68,7 @@ public class MqttSharedTopicFilterBuilder<P> extends MqttTopicFilterBuilder<P> {
     }
 
     @NotNull
+    @Override
     public MqttSharedTopicFilter build() {
         return MqttSharedTopicFilter.from(shareName, stringBuilder.toString());
     }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -27,16 +27,21 @@ import java.util.function.Function;
  */
 public class MqttSharedTopicFilterBuilder<P> extends MqttTopicFilterBuilder<P> {
 
-    private final Function<? super MqttSharedTopicFilter, P> parentConsumer;
+    public static <P> MqttSharedTopicFilterBuilder<P> create(
+            @NotNull final String shareName, @NotNull final String base,
+            @Nullable final Function<? super MqttSharedTopicFilter, P> parentConsumer) {
+
+        return new MqttSharedTopicFilterBuilder<>(shareName, base, (parentConsumer == null) ? null :
+                topicFilter -> parentConsumer.apply((MqttSharedTopicFilter) topicFilter));
+    }
 
     private final String shareName;
 
     public MqttSharedTopicFilterBuilder(
             @NotNull final String shareName, @NotNull final String base,
-            @Nullable final Function<? super MqttSharedTopicFilter, P> parentConsumer) {
+            @Nullable final Function<? super MqttTopicFilter, P> parentConsumer) {
 
-        super(base, null);
-        this.parentConsumer = parentConsumer;
+        super(base, parentConsumer);
         this.shareName = shareName;
     }
 
@@ -59,12 +64,6 @@ public class MqttSharedTopicFilterBuilder<P> extends MqttTopicFilterBuilder<P> {
     public MqttSharedTopicFilter multiLevelWildcardAndBuild() {
         super.multiLevelWildcardAndBuild();
         return build();
-    }
-
-    @NotNull
-    @Override
-    public P done() {
-        return done(build(), parentConsumer);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilterBuilder.java
@@ -62,7 +62,7 @@ public class MqttSharedTopicFilterBuilder<P> extends MqttTopicFilterBuilder<P> {
     @NotNull
     @Override
     public MqttSharedTopicFilter multiLevelWildcardAndBuild() {
-        super.multiLevelWildcardAndBuild();
+        multiLevelWildcard();
         return build();
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
@@ -51,13 +51,13 @@ public interface MqttTopic extends MqttUTF8String {
     }
 
     @NotNull
-    static MqttTopicBuilder builder(@NotNull final String topTopic) {
-        return new MqttTopicBuilder(topTopic);
+    static MqttTopicBuilder<Void> builder(@NotNull final String topTopic) {
+        return new MqttTopicBuilder<>(topTopic, null);
     }
 
     @NotNull
-    static MqttTopicBuilder extend(@NotNull final MqttTopic topic) {
-        return new MqttTopicBuilder(topic.toString());
+    static MqttTopicBuilder<Void> extend(@NotNull final MqttTopic topic) {
+        return new MqttTopicBuilder<>(topic.toString(), null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
@@ -19,33 +19,38 @@ package org.mqttbee.api.mqtt.datatypes;
 
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
+import org.mqttbee.util.FluentBuilder;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class MqttTopicBuilder {
+public class MqttTopicBuilder<P> extends FluentBuilder<MqttTopic, P> {
 
     private final StringBuilder stringBuilder;
 
-    MqttTopicBuilder(@NotNull final String base) {
-        stringBuilder = new StringBuilder(base);
+    public MqttTopicBuilder(@NotNull final String base, @Nullable final Function<? super MqttTopic, P> parentConsumer) {
+        super(parentConsumer);
+        this.stringBuilder = new StringBuilder(base);
     }
 
     @NotNull
-    public MqttTopicBuilder subTopic(@NotNull final String subTopic) {
+    public MqttTopicBuilder<P> addLevel(@NotNull final String subTopic) {
         Preconditions.checkNotNull(subTopic);
         stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(subTopic);
         return this;
     }
 
     @NotNull
-    public MqttTopicFilterBuilder filter() {
-        return new MqttTopicFilterBuilder(stringBuilder.toString());
+    public MqttTopicFilterBuilder<Void> filter() {
+        return new MqttTopicFilterBuilder<>(stringBuilder.toString(), null);
     }
 
     @NotNull
-    public MqttSharedTopicFilterBuilder share(@NotNull final String shareName) {
-        return new MqttSharedTopicFilterBuilder(shareName, stringBuilder.toString());
+    public MqttSharedTopicFilterBuilder<Void> share(@NotNull final String shareName) {
+        return new MqttSharedTopicFilterBuilder<>(shareName, stringBuilder.toString(), null);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
@@ -54,6 +54,7 @@ public class MqttTopicBuilder<P> extends FluentBuilder<MqttTopic, P> {
     }
 
     @NotNull
+    @Override
     public MqttTopic build() {
         return MqttTopic.from(stringBuilder.toString());
     }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
@@ -55,18 +55,18 @@ public interface MqttTopicFilter extends MqttUTF8String {
     }
 
     @NotNull
-    static MqttTopicFilterBuilder builder(@NotNull final String topTopic) {
-        return new MqttTopicFilterBuilder(topTopic);
+    static MqttTopicFilterBuilder<Void> builder(@NotNull final String topTopic) {
+        return new MqttTopicFilterBuilder<>(topTopic, null);
     }
 
     @NotNull
-    static MqttTopicFilterBuilder extend(@NotNull final MqttTopicFilter topicFilter) {
-        return new MqttTopicFilterBuilder(topicFilter.toString());
+    static MqttTopicFilterBuilder<Void> extend(@NotNull final MqttTopicFilter topicFilter) {
+        return new MqttTopicFilterBuilder<>(topicFilter.toString(), null);
     }
 
     @NotNull
-    static MqttTopicFilterBuilder filter(@NotNull final MqttTopic topic) {
-        return new MqttTopicFilterBuilder(topic.toString());
+    static MqttTopicFilterBuilder<Void> filter(@NotNull final MqttTopic topic) {
+        return new MqttTopicFilterBuilder<>(topic.toString(), null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -79,6 +79,7 @@ public class MqttTopicFilterBuilder<P> extends FluentBuilder<MqttTopicFilter, P>
     }
 
     @NotNull
+    @Override
     public MqttTopicFilter build() {
         return MqttTopicFilter.from(stringBuilder.toString());
     }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -54,7 +54,7 @@ public class MqttTopicFilterBuilder<P> extends FluentBuilder<MqttTopicFilter, P>
         return this;
     }
 
-    private void multiLevelWildcard() {
+    void multiLevelWildcard() {
         if (stringBuilder.length() > 0) {
             stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR);
         }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -19,27 +19,34 @@ package org.mqttbee.api.mqtt.datatypes;
 
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
+import org.mqttbee.util.FluentBuilder;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class MqttTopicFilterBuilder {
+public class MqttTopicFilterBuilder<P> extends FluentBuilder<MqttTopicFilter, P> {
 
     final StringBuilder stringBuilder;
 
-    MqttTopicFilterBuilder(@NotNull final String base) {
+    public MqttTopicFilterBuilder(
+            @NotNull final String base, @Nullable final Function<? super MqttTopicFilter, P> parentConsumer) {
+
+        super(parentConsumer);
         stringBuilder = new StringBuilder(base);
     }
 
     @NotNull
-    public MqttTopicFilterBuilder subTopic(@NotNull final String subTopic) {
+    public MqttTopicFilterBuilder<P> addLevel(@NotNull final String subTopic) {
         Preconditions.checkNotNull(subTopic);
         stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(subTopic);
         return this;
     }
 
     @NotNull
-    public MqttTopicFilterBuilder singleLevelWildcard() {
+    public MqttTopicFilterBuilder<P> singleLevelWildcard() {
         if (stringBuilder.length() > 0) {
             stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR);
         }
@@ -47,18 +54,28 @@ public class MqttTopicFilterBuilder {
         return this;
     }
 
-    @NotNull
-    public MqttTopicFilter multiLevelWildcard() {
+    private void multiLevelWildcard() {
         if (stringBuilder.length() > 0) {
             stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR);
         }
         stringBuilder.append(MqttTopicFilter.MULTI_LEVEL_WILDCARD);
+    }
+
+    @NotNull
+    public MqttTopicFilter multiLevelWildcardAndBuild() {
+        multiLevelWildcard();
         return build();
     }
 
     @NotNull
-    public MqttSharedTopicFilterBuilder share(@NotNull final String shareName) {
-        return new MqttSharedTopicFilterBuilder(shareName, stringBuilder.toString());
+    public P multiLevelWildcardAndDone() {
+        multiLevelWildcard();
+        return done();
+    }
+
+    @NotNull
+    public MqttSharedTopicFilterBuilder<P> share(@NotNull final String shareName) {
+        return new MqttSharedTopicFilterBuilder<>(shareName, stringBuilder.toString(), parentConsumer);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
@@ -20,32 +20,48 @@ package org.mqttbee.api.mqtt.mqtt3;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.MqttClient;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
+import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3ConnectBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAck;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3PublishResult;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
+import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3SubscribeBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAck;
 import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
+import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3UnsubscribeBuilder;
 import org.mqttbee.rx.FlowableWithSingle;
 
 /**
  * @author Silvio Giebl
  */
-@DoNotImplement
 public interface Mqtt3Client extends MqttClient {
 
     @NotNull
     Single<Mqtt3ConnAck> connect(@NotNull Mqtt3Connect connect);
 
     @NotNull
+    default Mqtt3ConnectBuilder<Single<Mqtt3ConnAck>> connect() {
+        return new Mqtt3ConnectBuilder<>(this::connect);
+    }
+
+    @NotNull
     Single<Mqtt3SubAck> subscribe(@NotNull Mqtt3Subscribe subscribe);
 
     @NotNull
+    default Mqtt3SubscribeBuilder<Single<Mqtt3SubAck>> subscribe() {
+        return new Mqtt3SubscribeBuilder<>(this::subscribe);
+    }
+
+    @NotNull
     FlowableWithSingle<Mqtt3SubAck, Mqtt3Publish> subscribeWithStream(@NotNull Mqtt3Subscribe subscribe);
+
+    @NotNull
+    default Mqtt3SubscribeBuilder<FlowableWithSingle<Mqtt3SubAck, Mqtt3Publish>> subscribeWithStream() {
+        return new Mqtt3SubscribeBuilder<>(this::subscribeWithStream);
+    }
 
     @NotNull
     Flowable<Mqtt3Publish> remainingPublishes();
@@ -55,6 +71,11 @@ public interface Mqtt3Client extends MqttClient {
 
     @NotNull
     Completable unsubscribe(@NotNull Mqtt3Unsubscribe unsubscribe);
+
+    @NotNull
+    default Mqtt3UnsubscribeBuilder<Completable> unsubscribe() {
+        return new Mqtt3UnsubscribeBuilder<>(this::unsubscribe);
+    }
 
     @NotNull
     Flowable<Mqtt3PublishResult> publish(@NotNull Flowable<Mqtt3Publish> publishFlowable);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
@@ -35,29 +35,122 @@ import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3UnsubscribeBuilder;
 import org.mqttbee.rx.FlowableWithSingle;
 
 /**
+ * MQTT 3 client with a reactive API.
+ *
  * @author Silvio Giebl
  */
 public interface Mqtt3Client extends MqttClient {
 
+    /**
+     * Creates a {@link Single} for connecting this client with the given Connect message.
+     * <p>
+     * The returned {@link Single} represents the source of the ConnAck message corresponding to the given Connect
+     * message. Calling this method does not connect yet. Connecting is performed lazy and asynchronous when subscribing
+     * (in terms of reactive-streams) to the returned {@link Single}.
+     *
+     * @param connect the Connect message to connect with.
+     * @return the {@link Single} which
+     *         <ul>
+     *         <li>succeeds with the ConnAck message if it does not contain an Error Code (connected
+     *         successfully),</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
+     *         Mqtt3MessageException} wrapping the ConnAck message if it contains an Error Code or</li>
+     *         <li>errors with a different exception if an error occurred before the Connect message was sent or before
+     *         a ConnAck message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Single<Mqtt3ConnAck> connect(@NotNull Mqtt3Connect connect);
 
+    /**
+     * Creates a {@link Mqtt3ConnectBuilder} for connecting this client with the Connect message built from the returned
+     * builder.
+     * <p>
+     * Calling {@link Mqtt3ConnectBuilder#done()} has the same effect as calling {@link #connect(Mqtt3Connect)} with the
+     * result of {@link Mqtt3ConnectBuilder#build()}.
+     *
+     * @return the builder for the Connect message.
+     * @see #connect(Mqtt3Connect)
+     */
     @NotNull
     default Mqtt3ConnectBuilder<Single<Mqtt3ConnAck>> connect() {
         return new Mqtt3ConnectBuilder<>(this::connect);
     }
 
+    /**
+     * Creates a {@link Single} for subscribing this client with the given Subscribe message.
+     * <p>
+     * The returned {@link Single} represents the source of the SubAck message corresponding to the given Subscribe
+     * message. Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when
+     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     * <p>
+     * For directly consuming the Publish messages matching the subscriptions of the Subscribe message, call {@link
+     * #subscribeWithStream(Mqtt3Subscribe)} instead.
+     *
+     * @param subscribe the Subscribe message to subscribe with.
+     * @return the {@link Single} which
+     *         <ul>
+     *         <li>succeeds with the SubAck message if it contains at least one Reason Code that is not an Error
+     *         Code (subscribed to at least one subscription),</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
+     *         Mqtt3MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
+     *         <li>errors with a different exception if an error occurred before the Subscribe message was sent or
+     *         before a SubAck message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Single<Mqtt3SubAck> subscribe(@NotNull Mqtt3Subscribe subscribe);
 
+    /**
+     * Creates a {@link Mqtt3SubscribeBuilder} for subscribing this client with the Subscribe message built from the
+     * returned builder.
+     * <p>
+     * Calling {@link Mqtt3SubscribeBuilder#done()} has the same effect as calling {@link #subscribe(Mqtt3Subscribe)}
+     * with the result of {@link Mqtt3SubscribeBuilder#build()}.
+     *
+     * @return the builder for the Subscribe message.
+     * @see #subscribe(Mqtt3Subscribe)
+     */
     @NotNull
     default Mqtt3SubscribeBuilder<Single<Mqtt3SubAck>> subscribe() {
         return new Mqtt3SubscribeBuilder<>(this::subscribe);
     }
 
+    /**
+     * Creates a {@link FlowableWithSingle} for subscribing this client with the given Subscribe message.
+     * <p>
+     * The returned {@link FlowableWithSingle} represents the source of the SubAck message corresponding to the given
+     * Subscribe message and the source of the Publish messages matching the subscriptions of the Subscribe message.
+     * Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when subscribing (in
+     * terms of reactive-streams) to the returned {@link FlowableWithSingle}.
+     *
+     * @param subscribe the Subscribe message to subscribe with.
+     * @return the {@link FlowableWithSingle} which
+     *         <ul>
+     *         <li>emits the SubAck message as the single and first element if it contains at least one Reason Code
+     *         that is not an Error Code (subscribed to at least one subscription) and then emits the Publish messages
+     *         matching the subscriptions of the Subscribe message,</li>
+     *         <li>completes when all subscriptions of the Subscribe message were unsubscribed,</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
+     *         Mqtt3MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
+     *         <li>errors with a different exception if an error occurred before the Subscribe message was sent,
+     *         before a SubAck message was received or when a error occurs before all subscriptions or the Subscribe
+     *         messages were unsubscribed.</li>
+     *         </ul>
+     */
     @NotNull
     FlowableWithSingle<Mqtt3SubAck, Mqtt3Publish> subscribeWithStream(@NotNull Mqtt3Subscribe subscribe);
 
+    /**
+     * Creates a {@link Mqtt3SubscribeBuilder} for subscribing this client with the Subscribe message built from the
+     * returned builder.
+     * <p>
+     * Calling {@link Mqtt3SubscribeBuilder#done()} has the same effect as calling {@link
+     * #subscribeWithStream(Mqtt3Subscribe)} with the result of {@link Mqtt3SubscribeBuilder#build()}.
+     *
+     * @return the builder for the Subscribe message.
+     * @see #subscribeWithStream(Mqtt3Subscribe)
+     */
     @NotNull
     default Mqtt3SubscribeBuilder<FlowableWithSingle<Mqtt3SubAck, Mqtt3Publish>> subscribeWithStream() {
         return new Mqtt3SubscribeBuilder<>(this::subscribeWithStream);
@@ -69,17 +162,73 @@ public interface Mqtt3Client extends MqttClient {
     @NotNull
     Flowable<Mqtt3Publish> allPublishes();
 
+    /**
+     * Creates a {@link Single} for unsubscribing this client with the given Unsubscribe message.
+     * <p>
+     * The returned {@link Single} represents the source of the UnsubAck message corresponding to the given Unsubscribe
+     * message. Calling this method does not unsubscribe yet. Unsubscribing is performed lazy and asynchronous when
+     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     *
+     * @param unsubscribe the Unsubscribe message to unsubscribe with.
+     * @return the {@link Single} which
+     *         <ul>
+     *         <li>succeeds with the UnsubAck message if it contains at least one Reason Code that is not an Error
+     *         Code (subscribed to at least one subscription),</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
+     *         Mqtt3MessageException} wrapping the UnsubAck message if it only contains Error Codes or</li>
+     *         <li>errors with a different exception if an error occurred before the Unsubscribe message was sent or
+     *         before a UnsubAck message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Completable unsubscribe(@NotNull Mqtt3Unsubscribe unsubscribe);
 
+    /**
+     * Creates a {@link Mqtt3UnsubscribeBuilder} for unsubscribing this client with the Unsubscribe message built from
+     * the returned builder.
+     * <p>
+     * Calling {@link Mqtt3UnsubscribeBuilder#done()} has the same effect as calling {@link
+     * #unsubscribe(Mqtt3Unsubscribe)} with the result of {@link Mqtt3UnsubscribeBuilder#build()}.
+     *
+     * @return the builder for the Unsubscribe message.
+     * @see #unsubscribe(Mqtt3Unsubscribe)
+     */
     @NotNull
     default Mqtt3UnsubscribeBuilder<Completable> unsubscribe() {
         return new Mqtt3UnsubscribeBuilder<>(this::unsubscribe);
     }
 
+    /**
+     * Creates a {@link Flowable} for publishing the Publish messages emitted by the given {@link Flowable}.
+     * <p>
+     * The returned {@link Flowable} represents the source of {@link Mqtt3PublishResult}s each corresponding to a
+     * Publish message emitted by the given {@link Flowable}. Calling this method does not start publishing yet.
+     * Publishing is performed lazy and asynchronous. When subscribing (in terms of reactive-streams) to the returned
+     * {@link Flowable} the client subscribes (in terms of reactive-streams) to the given {@link Flowable}.
+     *
+     * @param publishFlowable the source of the Publish messages to publish.
+     * @return the {@link Flowable} which
+     *         <ul>
+     *         <li>emits {@link Mqtt3PublishResult}s each corresponding to a Publish message,</li>
+     *         <li>completes when the given {@link Flowable} completes or</li>
+     *         <li>errors with the same exception when the given {@link Flowable} errors.</li>
+     *         </ul>
+     */
     @NotNull
     Flowable<Mqtt3PublishResult> publish(@NotNull Flowable<Mqtt3Publish> publishFlowable);
 
+    /**
+     * Creates a {@link Completable} for disconnecting this client.
+     * <p>
+     * Calling this method does not disconnect yet. Disconnecting is performed lazy and asynchronous when subscribing
+     * (in terms of reactive-streams) to the returned {@link Completable}.
+     *
+     * @return the {@link Completable} which
+     *         <ul>
+     *         <li>completes when the client was successfully disconnected or</li>
+     *         <li>errors if not disconnected successfully.</li>
+     *         </ul>
+     */
     @NotNull
     Completable disconnect();
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
@@ -46,9 +46,9 @@ public interface Mqtt3Client extends MqttClient {
      * <p>
      * The returned {@link Single} represents the source of the ConnAck message corresponding to the given Connect
      * message. Calling this method does not connect yet. Connecting is performed lazy and asynchronous when subscribing
-     * (in terms of reactive-streams) to the returned {@link Single}.
+     * (in terms of Reactive Streams) to the returned {@link Single}.
      *
-     * @param connect the Connect message to connect with.
+     * @param connect the Connect message sent to the broker during connect.
      * @return the {@link Single} which
      *         <ul>
      *         <li>succeeds with the ConnAck message if it does not contain an Error Code (connected
@@ -82,16 +82,17 @@ public interface Mqtt3Client extends MqttClient {
      * <p>
      * The returned {@link Single} represents the source of the SubAck message corresponding to the given Subscribe
      * message. Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when
-     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
      * <p>
-     * For directly consuming the Publish messages matching the subscriptions of the Subscribe message, call {@link
-     * #subscribeWithStream(Mqtt3Subscribe)} instead.
+     * See {@link #allPublishes()} or {@link #remainingPublishes()} to consume the Publish messages. Alternatively, call
+     * {@link #subscribeWithStream(Mqtt3Subscribe)} to consume the Publish messages matching the subscriptions of the
+     * Subscribe message directly.
      *
-     * @param subscribe the Subscribe message to subscribe with.
+     * @param subscribe the Subscribe message sent to the broker during subscribe.
      * @return the {@link Single} which
      *         <ul>
-     *         <li>succeeds with the SubAck message if it contains at least one Reason Code that is not an Error
-     *         Code (subscribed to at least one subscription),</li>
+     *         <li>succeeds with the SubAck message if at least one subscription of the Subscribe message was
+     *         successful (the SubAck message contains at least one Reason Code that is not an Error Code),</li>
      *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
      *         Mqtt3MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
      *         <li>errors with a different exception if an error occurred before the Subscribe message was sent or
@@ -122,14 +123,15 @@ public interface Mqtt3Client extends MqttClient {
      * The returned {@link FlowableWithSingle} represents the source of the SubAck message corresponding to the given
      * Subscribe message and the source of the Publish messages matching the subscriptions of the Subscribe message.
      * Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when subscribing (in
-     * terms of reactive-streams) to the returned {@link FlowableWithSingle}.
+     * terms of Reactive Streams) to the returned {@link FlowableWithSingle}.
      *
-     * @param subscribe the Subscribe message to subscribe with.
+     * @param subscribe the Subscribe message sent to the broker during subscribe.
      * @return the {@link FlowableWithSingle} which
      *         <ul>
-     *         <li>emits the SubAck message as the single and first element if it contains at least one Reason Code
-     *         that is not an Error Code (subscribed to at least one subscription) and then emits the Publish messages
-     *         matching the subscriptions of the Subscribe message,</li>
+     *         <li>emits the SubAck message as the single and first element if at least one subscription of the
+     *         Subscribe message was successful (the SubAck message contains at least one Reason Code that is not an
+     *         Error Code) and then emits the Publish messages matching the successful subscriptions of the Subscribe
+     *         message,</li>
      *         <li>completes when all subscriptions of the Subscribe message were unsubscribed,</li>
      *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
      *         Mqtt3MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
@@ -167,13 +169,14 @@ public interface Mqtt3Client extends MqttClient {
      * <p>
      * The returned {@link Single} represents the source of the UnsubAck message corresponding to the given Unsubscribe
      * message. Calling this method does not unsubscribe yet. Unsubscribing is performed lazy and asynchronous when
-     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
      *
-     * @param unsubscribe the Unsubscribe message to unsubscribe with.
+     * @param unsubscribe the Unsubscribe message sent to the broker during unsubscribe.
      * @return the {@link Single} which
      *         <ul>
-     *         <li>succeeds with the UnsubAck message if it contains at least one Reason Code that is not an Error
-     *         Code (subscribed to at least one subscription),</li>
+     *         <li>succeeds with the UnsubAck message if at least one Topic Filter of the Unsubscribe message was
+     *         successfully unsubscribed (the UnsubAck message contains at least one Reason Code that is not an Error
+     *         Code)</li>
      *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException
      *         Mqtt3MessageException} wrapping the UnsubAck message if it only contains Error Codes or</li>
      *         <li>errors with a different exception if an error occurred before the Unsubscribe message was sent or
@@ -203,8 +206,8 @@ public interface Mqtt3Client extends MqttClient {
      * <p>
      * The returned {@link Flowable} represents the source of {@link Mqtt3PublishResult}s each corresponding to a
      * Publish message emitted by the given {@link Flowable}. Calling this method does not start publishing yet.
-     * Publishing is performed lazy and asynchronous. When subscribing (in terms of reactive-streams) to the returned
-     * {@link Flowable} the client subscribes (in terms of reactive-streams) to the given {@link Flowable}.
+     * Publishing is performed lazy and asynchronous. When subscribing (in terms of Reactive Streams) to the returned
+     * {@link Flowable} the client subscribes (in terms of Reactive Streams) to the given {@link Flowable}.
      *
      * @param publishFlowable the source of the Publish messages to publish.
      * @return the {@link Flowable} which
@@ -221,7 +224,7 @@ public interface Mqtt3Client extends MqttClient {
      * Creates a {@link Completable} for disconnecting this client.
      * <p>
      * Calling this method does not disconnect yet. Disconnecting is performed lazy and asynchronous when subscribing
-     * (in terms of reactive-streams) to the returned {@link Completable}.
+     * (in terms of Reactive Streams) to the returned {@link Completable}.
      *
      * @return the {@link Completable} which
      *         <ul>

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -151,9 +151,9 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
         return new Mqtt3ClientView(new Mqtt5ClientImpl(buildClientData()));
     }
 
+    @NotNull
     private MqttClientData buildClientData() {
-        return new MqttClientData(MqttVersion.MQTT_3_1_1, identifier, serverHost, serverPort, sslConfig,
-                websocketConfig, false, false, executorConfig, null);
+        return new MqttClientData(MqttVersion.MQTT_3_1_1, identifier, serverHost, serverPort, sslConfig, websocketConfig, false, false, executorConfig, null);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -82,8 +82,8 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt3ClientBuilder useSslDefaults() {
-        super.useSslDefaults();
+    public Mqtt3ClientBuilder useSslWithDefaultConfig() {
+        super.useSslWithDefaultConfig();
         return this;
     }
 
@@ -102,8 +102,8 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt3ClientBuilder useWebSocketDefaults() {
-        super.useWebSocketDefaults();
+    public Mqtt3ClientBuilder useWebSocketWithDefaultConfig() {
+        super.useWebSocketWithDefaultConfig();
         return this;
     }
 
@@ -153,7 +153,8 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     private MqttClientData buildClientData() {
-        return new MqttClientData(MqttVersion.MQTT_3_1_1, identifier, serverHost, serverPort, sslConfig, websocketConfig, false, false, executorConfig, null);
+        return new MqttClientData(MqttVersion.MQTT_3_1_1, identifier, serverHost, serverPort, sslConfig,
+                websocketConfig, false, false, executorConfig, null);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -20,10 +20,7 @@ package org.mqttbee.api.mqtt.mqtt3;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.MqttClientBuilder;
-import org.mqttbee.api.mqtt.MqttClientExecutorConfig;
-import org.mqttbee.api.mqtt.MqttClientSslConfig;
-import org.mqttbee.api.mqtt.MqttWebsocketConfig;
+import org.mqttbee.api.mqtt.*;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.api.mqtt.mqtt5.Mqtt5ClientBuilder;
 import org.mqttbee.mqtt.MqttClientData;
@@ -85,8 +82,8 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt3ClientBuilder useSsl() {
-        super.useSsl();
+    public Mqtt3ClientBuilder useSslDefaults() {
+        super.useSslDefaults();
         return this;
     }
 
@@ -99,8 +96,14 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt3ClientBuilder useWebSocket() {
-        super.useWebSocket();
+    public MqttClientSslConfigBuilder<? extends Mqtt3ClientBuilder> useSsl() {
+        return new MqttClientSslConfigBuilder<>(this::useSsl);
+    }
+
+    @NotNull
+    @Override
+    public Mqtt3ClientBuilder useWebSocketDefaults() {
+        super.useWebSocketDefaults();
         return this;
     }
 
@@ -113,9 +116,21 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
+    public MqttWebsocketConfigBuilder<? extends Mqtt3ClientBuilder> useWebSocket() {
+        return new MqttWebsocketConfigBuilder<>(this::useWebSocket);
+    }
+
+    @NotNull
+    @Override
     public Mqtt3ClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
         super.executorConfig(executorConfig);
         return this;
+    }
+
+    @NotNull
+    @Override
+    public MqttClientExecutorConfigBuilder<? extends Mqtt3ClientBuilder> executorConfig() {
+        return new MqttClientExecutorConfigBuilder<>(this::executorConfig);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
@@ -37,7 +37,7 @@ public class Mqtt3SimpleAuthBuilder<P> extends FluentBuilder<Mqtt3SimpleAuth, P>
     private MqttUTF8StringImpl username;
     private ByteBuffer password;
 
-    public Mqtt3SimpleAuthBuilder(@Nullable final Function<Mqtt3SimpleAuth, P> parentConsumer) {
+    public Mqtt3SimpleAuthBuilder(@Nullable final Function<? super Mqtt3SimpleAuth, P> parentConsumer) {
         super(parentConsumer);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
@@ -24,45 +24,49 @@ import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.message.auth.mqtt3.Mqtt3SimpleAuthView;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt3SimpleAuthBuilder {
+public class Mqtt3SimpleAuthBuilder<P> extends FluentBuilder<Mqtt3SimpleAuth, P> {
 
     private MqttUTF8StringImpl username;
     private ByteBuffer password;
 
-    Mqtt3SimpleAuthBuilder() {
+    public Mqtt3SimpleAuthBuilder(@Nullable final Function<Mqtt3SimpleAuth, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder username(@NotNull final String username) {
+    public Mqtt3SimpleAuthBuilder<P> username(@NotNull final String username) {
         this.username = MqttBuilderUtil.string(username);
         return this;
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder username(@NotNull final MqttUTF8String username) {
+    public Mqtt3SimpleAuthBuilder<P> username(@NotNull final MqttUTF8String username) {
         this.username = MqttBuilderUtil.string(username);
         return this;
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder password(@Nullable final byte[] password) {
+    public Mqtt3SimpleAuthBuilder<P> password(@Nullable final byte[] password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder password(@Nullable final ByteBuffer password) {
+    public Mqtt3SimpleAuthBuilder<P> password(@Nullable final ByteBuffer password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt3SimpleAuth build() {
         Preconditions.checkState(username != null);
         return Mqtt3SimpleAuthView.of(username, password);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
@@ -25,6 +25,7 @@ import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * MQTT 3 CONNECT packet.
@@ -37,13 +38,13 @@ public interface Mqtt3Connect extends Mqtt3Message {
     boolean DEFAULT_CLEAN_SESSION = true;
 
     @NotNull
-    static Mqtt3ConnectBuilder builder() {
-        return new Mqtt3ConnectBuilder();
+    static Mqtt3ConnectBuilder<Void> builder() {
+        return new Mqtt3ConnectBuilder<>((Function<Mqtt3Connect, Void>) null);
     }
 
     @NotNull
-    static Mqtt3ConnectBuilder extend(@NotNull final Mqtt3Connect connect) {
-        return new Mqtt3ConnectBuilder(connect);
+    static Mqtt3ConnectBuilder<Void> extend(@NotNull final Mqtt3Connect connect) {
+        return new Mqtt3ConnectBuilder<>(connect);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuthBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3PublishBuilder;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 import org.mqttbee.mqtt.message.auth.mqtt3.Mqtt3SimpleAuthView;
 import org.mqttbee.mqtt.message.connect.mqtt3.Mqtt3ConnectView;
@@ -77,7 +78,7 @@ public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
     }
 
     @NotNull
-    public Mqtt3SimpleAuthBuilder<Mqtt3ConnectBuilder<P>> simpleAuth() {
+    public Mqtt3SimpleAuthBuilder<? extends Mqtt3ConnectBuilder<P>> simpleAuth() {
         return new Mqtt3SimpleAuthBuilder<>(this::simpleAuth);
     }
 
@@ -87,6 +88,11 @@ public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
                 MustNotBeImplementedUtil.checkNullOrNotImplemented(willPublish, Mqtt3PublishView.class);
         this.willPublish = (publishView == null) ? null : publishView.getWillDelegate();
         return this;
+    }
+
+    @NotNull
+    public Mqtt3PublishBuilder<? extends Mqtt3ConnectBuilder<P>> willPublish() {
+        return new Mqtt3PublishBuilder<>(this::willPublish);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -20,28 +20,34 @@ package org.mqttbee.api.mqtt.mqtt3.message.connect;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
+import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuthBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 import org.mqttbee.mqtt.message.auth.mqtt3.Mqtt3SimpleAuthView;
 import org.mqttbee.mqtt.message.connect.mqtt3.Mqtt3ConnectView;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 import org.mqttbee.mqtt.message.publish.mqtt3.Mqtt3PublishView;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt3ConnectBuilder {
+public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
 
     private int keepAlive = Mqtt3Connect.DEFAULT_KEEP_ALIVE;
     private boolean isCleanSession = Mqtt3Connect.DEFAULT_CLEAN_SESSION;
     private MqttSimpleAuth simpleAuth;
     private MqttWillPublish willPublish;
 
-    Mqtt3ConnectBuilder() {
+    public Mqtt3ConnectBuilder(@Nullable final Function<Mqtt3Connect, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     Mqtt3ConnectBuilder(@NotNull final Mqtt3Connect connect) {
+        super(null);
         final Mqtt3ConnectView connectView =
                 MustNotBeImplementedUtil.checkNotImplemented(connect, Mqtt3ConnectView.class);
         keepAlive = connectView.getKeepAlive();
@@ -51,19 +57,19 @@ public class Mqtt3ConnectBuilder {
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder keepAlive(final int keepAlive) {
+    public Mqtt3ConnectBuilder<P> keepAlive(final int keepAlive) {
         this.keepAlive = keepAlive;
         return this;
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder cleanSession(final boolean isCleanSession) {
+    public Mqtt3ConnectBuilder<P> cleanSession(final boolean isCleanSession) {
         this.isCleanSession = isCleanSession;
         return this;
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder simpleAuth(@Nullable final Mqtt3SimpleAuth simpleAuth) {
+    public Mqtt3ConnectBuilder<P> simpleAuth(@Nullable final Mqtt3SimpleAuth simpleAuth) {
         final Mqtt3SimpleAuthView simpleAuthView =
                 MustNotBeImplementedUtil.checkNullOrNotImplemented(simpleAuth, Mqtt3SimpleAuthView.class);
         this.simpleAuth = (simpleAuthView == null) ? null : simpleAuthView.getDelegate();
@@ -71,7 +77,12 @@ public class Mqtt3ConnectBuilder {
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder willPublish(@Nullable final Mqtt3Publish willPublish) {
+    public Mqtt3SimpleAuthBuilder<Mqtt3ConnectBuilder<P>> simpleAuth() {
+        return new Mqtt3SimpleAuthBuilder<>(this::simpleAuth);
+    }
+
+    @NotNull
+    public Mqtt3ConnectBuilder<P> willPublish(@Nullable final Mqtt3Publish willPublish) {
         final Mqtt3PublishView publishView =
                 MustNotBeImplementedUtil.checkNullOrNotImplemented(willPublish, Mqtt3PublishView.class);
         this.willPublish = (publishView == null) ? null : publishView.getWillDelegate();
@@ -79,6 +90,7 @@ public class Mqtt3ConnectBuilder {
     }
 
     @NotNull
+    @Override
     public Mqtt3Connect build() {
         return Mqtt3ConnectView.of(keepAlive, isCleanSession, simpleAuth, willPublish);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -43,7 +43,7 @@ public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
     private MqttSimpleAuth simpleAuth;
     private MqttWillPublish willPublish;
 
-    public Mqtt3ConnectBuilder(@Nullable final Function<Mqtt3Connect, P> parentConsumer) {
+    public Mqtt3ConnectBuilder(@Nullable final Function<? super Mqtt3Connect, P> parentConsumer) {
         super(parentConsumer);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
@@ -27,6 +27,7 @@ import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3SubscribeResult;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * MQTT 3 PUBLISH packet.
@@ -35,13 +36,13 @@ import java.util.Optional;
 public interface Mqtt3Publish extends Mqtt3Message, Mqtt3SubscribeResult {
 
     @NotNull
-    static Mqtt3PublishBuilder builder() {
-        return new Mqtt3PublishBuilder();
+    static Mqtt3PublishBuilder<Void> builder() {
+        return new Mqtt3PublishBuilder<>((Function<Mqtt3Publish, Void>) null);
     }
 
     @NotNull
-    static Mqtt3PublishBuilder extend(@NotNull final Mqtt3Publish publish) {
-        return new Mqtt3PublishBuilder(publish);
+    static Mqtt3PublishBuilder<Void> extend(@NotNull final Mqtt3Publish publish) {
+        return new Mqtt3PublishBuilder<>(publish);
     }
 
     /**
@@ -78,6 +79,5 @@ public interface Mqtt3Publish extends Mqtt3Message, Mqtt3SubscribeResult {
     default Mqtt3MessageType getType() {
         return Mqtt3MessageType.PUBLISH;
     }
-
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
 import org.mqttbee.mqtt.message.publish.mqtt3.Mqtt3PublishView;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
@@ -42,7 +43,7 @@ public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
     private MqttQoS qos;
     private boolean retain;
 
-    public Mqtt3PublishBuilder(@Nullable final Function<Mqtt3Publish, P> parentConsumer) {
+    public Mqtt3PublishBuilder(@Nullable final Function<? super Mqtt3Publish, P> parentConsumer) {
         super(parentConsumer);
     }
 
@@ -66,6 +67,11 @@ public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
     public Mqtt3PublishBuilder<P> topic(@NotNull final MqttTopic topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
+    }
+
+    @NotNull
+    public MqttTopicBuilder<? extends Mqtt3PublishBuilder<P>> topic() {
+        return new MqttTopicBuilder<>("", this::topic);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -26,24 +26,28 @@ import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
 import org.mqttbee.mqtt.message.publish.mqtt3.Mqtt3PublishView;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt3PublishBuilder {
+public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
 
     private MqttTopicImpl topic;
     private ByteBuffer payload;
     private MqttQoS qos;
     private boolean retain;
 
-    Mqtt3PublishBuilder() {
+    public Mqtt3PublishBuilder(@Nullable final Function<Mqtt3Publish, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     Mqtt3PublishBuilder(@NotNull final Mqtt3Publish publish) {
+        super(null);
         final Mqtt3PublishView publishView =
                 MustNotBeImplementedUtil.checkNotImplemented(publish, Mqtt3PublishView.class);
         topic = publishView.getDelegate().getTopic();
@@ -53,42 +57,43 @@ public class Mqtt3PublishBuilder {
     }
 
     @NotNull
-    public Mqtt3PublishBuilder topic(@NotNull final String topic) {
+    public Mqtt3PublishBuilder<P> topic(@NotNull final String topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder topic(@NotNull final MqttTopic topic) {
+    public Mqtt3PublishBuilder<P> topic(@NotNull final MqttTopic topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder payload(@Nullable final byte[] payload) {
+    public Mqtt3PublishBuilder<P> payload(@Nullable final byte[] payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.wrap(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder payload(@Nullable final ByteBuffer payload) {
+    public Mqtt3PublishBuilder<P> payload(@Nullable final ByteBuffer payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.slice(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder qos(@NotNull final MqttQoS qos) {
+    public Mqtt3PublishBuilder<P> qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
-    public Mqtt3PublishBuilder retain(final boolean retain) {
+    public Mqtt3PublishBuilder<P> retain(final boolean retain) {
         this.retain = retain;
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt3Publish build() {
         Preconditions.checkNotNull(topic);
         Preconditions.checkNotNull(qos);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
@@ -23,6 +23,8 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 
+import java.util.function.Function;
+
 /**
  * MQTT 3 SUBSCRIBE packet.
  */
@@ -30,8 +32,13 @@ import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 public interface Mqtt3Subscribe extends Mqtt3Message {
 
     @NotNull
-    static Mqtt3SubscribeBuilder builder() {
-        return new Mqtt3SubscribeBuilder();
+    static Mqtt3SubscribeBuilder<Void> builder() {
+        return new Mqtt3SubscribeBuilder<>((Function<Mqtt3Subscribe, Void>) null);
+    }
+
+    @NotNull
+    static Mqtt3SubscribeBuilder<Void> extend(@NotNull final Mqtt3Subscribe subscribe) {
+        return new Mqtt3SubscribeBuilder<>(subscribe);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
@@ -59,7 +59,7 @@ public class Mqtt3SubscribeBuilder<P> extends FluentBuilder<Mqtt3Subscribe, P> {
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder<Mqtt3SubscribeBuilder<P>> addSubscription() {
+    public Mqtt3SubscriptionBuilder<? extends Mqtt3SubscribeBuilder<P>> addSubscription() {
         return new Mqtt3SubscriptionBuilder<>(this::addSubscription);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscribeBuilder.java
@@ -36,7 +36,7 @@ public class Mqtt3SubscribeBuilder<P> extends FluentBuilder<Mqtt3Subscribe, P> {
 
     private final ImmutableList.Builder<MqttSubscription> subscriptionBuilder;
 
-    public Mqtt3SubscribeBuilder(@Nullable final Function<Mqtt3Subscribe, P> parentConsumer) {
+    public Mqtt3SubscribeBuilder(@Nullable final Function<? super Mqtt3Subscribe, P> parentConsumer) {
         super(parentConsumer);
         subscriptionBuilder = ImmutableList.builder();
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscription.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscription.java
@@ -31,8 +31,8 @@ import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 public interface Mqtt3Subscription {
 
     @NotNull
-    static Mqtt3SubscriptionBuilder builder() {
-        return new Mqtt3SubscriptionBuilder();
+    static Mqtt3SubscriptionBuilder<Void> builder() {
+        return new Mqtt3SubscriptionBuilder<>(null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -19,42 +19,48 @@ package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.message.subscribe.mqtt3.Mqtt3SubscriptionView;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt3SubscriptionBuilder {
+public class Mqtt3SubscriptionBuilder<P> extends FluentBuilder<Mqtt3Subscription, P> {
 
     private MqttTopicFilterImpl topicFilter;
     private MqttQoS qos;
 
-    Mqtt3SubscriptionBuilder() {
+    public Mqtt3SubscriptionBuilder(@Nullable final Function<Mqtt3Subscription, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder topicFilter(@NotNull final String topicFilter) {
+    public Mqtt3SubscriptionBuilder<P> topicFilter(@NotNull final String topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder topicFilter(@NotNull final MqttTopicFilter topicFilter) {
+    public Mqtt3SubscriptionBuilder<P> topicFilter(@NotNull final MqttTopicFilter topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder qos(@NotNull final MqttQoS qos) {
+    public Mqtt3SubscriptionBuilder<P> qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt3Subscription build() {
         Preconditions.checkNotNull(topicFilter);
         Preconditions.checkNotNull(qos);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.message.subscribe.mqtt3.Mqtt3SubscriptionView;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
@@ -37,7 +38,7 @@ public class Mqtt3SubscriptionBuilder<P> extends FluentBuilder<Mqtt3Subscription
     private MqttTopicFilterImpl topicFilter;
     private MqttQoS qos;
 
-    public Mqtt3SubscriptionBuilder(@Nullable final Function<Mqtt3Subscription, P> parentConsumer) {
+    public Mqtt3SubscriptionBuilder(@Nullable final Function<? super Mqtt3Subscription, P> parentConsumer) {
         super(parentConsumer);
     }
 
@@ -51,6 +52,11 @@ public class Mqtt3SubscriptionBuilder<P> extends FluentBuilder<Mqtt3Subscription
     public Mqtt3SubscriptionBuilder<P> topicFilter(@NotNull final MqttTopicFilter topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
+    }
+
+    @NotNull
+    public MqttTopicFilterBuilder<? extends Mqtt3SubscriptionBuilder<P>> topicFilter() {
+        return new MqttTopicFilterBuilder<>("", this::topicFilter);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
@@ -24,6 +24,8 @@ import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 
+import java.util.function.Function;
+
 /**
  * MQTT 3 UNSUBSCRIBE packet.
  */
@@ -31,8 +33,13 @@ import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 public interface Mqtt3Unsubscribe extends Mqtt3Message {
 
     @NotNull
-    static Mqtt3UnsubscribeBuilder builder() {
-        return new Mqtt3UnsubscribeBuilder();
+    static Mqtt3UnsubscribeBuilder<Void> builder() {
+        return new Mqtt3UnsubscribeBuilder<>((Function<Mqtt3Unsubscribe, Void>) null);
+    }
+
+    @NotNull
+    static Mqtt3UnsubscribeBuilder<Void> extend(@NotNull final Mqtt3Unsubscribe unsubscribe) {
+        return new Mqtt3UnsubscribeBuilder<>(unsubscribe);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -20,37 +20,53 @@ package org.mqttbee.api.mqtt.mqtt3.message.unsubscribe;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.message.unsubscribe.mqtt3.Mqtt3UnsubscribeView;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
+import org.mqttbee.util.MustNotBeImplementedUtil;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt3UnsubscribeBuilder {
+public class Mqtt3UnsubscribeBuilder<P> extends FluentBuilder<Mqtt3Unsubscribe, P> {
 
-    private final ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder = ImmutableList.builder();
+    private final ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder;
 
-    Mqtt3UnsubscribeBuilder() {
+    public Mqtt3UnsubscribeBuilder(@Nullable final Function<Mqtt3Unsubscribe, P> parentConsumer) {
+        super(parentConsumer);
+        topicFiltersBuilder = ImmutableList.builder();
+    }
+
+    Mqtt3UnsubscribeBuilder(@NotNull final Mqtt3Unsubscribe unsubscribe) {
+        super(null);
+        final Mqtt3UnsubscribeView unsubscribeView =
+                MustNotBeImplementedUtil.checkNotImplemented(unsubscribe, Mqtt3UnsubscribeView.class);
+        final ImmutableList<MqttTopicFilterImpl> topicFilters = unsubscribeView.getDelegate().getTopicFilters();
+        topicFiltersBuilder = ImmutableList.builderWithExpectedSize(topicFilters.size() + 1);
+        topicFiltersBuilder.addAll(topicFilters);
     }
 
     @NotNull
-    public Mqtt3UnsubscribeBuilder addTopicFilter(@NotNull final String topicFilter) {
+    public Mqtt3UnsubscribeBuilder<P> addTopicFilter(@NotNull final String topicFilter) {
         topicFiltersBuilder.add(MqttBuilderUtil.topicFilter(topicFilter));
         return this;
     }
 
     @NotNull
-    public Mqtt3UnsubscribeBuilder addTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
+    public Mqtt3UnsubscribeBuilder<P> addTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
         topicFiltersBuilder.add(MqttBuilderUtil.topicFilter(topicFilter));
         return this;
     }
 
     @NotNull
-    public Mqtt3UnsubscribeBuilder reverse(@NotNull final Mqtt3Subscribe subscribe) {
+    public Mqtt3UnsubscribeBuilder<P> reverse(@NotNull final Mqtt3Subscribe subscribe) {
         final ImmutableList<? extends Mqtt3Subscription> subscriptions = subscribe.getSubscriptions();
         for (final Mqtt3Subscription subscription : subscriptions) {
             addTopicFilter(subscription.getTopicFilter());
@@ -59,6 +75,7 @@ public class Mqtt3UnsubscribeBuilder {
     }
 
     @NotNull
+    @Override
     public Mqtt3Unsubscribe build() {
         final ImmutableList<MqttTopicFilterImpl> topicFilters = topicFiltersBuilder.build();
         Preconditions.checkState(!topicFilters.isEmpty());

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -39,7 +40,7 @@ public class Mqtt3UnsubscribeBuilder<P> extends FluentBuilder<Mqtt3Unsubscribe, 
 
     private final ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder;
 
-    public Mqtt3UnsubscribeBuilder(@Nullable final Function<Mqtt3Unsubscribe, P> parentConsumer) {
+    public Mqtt3UnsubscribeBuilder(@Nullable final Function<? super Mqtt3Unsubscribe, P> parentConsumer) {
         super(parentConsumer);
         topicFiltersBuilder = ImmutableList.builder();
     }
@@ -63,6 +64,11 @@ public class Mqtt3UnsubscribeBuilder<P> extends FluentBuilder<Mqtt3Unsubscribe, 
     public Mqtt3UnsubscribeBuilder<P> addTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
         topicFiltersBuilder.add(MqttBuilderUtil.topicFilter(topicFilter));
         return this;
+    }
+
+    @NotNull
+    public MqttTopicFilterBuilder<? extends Mqtt3UnsubscribeBuilder<P>> addTopicFilter() {
+        return new MqttTopicFilterBuilder<>("", this::addTopicFilter);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
@@ -49,9 +49,9 @@ public interface Mqtt5Client extends MqttClient {
      * <p>
      * The returned {@link Single} represents the source of the ConnAck message corresponding to the given Connect
      * message. Calling this method does not connect yet. Connecting is performed lazy and asynchronous when subscribing
-     * (in terms of reactive-streams) to the returned {@link Single}.
+     * (in terms of Reactive Streams) to the returned {@link Single}.
      *
-     * @param connect the Connect message to connect with.
+     * @param connect the Connect message sent to the broker during connect.
      * @return the {@link Single} which
      *         <ul>
      *         <li>succeeds with the ConnAck message if it does not contain an Error Code (connected
@@ -85,16 +85,17 @@ public interface Mqtt5Client extends MqttClient {
      * <p>
      * The returned {@link Single} represents the source of the SubAck message corresponding to the given Subscribe
      * message. Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when
-     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
      * <p>
-     * For directly consuming the Publish messages matching the subscriptions of the Subscribe message, call {@link
-     * #subscribeWithStream(Mqtt5Subscribe)} instead.
+     * See {@link #allPublishes()} or {@link #remainingPublishes()} to consume the Publish messages. Alternatively, call
+     * {@link #subscribeWithStream(Mqtt5Subscribe)} to consume the Publish messages matching the subscriptions of the
+     * Subscribe message directly.
      *
-     * @param subscribe the Subscribe message to subscribe with.
+     * @param subscribe the Subscribe message sent to the broker during subscribe.
      * @return the {@link Single} which
      *         <ul>
-     *         <li>succeeds with the SubAck message if it contains at least one Reason Code that is not an Error
-     *         Code (subscribed to at least one subscription),</li>
+     *         <li>succeeds with the SubAck message if at least one subscription of the Subscribe message was
+     *         successful (the SubAck message contains at least one Reason Code that is not an Error Code),</li>
      *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
      *         Mqtt5MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
      *         <li>errors with a different exception if an error occurred before the Subscribe message was sent or
@@ -125,14 +126,15 @@ public interface Mqtt5Client extends MqttClient {
      * The returned {@link FlowableWithSingle} represents the source of the SubAck message corresponding to the given
      * Subscribe message and the source of the Publish messages matching the subscriptions of the Subscribe message.
      * Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when subscribing (in
-     * terms of reactive-streams) to the returned {@link FlowableWithSingle}.
+     * terms of Reactive Streams) to the returned {@link FlowableWithSingle}.
      *
-     * @param subscribe the Subscribe message to subscribe with.
+     * @param subscribe the Subscribe message sent to the broker during subscribe.
      * @return the {@link FlowableWithSingle} which
      *         <ul>
-     *         <li>emits the SubAck message as the single and first element if it contains at least one Reason Code
-     *         that is not an Error Code (subscribed to at least one subscription) and then emits the Publish messages
-     *         matching the subscriptions of the Subscribe message,</li>
+     *         <li>emits the SubAck message as the single and first element if at least one subscription of the
+     *         Subscribe message was successful (the SubAck message contains at least one Reason Code that is not an
+     *         Error Code) and then emits the Publish messages matching the successful subscriptions of the Subscribe
+     *         message,</li>
      *         <li>completes when all subscriptions of the Subscribe message were unsubscribed,</li>
      *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
      *         Mqtt5MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
@@ -170,13 +172,14 @@ public interface Mqtt5Client extends MqttClient {
      * <p>
      * The returned {@link Single} represents the source of the UnsubAck message corresponding to the given Unsubscribe
      * message. Calling this method does not unsubscribe yet. Unsubscribing is performed lazy and asynchronous when
-     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
      *
-     * @param unsubscribe the Unsubscribe message to unsubscribe with.
+     * @param unsubscribe the Unsubscribe message sent to the broker during unsubscribe.
      * @return the {@link Single} which
      *         <ul>
-     *         <li>succeeds with the UnsubAck message if it contains at least one Reason Code that is not an Error
-     *         Code (subscribed to at least one subscription),</li>
+     *         <li>succeeds with the UnsubAck message if at least one Topic Filter of the Unsubscribe message was
+     *         successfully unsubscribed (the UnsubAck message contains at least one Reason Code that is not an Error
+     *         Code)</li>
      *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
      *         Mqtt5MessageException} wrapping the UnsubAck message if it only contains Error Codes or</li>
      *         <li>errors with a different exception if an error occurred before the Unsubscribe message was sent or
@@ -206,8 +209,8 @@ public interface Mqtt5Client extends MqttClient {
      * <p>
      * The returned {@link Flowable} represents the source of {@link Mqtt5PublishResult}s each corresponding to a
      * Publish message emitted by the given {@link Flowable}. Calling this method does not start publishing yet.
-     * Publishing is performed lazy and asynchronous. When subscribing (in terms of reactive-streams) to the returned
-     * {@link Flowable} the client subscribes (in terms of reactive-streams) to the given {@link Flowable}.
+     * Publishing is performed lazy and asynchronous. When subscribing (in terms of Reactive Streams) to the returned
+     * {@link Flowable} the client subscribes (in terms of Reactive Streams) to the given {@link Flowable}.
      *
      * @param publishFlowable the source of the Publish messages to publish.
      * @return the {@link Flowable} which
@@ -224,7 +227,7 @@ public interface Mqtt5Client extends MqttClient {
      * Creates a {@link Completable} for re-authenticating this client with the given Disconnect message.
      * <p>
      * Calling this method does not re-authenticate yet. Re-authenticating is performed lazy and asynchronous when
-     * subscribing (in terms of reactive-streams) to the returned {@link Completable}.
+     * subscribing (in terms of Reactive Streams) to the returned {@link Completable}.
      *
      * @return the {@link Completable} which
      *         <ul>
@@ -243,9 +246,9 @@ public interface Mqtt5Client extends MqttClient {
      * Creates a {@link Completable} for disconnecting this client with the given Disconnect message.
      * <p>
      * Calling this method does not disconnect yet. Disconnecting is performed lazy and asynchronous when subscribing
-     * (in terms of reactive-streams) to the returned {@link Completable}.
+     * (in terms of Reactive Streams) to the returned {@link Completable}.
      *
-     * @param disconnect the Disconnect message to unsubscribe with.
+     * @param disconnect the Disconnect message sent to the broker during disconnect.
      * @return the {@link Completable} which
      *         <ul>
      *         <li>completes when the client was successfully disconnected or</li>

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
@@ -20,34 +20,51 @@ package org.mqttbee.api.mqtt.mqtt5;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.MqttClient;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect;
+import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5ConnectBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
+import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
+import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5SubscribeBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe;
+import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.Mqtt5UnsubscribeBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import org.mqttbee.rx.FlowableWithSingle;
 
 /**
  * @author Silvio Giebl
  */
-@DoNotImplement
 public interface Mqtt5Client extends MqttClient {
 
     @NotNull
     Single<Mqtt5ConnAck> connect(@NotNull Mqtt5Connect connect);
 
     @NotNull
+    default Mqtt5ConnectBuilder<Single<Mqtt5ConnAck>> connect() {
+        return new Mqtt5ConnectBuilder<>(this::connect);
+    }
+
+    @NotNull
     Single<Mqtt5SubAck> subscribe(@NotNull Mqtt5Subscribe subscribe);
 
     @NotNull
+    default Mqtt5SubscribeBuilder<Single<Mqtt5SubAck>> subscribe() {
+        return new Mqtt5SubscribeBuilder<>(this::subscribe);
+    }
+
+    @NotNull
     FlowableWithSingle<Mqtt5SubAck, Mqtt5Publish> subscribeWithStream(@NotNull Mqtt5Subscribe subscribe);
+
+    @NotNull
+    default Mqtt5SubscribeBuilder<FlowableWithSingle<Mqtt5SubAck, Mqtt5Publish>> subscribeWithStream() {
+        return new Mqtt5SubscribeBuilder<>(this::subscribeWithStream);
+    }
 
     @NotNull
     Flowable<Mqtt5Publish> remainingPublishes();
@@ -59,6 +76,11 @@ public interface Mqtt5Client extends MqttClient {
     Single<Mqtt5UnsubAck> unsubscribe(@NotNull Mqtt5Unsubscribe unsubscribe);
 
     @NotNull
+    default Mqtt5UnsubscribeBuilder<Single<Mqtt5UnsubAck>> unsubscribe() {
+        return new Mqtt5UnsubscribeBuilder<>(this::unsubscribe);
+    }
+
+    @NotNull
     Flowable<Mqtt5PublishResult> publish(@NotNull Flowable<Mqtt5Publish> publishFlowable);
 
     @NotNull
@@ -66,6 +88,11 @@ public interface Mqtt5Client extends MqttClient {
 
     @NotNull
     Completable disconnect(@NotNull Mqtt5Disconnect disconnect);
+
+    @NotNull
+    default Mqtt5DisconnectBuilder<Completable> disconnect() {
+        return new Mqtt5DisconnectBuilder<>(this::disconnect);
+    }
 
     @NotNull
     @Override

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
@@ -38,29 +38,122 @@ import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import org.mqttbee.rx.FlowableWithSingle;
 
 /**
+ * MQTT 5 client with a reactive API.
+ *
  * @author Silvio Giebl
  */
 public interface Mqtt5Client extends MqttClient {
 
+    /**
+     * Creates a {@link Single} for connecting this client with the given Connect message.
+     * <p>
+     * The returned {@link Single} represents the source of the ConnAck message corresponding to the given Connect
+     * message. Calling this method does not connect yet. Connecting is performed lazy and asynchronous when subscribing
+     * (in terms of reactive-streams) to the returned {@link Single}.
+     *
+     * @param connect the Connect message to connect with.
+     * @return the {@link Single} which
+     *         <ul>
+     *         <li>succeeds with the ConnAck message if it does not contain an Error Code (connected
+     *         successfully),</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
+     *         Mqtt5MessageException} wrapping the ConnAck message if it contains an Error Code or</li>
+     *         <li>errors with a different exception if an error occurred before the Connect message was sent or before
+     *         a ConnAck message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Single<Mqtt5ConnAck> connect(@NotNull Mqtt5Connect connect);
 
+    /**
+     * Creates a {@link Mqtt5ConnectBuilder} for connecting this client with the Connect message built from the returned
+     * builder.
+     * <p>
+     * Calling {@link Mqtt5ConnectBuilder#done()} has the same effect as calling {@link #connect(Mqtt5Connect)} with the
+     * result of {@link Mqtt5ConnectBuilder#build()}.
+     *
+     * @return the builder for the Connect message.
+     * @see #connect(Mqtt5Connect)
+     */
     @NotNull
     default Mqtt5ConnectBuilder<Single<Mqtt5ConnAck>> connect() {
         return new Mqtt5ConnectBuilder<>(this::connect);
     }
 
+    /**
+     * Creates a {@link Single} for subscribing this client with the given Subscribe message.
+     * <p>
+     * The returned {@link Single} represents the source of the SubAck message corresponding to the given Subscribe
+     * message. Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when
+     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     * <p>
+     * For directly consuming the Publish messages matching the subscriptions of the Subscribe message, call {@link
+     * #subscribeWithStream(Mqtt5Subscribe)} instead.
+     *
+     * @param subscribe the Subscribe message to subscribe with.
+     * @return the {@link Single} which
+     *         <ul>
+     *         <li>succeeds with the SubAck message if it contains at least one Reason Code that is not an Error
+     *         Code (subscribed to at least one subscription),</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
+     *         Mqtt5MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
+     *         <li>errors with a different exception if an error occurred before the Subscribe message was sent or
+     *         before a SubAck message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Single<Mqtt5SubAck> subscribe(@NotNull Mqtt5Subscribe subscribe);
 
+    /**
+     * Creates a {@link Mqtt5SubscribeBuilder} for subscribing this client with the Subscribe message built from the
+     * returned builder.
+     * <p>
+     * Calling {@link Mqtt5SubscribeBuilder#done()} has the same effect as calling {@link #subscribe(Mqtt5Subscribe)}
+     * with the result of {@link Mqtt5SubscribeBuilder#build()}.
+     *
+     * @return the builder for the Subscribe message.
+     * @see #subscribe(Mqtt5Subscribe)
+     */
     @NotNull
     default Mqtt5SubscribeBuilder<Single<Mqtt5SubAck>> subscribe() {
         return new Mqtt5SubscribeBuilder<>(this::subscribe);
     }
 
+    /**
+     * Creates a {@link FlowableWithSingle} for subscribing this client with the given Subscribe message.
+     * <p>
+     * The returned {@link FlowableWithSingle} represents the source of the SubAck message corresponding to the given
+     * Subscribe message and the source of the Publish messages matching the subscriptions of the Subscribe message.
+     * Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when subscribing (in
+     * terms of reactive-streams) to the returned {@link FlowableWithSingle}.
+     *
+     * @param subscribe the Subscribe message to subscribe with.
+     * @return the {@link FlowableWithSingle} which
+     *         <ul>
+     *         <li>emits the SubAck message as the single and first element if it contains at least one Reason Code
+     *         that is not an Error Code (subscribed to at least one subscription) and then emits the Publish messages
+     *         matching the subscriptions of the Subscribe message,</li>
+     *         <li>completes when all subscriptions of the Subscribe message were unsubscribed,</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
+     *         Mqtt5MessageException} wrapping the SubAck message if it only contains Error Codes or</li>
+     *         <li>errors with a different exception if an error occurred before the Subscribe message was sent,
+     *         before a SubAck message was received or when a error occurs before all subscriptions or the Subscribe
+     *         messages were unsubscribed.</li>
+     *         </ul>
+     */
     @NotNull
     FlowableWithSingle<Mqtt5SubAck, Mqtt5Publish> subscribeWithStream(@NotNull Mqtt5Subscribe subscribe);
 
+    /**
+     * Creates a {@link Mqtt5SubscribeBuilder} for subscribing this client with the Subscribe message built from the
+     * returned builder.
+     * <p>
+     * Calling {@link Mqtt5SubscribeBuilder#done()} has the same effect as calling {@link
+     * #subscribeWithStream(Mqtt5Subscribe)} with the result of {@link Mqtt5SubscribeBuilder#build()}.
+     *
+     * @return the builder for the Subscribe message.
+     * @see #subscribeWithStream(Mqtt5Subscribe)
+     */
     @NotNull
     default Mqtt5SubscribeBuilder<FlowableWithSingle<Mqtt5SubAck, Mqtt5Publish>> subscribeWithStream() {
         return new Mqtt5SubscribeBuilder<>(this::subscribeWithStream);
@@ -72,23 +165,106 @@ public interface Mqtt5Client extends MqttClient {
     @NotNull
     Flowable<Mqtt5Publish> allPublishes();
 
+    /**
+     * Creates a {@link Single} for unsubscribing this client with the given Unsubscribe message.
+     * <p>
+     * The returned {@link Single} represents the source of the UnsubAck message corresponding to the given Unsubscribe
+     * message. Calling this method does not unsubscribe yet. Unsubscribing is performed lazy and asynchronous when
+     * subscribing (in terms of reactive-streams) to the returned {@link Single}.
+     *
+     * @param unsubscribe the Unsubscribe message to unsubscribe with.
+     * @return the {@link Single} which
+     *         <ul>
+     *         <li>succeeds with the UnsubAck message if it contains at least one Reason Code that is not an Error
+     *         Code (subscribed to at least one subscription),</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
+     *         Mqtt5MessageException} wrapping the UnsubAck message if it only contains Error Codes or</li>
+     *         <li>errors with a different exception if an error occurred before the Unsubscribe message was sent or
+     *         before a UnsubAck message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Single<Mqtt5UnsubAck> unsubscribe(@NotNull Mqtt5Unsubscribe unsubscribe);
 
+    /**
+     * Creates a {@link Mqtt5UnsubscribeBuilder} for unsubscribing this client with the Unsubscribe message built from
+     * the returned builder.
+     * <p>
+     * Calling {@link Mqtt5UnsubscribeBuilder#done()} has the same effect as calling {@link
+     * #unsubscribe(Mqtt5Unsubscribe)} with the result of {@link Mqtt5UnsubscribeBuilder#build()}.
+     *
+     * @return the builder for the Unsubscribe message.
+     * @see #unsubscribe(Mqtt5Unsubscribe)
+     */
     @NotNull
     default Mqtt5UnsubscribeBuilder<Single<Mqtt5UnsubAck>> unsubscribe() {
         return new Mqtt5UnsubscribeBuilder<>(this::unsubscribe);
     }
 
+    /**
+     * Creates a {@link Flowable} for publishing the Publish messages emitted by the given {@link Flowable}.
+     * <p>
+     * The returned {@link Flowable} represents the source of {@link Mqtt5PublishResult}s each corresponding to a
+     * Publish message emitted by the given {@link Flowable}. Calling this method does not start publishing yet.
+     * Publishing is performed lazy and asynchronous. When subscribing (in terms of reactive-streams) to the returned
+     * {@link Flowable} the client subscribes (in terms of reactive-streams) to the given {@link Flowable}.
+     *
+     * @param publishFlowable the source of the Publish messages to publish.
+     * @return the {@link Flowable} which
+     *         <ul>
+     *         <li>emits {@link Mqtt5PublishResult}s each corresponding to a Publish message,</li>
+     *         <li>completes when the given {@link Flowable} completes or</li>
+     *         <li>errors with the same exception when the given {@link Flowable} errors.</li>
+     *         </ul>
+     */
     @NotNull
     Flowable<Mqtt5PublishResult> publish(@NotNull Flowable<Mqtt5Publish> publishFlowable);
 
+    /**
+     * Creates a {@link Completable} for re-authenticating this client with the given Disconnect message.
+     * <p>
+     * Calling this method does not re-authenticate yet. Re-authenticating is performed lazy and asynchronous when
+     * subscribing (in terms of reactive-streams) to the returned {@link Completable}.
+     *
+     * @return the {@link Completable} which
+     *         <ul>
+     *         <li>completes when the client was successfully re-authenticated,</li>
+     *         <li>errors with an {@link org.mqttbee.api.mqtt.mqtt5.exceptions.Mqtt5MessageException
+     *         Mqtt5MessageException} wrapping the Auth message with the Error Code if not re-authenticated successfully
+     *         or</li>
+     *         <li>errors with a different exception if an error occurred before the first Auth message was sent or
+     *         before the last Auth message was received.</li>
+     *         </ul>
+     */
     @NotNull
     Completable reauth();
 
+    /**
+     * Creates a {@link Completable} for disconnecting this client with the given Disconnect message.
+     * <p>
+     * Calling this method does not disconnect yet. Disconnecting is performed lazy and asynchronous when subscribing
+     * (in terms of reactive-streams) to the returned {@link Completable}.
+     *
+     * @param disconnect the Disconnect message to unsubscribe with.
+     * @return the {@link Completable} which
+     *         <ul>
+     *         <li>completes when the client was successfully disconnected or</li>
+     *         <li>errors if not disconnected successfully.</li>
+     *         </ul>
+     */
     @NotNull
     Completable disconnect(@NotNull Mqtt5Disconnect disconnect);
 
+    /**
+     * Creates a {@link Mqtt5DisconnectBuilder} for disconnecting this MQTT 5 client with the Disconnect message built
+     * from the returned builder.
+     * <p>
+     * Calling {@link Mqtt5DisconnectBuilder#done()} has the same effect as calling {@link #disconnect(Mqtt5Disconnect)}
+     * with the result of {@link Mqtt5DisconnectBuilder#build()}.
+     *
+     * @return the builder for the Disconnect message.
+     * @see #disconnect(Mqtt5Disconnect)
+     */
     @NotNull
     default Mqtt5DisconnectBuilder<Completable> disconnect() {
         return new Mqtt5DisconnectBuilder<>(this::disconnect);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -37,13 +37,6 @@ import org.mqttbee.util.MustNotBeImplementedUtil;
  */
 public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
-    private final MqttClientIdentifierImpl identifier;
-    private final String serverHost;
-    private final int serverPort;
-    private final MqttClientSslConfig sslConfig;
-    private final MqttWebsocketConfig websocketConfig;
-    private final MqttClientExecutorConfigImpl executorConfig;
-
     private boolean followRedirects = false;
     private boolean allowServerReAuth = false;
     private MqttAdvancedClientData advancedClientData;
@@ -183,6 +176,7 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
         return new Mqtt5ClientImpl(buildClientData());
     }
 
+    @NotNull
     private MqttClientData buildClientData() {
         return new MqttClientData(MqttVersion.MQTT_5_0, identifier, serverHost, serverPort, sslConfig, websocketConfig,
                 followRedirects, allowServerReAuth, executorConfig, advancedClientData);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -20,10 +20,7 @@ package org.mqttbee.api.mqtt.mqtt5;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.MqttClientBuilder;
-import org.mqttbee.api.mqtt.MqttClientExecutorConfig;
-import org.mqttbee.api.mqtt.MqttClientSslConfig;
-import org.mqttbee.api.mqtt.MqttWebsocketConfig;
+import org.mqttbee.api.mqtt.*;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.api.mqtt.mqtt3.Mqtt3ClientBuilder;
 import org.mqttbee.api.mqtt.mqtt5.advanced.Mqtt5AdvancedClientData;
@@ -98,8 +95,8 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt5ClientBuilder useSsl() {
-        super.useSsl();
+    public Mqtt5ClientBuilder useSslDefaults() {
+        super.useSslDefaults();
         return this;
     }
 
@@ -112,8 +109,14 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt5ClientBuilder useWebSocket() {
-        super.useWebSocket();
+    public MqttClientSslConfigBuilder<? extends Mqtt5ClientBuilder> useSsl() {
+        return new MqttClientSslConfigBuilder<>(this::useSsl);
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5ClientBuilder useWebSocketDefaults() {
+        super.useWebSocketDefaults();
         return this;
     }
 
@@ -126,9 +129,21 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
+    public MqttWebsocketConfigBuilder<? extends Mqtt5ClientBuilder> useWebSocket() {
+        return new MqttWebsocketConfigBuilder<>(this::useWebSocket);
+    }
+
+    @NotNull
+    @Override
     public Mqtt5ClientBuilder executorConfig(@NotNull final MqttClientExecutorConfig executorConfig) {
         super.executorConfig(executorConfig);
         return this;
+    }
+
+    @NotNull
+    @Override
+    public MqttClientExecutorConfigBuilder<? extends Mqtt5ClientBuilder> executorConfig() {
+        return new MqttClientExecutorConfigBuilder<>(this::executorConfig);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -88,8 +88,8 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt5ClientBuilder useSslDefaults() {
-        super.useSslDefaults();
+    public Mqtt5ClientBuilder useSslWithDefaultConfig() {
+        super.useSslWithDefaultConfig();
         return this;
     }
 
@@ -108,8 +108,8 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
 
     @NotNull
     @Override
-    public Mqtt5ClientBuilder useWebSocketDefaults() {
-        super.useWebSocketDefaults();
+    public Mqtt5ClientBuilder useWebSocketWithDefaultConfig() {
+        super.useWebSocketWithDefaultConfig();
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
@@ -25,6 +25,8 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.util.MustNotBeImplementedUtil;
 
+import java.util.function.Function;
+
 /**
  * Collection of {@link Mqtt5UserProperty User Properties}.
  *
@@ -60,13 +62,13 @@ public interface Mqtt5UserProperties {
     }
 
     @NotNull
-    static Mqtt5UserPropertiesBuilder builder() {
-        return new Mqtt5UserPropertiesBuilder();
+    static Mqtt5UserPropertiesBuilder<Void> builder() {
+        return new Mqtt5UserPropertiesBuilder<>((Function<Mqtt5UserProperties, Void>) null);
     }
 
     @NotNull
-    static Mqtt5UserPropertiesBuilder extend(@NotNull final Mqtt5UserProperties userProperties) {
-        return new Mqtt5UserPropertiesBuilder(userProperties);
+    static Mqtt5UserPropertiesBuilder<Void> extend(@NotNull final Mqtt5UserProperties userProperties) {
+        return new Mqtt5UserPropertiesBuilder<>(userProperties);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserPropertiesBuilder.java
@@ -19,37 +19,55 @@ package org.mqttbee.api.mqtt.mqtt5.datatypes;
 
 import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
+import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5UserPropertiesBuilder {
+public class Mqtt5UserPropertiesBuilder<P> extends FluentBuilder<Mqtt5UserProperties, P> {
 
-    private ImmutableList.Builder<MqttUserPropertyImpl> listBuilder;
+    private final ImmutableList.Builder<MqttUserPropertyImpl> listBuilder;
 
-    Mqtt5UserPropertiesBuilder() {
+    public Mqtt5UserPropertiesBuilder(@Nullable final Function<Mqtt5UserProperties, P> parentConsumer) {
+        super(parentConsumer);
+        listBuilder = ImmutableList.builder();
     }
 
     Mqtt5UserPropertiesBuilder(@NotNull final Mqtt5UserProperties userProperties) {
-        final MqttUserPropertiesImpl userPropertiesImpl = MqttBuilderUtil.userProperties(userProperties);
-        listBuilder = ImmutableList.builder();
-        listBuilder.addAll(userPropertiesImpl.asList());
+        super(null);
+        final ImmutableList<MqttUserPropertyImpl> list = MqttBuilderUtil.userProperties(userProperties).asList();
+        listBuilder = ImmutableList.builderWithExpectedSize(list.size() + 1);
+        listBuilder.addAll(list);
     }
 
     @NotNull
-    public Mqtt5UserPropertiesBuilder add(@NotNull final Mqtt5UserProperty userProperty) {
-        if (listBuilder == null) {
-            listBuilder = ImmutableList.builder();
-        }
+    public Mqtt5UserPropertiesBuilder<P> add(@NotNull final String name, @NotNull final String value) {
+        listBuilder.add(MqttBuilderUtil.userProperty(name, value));
+        return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<P> add(@NotNull final MqttUTF8String name, @NotNull final MqttUTF8String value) {
+        listBuilder.add(MqttBuilderUtil.userProperty(name, value));
+        return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<P> add(@NotNull final Mqtt5UserProperty userProperty) {
         listBuilder.add(MustNotBeImplementedUtil.checkNotImplemented(userProperty, MqttUserPropertyImpl.class));
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5UserProperties build() {
         return MqttUserPropertiesImpl.build(listBuilder);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperty.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperty.java
@@ -20,7 +20,6 @@ package org.mqttbee.api.mqtt.mqtt5.datatypes;
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
-import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
 
 /**
@@ -42,7 +41,7 @@ public interface Mqtt5UserProperty {
      */
     @NotNull
     static Mqtt5UserProperty of(@NotNull final String name, @NotNull final String value) {
-        return MqttUserPropertyImpl.of(MqttBuilderUtil.string(name), MqttBuilderUtil.string(value));
+        return MqttBuilderUtil.userProperty(name, value);
     }
 
     /**
@@ -54,7 +53,7 @@ public interface Mqtt5UserProperty {
      */
     @NotNull
     static Mqtt5UserProperty of(@NotNull final MqttUTF8String name, @NotNull final MqttUTF8String value) {
-        return MqttUserPropertyImpl.of(MqttBuilderUtil.string(name), MqttBuilderUtil.string(value));
+        return MqttBuilderUtil.userProperty(name, value);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5AuthBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 
 import java.nio.ByteBuffer;
 
@@ -45,5 +46,8 @@ public interface Mqtt5AuthBuilder {
 
     @NotNull
     Mqtt5AuthBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
+
+    @NotNull
+    Mqtt5UserPropertiesBuilder<? extends Mqtt5AuthBuilder> userProperties();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuth.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuth.java
@@ -31,8 +31,8 @@ import java.util.Optional;
 public interface Mqtt5SimpleAuth {
 
     @NotNull
-    static Mqtt5SimpleAuthBuilder builder() {
-        return new Mqtt5SimpleAuthBuilder();
+    static Mqtt5SimpleAuthBuilder<Void> builder() {
+        return new Mqtt5SimpleAuthBuilder<>(null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
@@ -37,7 +37,7 @@ public class Mqtt5SimpleAuthBuilder<P> extends FluentBuilder<Mqtt5SimpleAuth, P>
     private MqttUTF8StringImpl username;
     private ByteBuffer password;
 
-    public Mqtt5SimpleAuthBuilder(@Nullable final Function<Mqtt5SimpleAuth, P> parentConsumer) {
+    public Mqtt5SimpleAuthBuilder(@Nullable final Function<? super Mqtt5SimpleAuth, P> parentConsumer) {
         super(parentConsumer);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/auth/Mqtt5SimpleAuthBuilder.java
@@ -24,45 +24,49 @@ import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5SimpleAuthBuilder {
+public class Mqtt5SimpleAuthBuilder<P> extends FluentBuilder<Mqtt5SimpleAuth, P> {
 
     private MqttUTF8StringImpl username;
     private ByteBuffer password;
 
-    Mqtt5SimpleAuthBuilder() {
+    public Mqtt5SimpleAuthBuilder(@Nullable final Function<Mqtt5SimpleAuth, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder username(@Nullable final String username) {
+    public Mqtt5SimpleAuthBuilder<P> username(@Nullable final String username) {
         this.username = MqttBuilderUtil.stringOrNull(username);
         return this;
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder username(@Nullable final MqttUTF8String username) {
+    public Mqtt5SimpleAuthBuilder<P> username(@Nullable final MqttUTF8String username) {
         this.username = MqttBuilderUtil.stringOrNull(username);
         return this;
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder password(@Nullable final byte[] password) {
+    public Mqtt5SimpleAuthBuilder<P> password(@Nullable final byte[] password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder password(@Nullable final ByteBuffer password) {
+    public Mqtt5SimpleAuthBuilder<P> password(@Nullable final ByteBuffer password) {
         this.password = MqttBuilderUtil.binaryDataOrNull(password);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5SimpleAuth build() {
         Preconditions.checkState(username != null || password != null);
         return new MqttSimpleAuth(username, password);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
@@ -28,6 +28,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublish;
 import org.mqttbee.util.UnsignedDataTypes;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * MQTT 5 CONNECT packet.
@@ -46,13 +47,13 @@ public interface Mqtt5Connect extends Mqtt5Message {
     boolean DEFAULT_PROBLEM_INFORMATION_REQUESTED = true;
 
     @NotNull
-    static Mqtt5ConnectBuilder builder() {
-        return new Mqtt5ConnectBuilder();
+    static Mqtt5ConnectBuilder<Void> builder() {
+        return new Mqtt5ConnectBuilder<>((Function<Mqtt5Connect, Void>) null);
     }
 
     @NotNull
-    static Mqtt5ConnectBuilder extend(@NotNull final Mqtt5Connect connect) {
-        return new Mqtt5ConnectBuilder(connect);
+    static Mqtt5ConnectBuilder<Void> extend(@NotNull final Mqtt5Connect connect) {
+        return new Mqtt5ConnectBuilder<>(connect);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -112,7 +112,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder<Mqtt5ConnectBuilder<P>> restrictions() {
+    public Mqtt5ConnectRestrictionsBuilder<? extends Mqtt5ConnectBuilder<P>> restrictions() {
         return new Mqtt5ConnectRestrictionsBuilder<>(this::restrictions);
     }
 
@@ -123,7 +123,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     }
 
     @NotNull
-    public Mqtt5SimpleAuthBuilder<Mqtt5ConnectBuilder<P>> simpleAuth() {
+    public Mqtt5SimpleAuthBuilder<? extends Mqtt5ConnectBuilder<P>> simpleAuth() {
         return new Mqtt5SimpleAuthBuilder<>(this::simpleAuth);
     }
 
@@ -140,7 +140,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     }
 
     @NotNull
-    public Mqtt5WillPublishBuilder<Mqtt5ConnectBuilder<P>> willPublish() {
+    public Mqtt5WillPublishBuilder<? extends Mqtt5ConnectBuilder<P>> willPublish() {
         return new Mqtt5WillPublishBuilder<>(this::willPublish);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -54,7 +54,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     private MqttWillPublish willPublish;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    public Mqtt5ConnectBuilder(@Nullable final Function<Mqtt5Connect, P> parentConsumer) {
+    public Mqtt5ConnectBuilder(@Nullable final Function<? super Mqtt5Connect, P> parentConsumer) {
         super(parentConsumer);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt5.auth.Mqtt5EnhancedAuthProvider;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuthBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublish;
@@ -147,6 +148,11 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     public Mqtt5ConnectBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<? extends Mqtt5ConnectBuilder<P>> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -23,19 +23,24 @@ import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt5.auth.Mqtt5EnhancedAuthProvider;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
+import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuthBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublish;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublishBuilder;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 import org.mqttbee.mqtt.message.connect.MqttConnect;
 import org.mqttbee.mqtt.message.connect.MqttConnectRestrictions;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
 import org.mqttbee.util.UnsignedDataTypes;
 
+import java.util.function.Function;
+
 import static org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect.*;
 
-public class Mqtt5ConnectBuilder {
+public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
 
     private int keepAlive = DEFAULT_KEEP_ALIVE;
     private boolean isCleanStart = DEFAULT_CLEAN_START;
@@ -48,10 +53,12 @@ public class Mqtt5ConnectBuilder {
     private MqttWillPublish willPublish;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    Mqtt5ConnectBuilder() {
+    public Mqtt5ConnectBuilder(@Nullable final Function<Mqtt5Connect, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     Mqtt5ConnectBuilder(@NotNull final Mqtt5Connect connect) {
+        super(null);
         final MqttConnect connectImpl = MustNotBeImplementedUtil.checkNotImplemented(connect, MqttConnect.class);
         keepAlive = connectImpl.getKeepAlive();
         isCleanStart = connectImpl.isCleanStart();
@@ -66,67 +73,84 @@ public class Mqtt5ConnectBuilder {
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder keepAlive(final int keepAlive) {
+    public Mqtt5ConnectBuilder<P> keepAlive(final int keepAlive) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAlive));
         this.keepAlive = keepAlive;
         return this;
     }
 
-    public Mqtt5ConnectBuilder cleanStart(final boolean isCleanStart) {
+    @NotNull
+    public Mqtt5ConnectBuilder<P> cleanStart(final boolean isCleanStart) {
         this.isCleanStart = isCleanStart;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder sessionExpiryInterval(final long sessionExpiryInterval) {
+    public Mqtt5ConnectBuilder<P> sessionExpiryInterval(final long sessionExpiryInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryInterval));
         this.sessionExpiryInterval = sessionExpiryInterval;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder responseInformationRequested(final boolean isResponseInformationRequested) {
+    public Mqtt5ConnectBuilder<P> responseInformationRequested(final boolean isResponseInformationRequested) {
         this.isResponseInformationRequested = isResponseInformationRequested;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder problemInformationRequested(final boolean isProblemInformationRequested) {
+    public Mqtt5ConnectBuilder<P> problemInformationRequested(final boolean isProblemInformationRequested) {
         this.isProblemInformationRequested = isProblemInformationRequested;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder restrictions(@NotNull final Mqtt5ConnectRestrictions restrictions) {
+    public Mqtt5ConnectBuilder<P> restrictions(@NotNull final Mqtt5ConnectRestrictions restrictions) {
         this.restrictions = MustNotBeImplementedUtil.checkNotImplemented(restrictions, MqttConnectRestrictions.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder simpleAuth(@Nullable final Mqtt5SimpleAuth simpleAuth) {
+    public Mqtt5ConnectRestrictionsBuilder<Mqtt5ConnectBuilder<P>> restrictions() {
+        return new Mqtt5ConnectRestrictionsBuilder<>(this::restrictions);
+    }
+
+    @NotNull
+    public Mqtt5ConnectBuilder<P> simpleAuth(@Nullable final Mqtt5SimpleAuth simpleAuth) {
         this.simpleAuth = MustNotBeImplementedUtil.checkNullOrNotImplemented(simpleAuth, MqttSimpleAuth.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder enhancedAuth(@Nullable final Mqtt5EnhancedAuthProvider enhancedAuthProvider) {
+    public Mqtt5SimpleAuthBuilder<Mqtt5ConnectBuilder<P>> simpleAuth() {
+        return new Mqtt5SimpleAuthBuilder<>(this::simpleAuth);
+    }
+
+    @NotNull
+    public Mqtt5ConnectBuilder<P> enhancedAuth(@Nullable final Mqtt5EnhancedAuthProvider enhancedAuthProvider) {
         this.enhancedAuthProvider = enhancedAuthProvider;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder willPublish(@Nullable final Mqtt5WillPublish willPublish) {
+    public Mqtt5ConnectBuilder<P> willPublish(@Nullable final Mqtt5WillPublish willPublish) {
         this.willPublish = MustNotBeImplementedUtil.checkNullOrNotImplemented(willPublish, MqttWillPublish.class);
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5WillPublishBuilder<Mqtt5ConnectBuilder<P>> willPublish() {
+        return new Mqtt5WillPublishBuilder<>(this::willPublish);
+    }
+
+    @NotNull
+    public Mqtt5ConnectBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5Connect build() {
         return new MqttConnect(keepAlive, isCleanStart, sessionExpiryInterval, isResponseInformationRequested,
                 isProblemInformationRequested, restrictions, simpleAuth, enhancedAuthProvider, willPublish,

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -141,7 +141,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
 
     @NotNull
     public Mqtt5WillPublishBuilder<? extends Mqtt5ConnectBuilder<P>> willPublish() {
-        return new Mqtt5WillPublishBuilder<>(this::willPublish);
+        return Mqtt5WillPublishBuilder.create(this::willPublish);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictions.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictions.java
@@ -42,8 +42,8 @@ public interface Mqtt5ConnectRestrictions {
     int DEFAULT_MAXIMUM_PACKET_SIZE_NO_LIMIT = MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT;
 
     @NotNull
-    static Mqtt5ConnectRestrictionsBuilder builder() {
-        return new Mqtt5ConnectRestrictionsBuilder();
+    static Mqtt5ConnectRestrictionsBuilder<Void> builder() {
+        return new Mqtt5ConnectRestrictionsBuilder<>(null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
@@ -19,43 +19,49 @@ package org.mqttbee.api.mqtt.mqtt5.message.connect;
 
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.mqtt.message.connect.MqttConnectRestrictions;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.UnsignedDataTypes;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5ConnectRestrictionsBuilder {
+public class Mqtt5ConnectRestrictionsBuilder<P> extends FluentBuilder<Mqtt5ConnectRestrictions, P> {
 
     private int receiveMaximum = Mqtt5ConnectRestrictions.DEFAULT_RECEIVE_MAXIMUM;
     private int topicAliasMaximum = Mqtt5ConnectRestrictions.DEFAULT_TOPIC_ALIAS_MAXIMUM;
     private int maximumPacketSize = Mqtt5ConnectRestrictions.DEFAULT_MAXIMUM_PACKET_SIZE_NO_LIMIT;
 
-    Mqtt5ConnectRestrictionsBuilder() {
+    public Mqtt5ConnectRestrictionsBuilder(@Nullable final Function<Mqtt5ConnectRestrictions, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder receiveMaximum(final int receiveMaximum) {
+    public Mqtt5ConnectRestrictionsBuilder<P> receiveMaximum(final int receiveMaximum) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(receiveMaximum));
         this.receiveMaximum = receiveMaximum;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder topicAliasMaximum(final int topicAliasMaximum) {
+    public Mqtt5ConnectRestrictionsBuilder<P> topicAliasMaximum(final int topicAliasMaximum) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(topicAliasMaximum));
         this.topicAliasMaximum = topicAliasMaximum;
         return this;
     }
 
     @NotNull
-    public Mqtt5ConnectRestrictionsBuilder maximumPacketSize(final int maximumPacketSize) {
+    public Mqtt5ConnectRestrictionsBuilder<P> maximumPacketSize(final int maximumPacketSize) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(maximumPacketSize));
         this.maximumPacketSize = maximumPacketSize;
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5ConnectRestrictions build() {
         return new MqttConnectRestrictions(receiveMaximum, topicAliasMaximum, maximumPacketSize);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
@@ -35,7 +35,9 @@ public class Mqtt5ConnectRestrictionsBuilder<P> extends FluentBuilder<Mqtt5Conne
     private int topicAliasMaximum = Mqtt5ConnectRestrictions.DEFAULT_TOPIC_ALIAS_MAXIMUM;
     private int maximumPacketSize = Mqtt5ConnectRestrictions.DEFAULT_MAXIMUM_PACKET_SIZE_NO_LIMIT;
 
-    public Mqtt5ConnectRestrictionsBuilder(@Nullable final Function<Mqtt5ConnectRestrictions, P> parentConsumer) {
+    public Mqtt5ConnectRestrictionsBuilder(
+            @Nullable final Function<? super Mqtt5ConnectRestrictions, P> parentConsumer) {
+
         super(parentConsumer);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
@@ -35,8 +35,8 @@ import java.util.Optional;
 public interface Mqtt5Disconnect extends Mqtt5Message {
 
     @NotNull
-    static Mqtt5DisconnectBuilder builder() {
-        return new Mqtt5DisconnectBuilder();
+    static Mqtt5DisconnectBuilder<Void> builder() {
+        return new Mqtt5DisconnectBuilder<>(null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.disconnect.MqttDisconnect;
@@ -90,6 +91,11 @@ public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P>
     public Mqtt5DisconnectBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<? extends Mqtt5DisconnectBuilder<P>> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -26,7 +26,10 @@ import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.disconnect.MqttDisconnect;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.UnsignedDataTypes;
+
+import java.util.function.Function;
 
 import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE;
 import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode.NORMAL_DISCONNECTION;
@@ -34,7 +37,7 @@ import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReaso
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5DisconnectBuilder {
+public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P> {
 
     private boolean withWillMessage = false;
     private long sessionExpiryInterval = MqttDisconnect.SESSION_EXPIRY_INTERVAL_FROM_CONNECT;
@@ -42,53 +45,55 @@ public class Mqtt5DisconnectBuilder {
     private MqttUTF8StringImpl reasonString;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    Mqtt5DisconnectBuilder() {
+    public Mqtt5DisconnectBuilder(@Nullable final Function<Mqtt5Disconnect, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder willMessage(final boolean withWillMessage) {
+    public Mqtt5DisconnectBuilder<P> willMessage(final boolean withWillMessage) {
         this.withWillMessage = withWillMessage;
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder sessionExpiryInterval(final long sessionExpiryInterval) {
+    public Mqtt5DisconnectBuilder<P> sessionExpiryInterval(final long sessionExpiryInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryInterval));
         this.sessionExpiryInterval = sessionExpiryInterval;
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder serverReference(@Nullable final String serverReference) {
+    public Mqtt5DisconnectBuilder<P> serverReference(@Nullable final String serverReference) {
         this.serverReference = MqttBuilderUtil.stringOrNull(serverReference);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder serverReference(@Nullable final MqttUTF8String serverReference) {
+    public Mqtt5DisconnectBuilder<P> serverReference(@Nullable final MqttUTF8String serverReference) {
         this.serverReference = MqttBuilderUtil.stringOrNull(serverReference);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder reasonString(@Nullable final String reasonString) {
+    public Mqtt5DisconnectBuilder<P> reasonString(@Nullable final String reasonString) {
         this.reasonString = MqttBuilderUtil.stringOrNull(reasonString);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder reasonString(@Nullable final MqttUTF8String reasonString) {
+    public Mqtt5DisconnectBuilder<P> reasonString(@Nullable final MqttUTF8String reasonString) {
         this.reasonString = MqttBuilderUtil.stringOrNull(reasonString);
         return this;
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5DisconnectBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5Disconnect build() {
         final Mqtt5DisconnectReasonCode reasonCode =
                 withWillMessage ? DISCONNECT_WITH_WILL_MESSAGE : NORMAL_DISCONNECTION;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -46,7 +46,7 @@ public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P>
     private MqttUTF8StringImpl reasonString;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    public Mqtt5DisconnectBuilder(@Nullable final Function<Mqtt5Disconnect, P> parentConsumer) {
+    public Mqtt5DisconnectBuilder(@Nullable final Function<? super Mqtt5Disconnect, P> parentConsumer) {
         super(parentConsumer);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -29,6 +29,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5SubscribeResult;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * MQTT 5 PUBLISH packet.
@@ -45,13 +46,13 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
     TopicAliasUsage DEFAULT_TOPIC_ALIAS_USAGE = TopicAliasUsage.MUST_NOT;
 
     @NotNull
-    static Mqtt5PublishBuilder builder() {
-        return new Mqtt5PublishBuilder();
+    static Mqtt5PublishBuilder<Void> builder() {
+        return new Mqtt5PublishBuilder<>((Function<Mqtt5Publish, Void>) null);
     }
 
     @NotNull
-    static Mqtt5PublishBuilder extend(@NotNull final Mqtt5Publish publish) {
-        return new Mqtt5PublishBuilder(publish);
+    static Mqtt5PublishBuilder<Void> extend(@NotNull final Mqtt5Publish publish) {
+        return new Mqtt5PublishBuilder<>(publish);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
@@ -58,7 +59,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     private TopicAliasUsage topicAliasUsage = DEFAULT_TOPIC_ALIAS_USAGE;
     MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    public Mqtt5PublishBuilder(@Nullable final Function<Mqtt5Publish, P> parentConsumer) {
+    public Mqtt5PublishBuilder(@Nullable final Function<? super Mqtt5Publish, P> parentConsumer) {
         super(parentConsumer);
     }
 
@@ -88,6 +89,11 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     public Mqtt5PublishBuilder<P> topic(@NotNull final MqttTopic topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
+    }
+
+    @NotNull
+    public MqttTopicBuilder<? extends Mqtt5PublishBuilder<P>> topic() {
+        return new MqttTopicBuilder<>("", this::topic);
     }
 
     @NotNull
@@ -151,6 +157,11 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     public Mqtt5PublishBuilder<P> responseTopic(@Nullable final MqttTopic responseTopic) {
         this.responseTopic = MqttBuilderUtil.topicOrNull(responseTopic);
         return this;
+    }
+
+    @NotNull
+    public MqttTopicBuilder<? extends Mqtt5PublishBuilder<P>> responseTopic() {
+        return new MqttTopicBuilder<>("", this::responseTopic);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -30,10 +30,12 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
 import org.mqttbee.util.UnsignedDataTypes;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 import static org.mqttbee.mqtt.message.publish.MqttPublish.DEFAULT_TOPIC_ALIAS_USAGE;
 import static org.mqttbee.mqtt.message.publish.MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY;
@@ -41,7 +43,7 @@ import static org.mqttbee.mqtt.message.publish.MqttPublish.MESSAGE_EXPIRY_INTERV
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5PublishBuilder {
+public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
 
     MqttTopicImpl topic;
     ByteBuffer payload;
@@ -55,10 +57,12 @@ public class Mqtt5PublishBuilder {
     private TopicAliasUsage topicAliasUsage = DEFAULT_TOPIC_ALIAS_USAGE;
     MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    Mqtt5PublishBuilder() {
+    public Mqtt5PublishBuilder(@Nullable final Function<Mqtt5Publish, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     Mqtt5PublishBuilder(@NotNull final Mqtt5Publish publish) {
+        super(null);
         final MqttPublish publishImpl = MustNotBeImplementedUtil.checkNotImplemented(publish, MqttPublish.class);
         topic = publishImpl.getTopic();
         payload = publishImpl.getRawPayload();
@@ -74,50 +78,50 @@ public class Mqtt5PublishBuilder {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder topic(@NotNull final String topic) {
+    public Mqtt5PublishBuilder<P> topic(@NotNull final String topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder topic(@NotNull final MqttTopic topic) {
+    public Mqtt5PublishBuilder<P> topic(@NotNull final MqttTopic topic) {
         this.topic = MqttBuilderUtil.topic(topic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder payload(@Nullable final byte[] payload) {
+    public Mqtt5PublishBuilder<P> payload(@Nullable final byte[] payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.wrap(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder payload(@Nullable final ByteBuffer payload) {
+    public Mqtt5PublishBuilder<P> payload(@Nullable final ByteBuffer payload) {
         this.payload = (payload == null) ? null : ByteBufferUtil.slice(payload);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder qos(@NotNull final MqttQoS qos) {
+    public Mqtt5PublishBuilder<P> qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder retain(final boolean retain) {
+    public Mqtt5PublishBuilder<P> retain(final boolean retain) {
         this.retain = retain;
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder messageExpiryInterval(final long messageExpiryInterval) {
+    public Mqtt5PublishBuilder<P> messageExpiryInterval(final long messageExpiryInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(messageExpiryInterval));
         this.messageExpiryInterval = messageExpiryInterval;
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder payloadFormatIndicator(
+    public Mqtt5PublishBuilder<P> payloadFormatIndicator(
             @Nullable final Mqtt5PayloadFormatIndicator payloadFormatIndicator) {
 
         this.payloadFormatIndicator = payloadFormatIndicator;
@@ -125,55 +129,56 @@ public class Mqtt5PublishBuilder {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder contentType(@Nullable final String contentType) {
+    public Mqtt5PublishBuilder<P> contentType(@Nullable final String contentType) {
         this.contentType = MqttBuilderUtil.stringOrNull(contentType);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder contentType(@Nullable final MqttUTF8String contentType) {
+    public Mqtt5PublishBuilder<P> contentType(@Nullable final MqttUTF8String contentType) {
         this.contentType = MqttBuilderUtil.stringOrNull(contentType);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder responseTopic(@Nullable final String responseTopic) {
+    public Mqtt5PublishBuilder<P> responseTopic(@Nullable final String responseTopic) {
         this.responseTopic = MqttBuilderUtil.topicOrNull(responseTopic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder responseTopic(@Nullable final MqttTopic responseTopic) {
+    public Mqtt5PublishBuilder<P> responseTopic(@Nullable final MqttTopic responseTopic) {
         this.responseTopic = MqttBuilderUtil.topicOrNull(responseTopic);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder correlationData(@Nullable final byte[] correlationData) {
+    public Mqtt5PublishBuilder<P> correlationData(@Nullable final byte[] correlationData) {
         this.correlationData = MqttBuilderUtil.binaryDataOrNull(correlationData);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder correlationData(@Nullable final ByteBuffer correlationData) {
+    public Mqtt5PublishBuilder<P> correlationData(@Nullable final ByteBuffer correlationData) {
         this.correlationData = MqttBuilderUtil.binaryDataOrNull(correlationData);
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
+    public Mqtt5PublishBuilder<P> topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
         Preconditions.checkNotNull(topicAliasUsage);
         this.topicAliasUsage = topicAliasUsage;
         return this;
     }
 
     @NotNull
-    public Mqtt5PublishBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5PublishBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5Publish build() {
         Preconditions.checkNotNull(topic);
         Preconditions.checkNotNull(qos);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -24,6 +24,7 @@ import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
@@ -175,6 +176,11 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     public Mqtt5PublishBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<? extends Mqtt5PublishBuilder<P>> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
@@ -20,6 +20,8 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish;
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
 
+import java.util.function.Function;
+
 /**
  * MQTT 5 Will Publish which can be a part of the CONNECT packet.
  *
@@ -29,13 +31,13 @@ import org.mqttbee.annotations.NotNull;
 public interface Mqtt5WillPublish extends Mqtt5Publish {
 
     @NotNull
-    static Mqtt5WillPublishBuilder builder() {
-        return new Mqtt5WillPublishBuilder();
+    static Mqtt5WillPublishBuilder<Void> builder() {
+        return new Mqtt5WillPublishBuilder<>((Function<Mqtt5WillPublish, Void>) null);
     }
 
     @NotNull
-    static Mqtt5WillPublishBuilder extend(@NotNull final Mqtt5Publish publish) {
-        return new Mqtt5WillPublishBuilder(publish);
+    static Mqtt5WillPublishBuilder<Void> extend(@NotNull final Mqtt5Publish publish) {
+        return new Mqtt5WillPublishBuilder<>(publish);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
@@ -32,7 +32,7 @@ public interface Mqtt5WillPublish extends Mqtt5Publish {
 
     @NotNull
     static Mqtt5WillPublishBuilder<Void> builder() {
-        return new Mqtt5WillPublishBuilder<>((Function<Mqtt5WillPublish, Void>) null);
+        return new Mqtt5WillPublishBuilder<>((Function<Mqtt5Publish, Void>) null);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -24,6 +24,7 @@ import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
 import org.mqttbee.util.MustNotBeImplementedUtil;
@@ -165,7 +166,13 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     }
 
     @NotNull
-    public Mqtt5WillPublishBuilder<P> withDelayInterval(final long delayInterval) {
+    @Override
+    public Mqtt5UserPropertiesBuilder<? extends Mqtt5WillPublishBuilder<P>> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
+    }
+
+    @NotNull
+    public Mqtt5WillPublishBuilder<P> delayInterval(final long delayInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayInterval));
         this.delayInterval = delayInterval;
         return this;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -30,21 +30,27 @@ import org.mqttbee.util.MustNotBeImplementedUtil;
 import org.mqttbee.util.UnsignedDataTypes;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 import static org.mqttbee.mqtt.message.publish.MqttWillPublish.DEFAULT_DELAY_INTERVAL;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5WillPublishBuilder extends Mqtt5PublishBuilder {
+public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
+
+    private final Function<Mqtt5WillPublish, P> parentConsumer;
 
     private long delayInterval = DEFAULT_DELAY_INTERVAL;
 
-    Mqtt5WillPublishBuilder() {
+    public Mqtt5WillPublishBuilder(@Nullable final Function<Mqtt5WillPublish, P> parentConsumer) {
+        super((Function<Mqtt5Publish, P>) null);
+        this.parentConsumer = parentConsumer;
     }
 
     Mqtt5WillPublishBuilder(@NotNull final Mqtt5Publish publish) {
         super(publish);
+        parentConsumer = null;
         if (publish instanceof Mqtt5WillPublish) {
             delayInterval =
                     MustNotBeImplementedUtil.checkNotImplemented(publish, MqttWillPublish.class).getDelayInterval();
@@ -53,49 +59,49 @@ public class Mqtt5WillPublishBuilder extends Mqtt5PublishBuilder {
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder topic(@NotNull final String topic) {
+    public Mqtt5WillPublishBuilder<P> topic(@NotNull final String topic) {
         super.topic(topic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder topic(@NotNull final MqttTopic topic) {
+    public Mqtt5WillPublishBuilder<P> topic(@NotNull final MqttTopic topic) {
         super.topic(topic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder payload(@Nullable final byte[] payload) {
+    public Mqtt5WillPublishBuilder<P> payload(@Nullable final byte[] payload) {
         this.payload = MqttBuilderUtil.binaryDataOrNull(payload);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder payload(@Nullable final ByteBuffer payload) {
+    public Mqtt5WillPublishBuilder<P> payload(@Nullable final ByteBuffer payload) {
         this.payload = MqttBuilderUtil.binaryDataOrNull(payload);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder qos(@NotNull final MqttQoS qos) {
+    public Mqtt5WillPublishBuilder<P> qos(@NotNull final MqttQoS qos) {
         super.qos(qos);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder retain(final boolean retain) {
+    public Mqtt5WillPublishBuilder<P> retain(final boolean retain) {
         super.retain(retain);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder payloadFormatIndicator(
+    public Mqtt5WillPublishBuilder<P> payloadFormatIndicator(
             @Nullable final Mqtt5PayloadFormatIndicator payloadFormatIndicator) {
 
         super.payloadFormatIndicator(payloadFormatIndicator);
@@ -104,42 +110,42 @@ public class Mqtt5WillPublishBuilder extends Mqtt5PublishBuilder {
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder contentType(@Nullable final String contentType) {
+    public Mqtt5WillPublishBuilder<P> contentType(@Nullable final String contentType) {
         super.contentType(contentType);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder contentType(@Nullable final MqttUTF8String contentType) {
+    public Mqtt5WillPublishBuilder<P> contentType(@Nullable final MqttUTF8String contentType) {
         super.contentType(contentType);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder responseTopic(@Nullable final String responseTopic) {
+    public Mqtt5WillPublishBuilder<P> responseTopic(@Nullable final String responseTopic) {
         super.responseTopic(responseTopic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder responseTopic(@Nullable final MqttTopic responseTopic) {
+    public Mqtt5WillPublishBuilder<P> responseTopic(@Nullable final MqttTopic responseTopic) {
         super.responseTopic(responseTopic);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder correlationData(@Nullable final byte[] correlationData) {
+    public Mqtt5WillPublishBuilder<P> correlationData(@Nullable final byte[] correlationData) {
         super.correlationData(correlationData);
         return this;
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder correlationData(@Nullable final ByteBuffer correlationData) {
+    public Mqtt5WillPublishBuilder<P> correlationData(@Nullable final ByteBuffer correlationData) {
         super.correlationData(correlationData);
         return this;
     }
@@ -147,22 +153,28 @@ public class Mqtt5WillPublishBuilder extends Mqtt5PublishBuilder {
     @NotNull
     @Override
     @Deprecated
-    public Mqtt5WillPublishBuilder topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
+    public Mqtt5WillPublishBuilder<P> topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5WillPublishBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         super.userProperties(userProperties);
         return this;
     }
 
     @NotNull
-    public Mqtt5WillPublishBuilder withDelayInterval(final long delayInterval) {
+    public Mqtt5WillPublishBuilder<P> withDelayInterval(final long delayInterval) {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayInterval));
         this.delayInterval = delayInterval;
         return this;
+    }
+
+    @NotNull
+    @Override
+    public P done() {
+        return done(build(), parentConsumer);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -41,6 +41,7 @@ import static org.mqttbee.mqtt.message.publish.MqttWillPublish.DEFAULT_DELAY_INT
  */
 public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
 
+    @NotNull
     public static <P> Mqtt5WillPublishBuilder<P> create(
             @Nullable final Function<? super Mqtt5WillPublish, P> parentConsumer) {
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -41,18 +41,21 @@ import static org.mqttbee.mqtt.message.publish.MqttWillPublish.DEFAULT_DELAY_INT
  */
 public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
 
-    private final Function<? super Mqtt5WillPublish, P> parentConsumer;
+    public static <P> Mqtt5WillPublishBuilder<P> create(
+            @Nullable final Function<? super Mqtt5WillPublish, P> parentConsumer) {
+
+        return new Mqtt5WillPublishBuilder<>(
+                (parentConsumer == null) ? null : publish -> parentConsumer.apply((Mqtt5WillPublish) publish));
+    }
 
     private long delayInterval = DEFAULT_DELAY_INTERVAL;
 
-    public Mqtt5WillPublishBuilder(@Nullable final Function<? super Mqtt5WillPublish, P> parentConsumer) {
-        super((Function<Mqtt5Publish, P>) null);
-        this.parentConsumer = parentConsumer;
+    public Mqtt5WillPublishBuilder(@Nullable final Function<? super Mqtt5Publish, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     Mqtt5WillPublishBuilder(@NotNull final Mqtt5Publish publish) {
         super(publish);
-        parentConsumer = null;
         if (publish instanceof Mqtt5WillPublish) {
             delayInterval =
                     MustNotBeImplementedUtil.checkNotImplemented(publish, MqttWillPublish.class).getDelayInterval();
@@ -189,12 +192,6 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
         Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayInterval));
         this.delayInterval = delayInterval;
         return this;
-    }
-
-    @NotNull
-    @Override
-    public P done() {
-        return done(build(), parentConsumer);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
@@ -40,11 +41,11 @@ import static org.mqttbee.mqtt.message.publish.MqttWillPublish.DEFAULT_DELAY_INT
  */
 public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
 
-    private final Function<Mqtt5WillPublish, P> parentConsumer;
+    private final Function<? super Mqtt5WillPublish, P> parentConsumer;
 
     private long delayInterval = DEFAULT_DELAY_INTERVAL;
 
-    public Mqtt5WillPublishBuilder(@Nullable final Function<Mqtt5WillPublish, P> parentConsumer) {
+    public Mqtt5WillPublishBuilder(@Nullable final Function<? super Mqtt5WillPublish, P> parentConsumer) {
         super((Function<Mqtt5Publish, P>) null);
         this.parentConsumer = parentConsumer;
     }
@@ -70,6 +71,12 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     public Mqtt5WillPublishBuilder<P> topic(@NotNull final MqttTopic topic) {
         super.topic(topic);
         return this;
+    }
+
+    @NotNull
+    @Override
+    public MqttTopicBuilder<? extends Mqtt5WillPublishBuilder<P>> topic() {
+        return new MqttTopicBuilder<>("", this::topic);
     }
 
     @NotNull
@@ -135,6 +142,12 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     public Mqtt5WillPublishBuilder<P> responseTopic(@Nullable final MqttTopic responseTopic) {
         super.responseTopic(responseTopic);
         return this;
+    }
+
+    @NotNull
+    @Override
+    public MqttTopicBuilder<? extends Mqtt5WillPublishBuilder<P>> responseTopic() {
+        return new MqttTopicBuilder<>("", this::responseTopic);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
@@ -24,6 +24,8 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 
+import java.util.function.Function;
+
 /**
  * MQTT 5 SUBSCRIBE packet.
  *
@@ -33,8 +35,13 @@ import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 public interface Mqtt5Subscribe extends Mqtt5Message {
 
     @NotNull
-    static Mqtt5SubscribeBuilder builder() {
-        return new Mqtt5SubscribeBuilder();
+    static Mqtt5SubscribeBuilder<Void> builder() {
+        return new Mqtt5SubscribeBuilder<>((Function<Mqtt5Subscribe, Void>) null);
+    }
+
+    @NotNull
+    static Mqtt5SubscribeBuilder<Void> extend(@NotNull final Mqtt5Subscribe subscribe) {
+        return new Mqtt5SubscribeBuilder<>(subscribe);
     }
 
     /**
@@ -54,6 +61,5 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
     default Mqtt5MessageType getType() {
         return Mqtt5MessageType.SUBSCRIBE;
     }
-
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -61,7 +61,7 @@ public class Mqtt5SubscribeBuilder<P> extends FluentBuilder<Mqtt5Subscribe, P> {
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder<Mqtt5SubscribeBuilder<P>> addSubscription() {
+    public Mqtt5SubscriptionBuilder<? extends Mqtt5SubscribeBuilder<P>> addSubscription() {
         return new Mqtt5SubscriptionBuilder<>(this::addSubscription);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
@@ -68,6 +69,11 @@ public class Mqtt5SubscribeBuilder<P> extends FluentBuilder<Mqtt5Subscribe, P> {
     public Mqtt5SubscribeBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<? extends Mqtt5SubscribeBuilder<P>> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -20,37 +20,58 @@ package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5SubscribeBuilder {
+public class Mqtt5SubscribeBuilder<P> extends FluentBuilder<Mqtt5Subscribe, P> {
 
-    private final ImmutableList.Builder<MqttSubscription> subscriptionBuilder = ImmutableList.builder();
+    private final ImmutableList.Builder<MqttSubscription> subscriptionBuilder;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    Mqtt5SubscribeBuilder() {
+    public Mqtt5SubscribeBuilder(@Nullable final Function<Mqtt5Subscribe, P> parentConsumer) {
+        super(parentConsumer);
+        subscriptionBuilder = ImmutableList.builder();
+    }
+
+    Mqtt5SubscribeBuilder(@NotNull final Mqtt5Subscribe subscribe) {
+        super(null);
+        final MqttSubscribe subscribeImpl =
+                MustNotBeImplementedUtil.checkNotImplemented(subscribe, MqttSubscribe.class);
+        final ImmutableList<MqttSubscription> subscriptions = subscribeImpl.getSubscriptions();
+        subscriptionBuilder = ImmutableList.builderWithExpectedSize(subscriptions.size() + 1);
+        subscriptionBuilder.addAll(subscriptions);
     }
 
     @NotNull
-    public Mqtt5SubscribeBuilder addSubscription(@NotNull final Mqtt5Subscription subscription) {
+    public Mqtt5SubscribeBuilder<P> addSubscription(@NotNull final Mqtt5Subscription subscription) {
         subscriptionBuilder.add(MustNotBeImplementedUtil.checkNotImplemented(subscription, MqttSubscription.class));
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscribeBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5SubscriptionBuilder<Mqtt5SubscribeBuilder<P>> addSubscription() {
+        return new Mqtt5SubscriptionBuilder<>(this::addSubscription);
+    }
+
+    @NotNull
+    public Mqtt5SubscribeBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5Subscribe build() {
         final ImmutableList<MqttSubscription> subscriptions = subscriptionBuilder.build();
         Preconditions.checkState(!subscriptions.isEmpty());

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscribeBuilder.java
@@ -40,7 +40,7 @@ public class Mqtt5SubscribeBuilder<P> extends FluentBuilder<Mqtt5Subscribe, P> {
     private final ImmutableList.Builder<MqttSubscription> subscriptionBuilder;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    public Mqtt5SubscribeBuilder(@Nullable final Function<Mqtt5Subscribe, P> parentConsumer) {
+    public Mqtt5SubscribeBuilder(@Nullable final Function<? super Mqtt5Subscribe, P> parentConsumer) {
         super(parentConsumer);
         subscriptionBuilder = ImmutableList.builder();
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscription.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscription.java
@@ -45,8 +45,8 @@ public interface Mqtt5Subscription {
     boolean DEFAULT_RETAIN_AS_PUBLISHED = false;
 
     @NotNull
-    static Mqtt5SubscriptionBuilder builder() {
-        return new Mqtt5SubscriptionBuilder();
+    static Mqtt5SubscriptionBuilder<Void> builder() {
+        return new Mqtt5SubscriptionBuilder<>(null);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -19,16 +19,20 @@ package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5SubscriptionBuilder {
+public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription, P> {
 
     private MqttTopicFilterImpl topicFilter;
     private MqttQoS qos;
@@ -36,46 +40,48 @@ public class Mqtt5SubscriptionBuilder {
     private Mqtt5RetainHandling retainHandling = Mqtt5Subscription.DEFAULT_RETAIN_HANDLING;
     private boolean retainAsPublished = Mqtt5Subscription.DEFAULT_RETAIN_AS_PUBLISHED;
 
-    Mqtt5SubscriptionBuilder() {
+    public Mqtt5SubscriptionBuilder(@Nullable final Function<Mqtt5Subscription, P> parentConsumer) {
+        super(parentConsumer);
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder topicFilter(@NotNull final String topicFilter) {
+    public Mqtt5SubscriptionBuilder<P> topicFilter(@NotNull final String topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder topicFilter(@NotNull final MqttTopicFilter topicFilter) {
+    public Mqtt5SubscriptionBuilder<P> topicFilter(@NotNull final MqttTopicFilter topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder qos(@NotNull final MqttQoS qos) {
+    public Mqtt5SubscriptionBuilder<P> qos(@NotNull final MqttQoS qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder noLocal(final boolean noLocal) {
+    public Mqtt5SubscriptionBuilder<P> noLocal(final boolean noLocal) {
         this.noLocal = noLocal;
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder retainHandling(@NotNull final Mqtt5RetainHandling retainHandling) {
+    public Mqtt5SubscriptionBuilder<P> retainHandling(@NotNull final Mqtt5RetainHandling retainHandling) {
         this.retainHandling = Preconditions.checkNotNull(retainHandling);
         return this;
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder retainAsPublished(final boolean retainAsPublished) {
+    public Mqtt5SubscriptionBuilder<P> retainAsPublished(final boolean retainAsPublished) {
         this.retainAsPublished = retainAsPublished;
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5Subscription build() {
         Preconditions.checkNotNull(topicFilter);
         Preconditions.checkNotNull(qos);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
@@ -40,7 +41,7 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
     private Mqtt5RetainHandling retainHandling = Mqtt5Subscription.DEFAULT_RETAIN_HANDLING;
     private boolean retainAsPublished = Mqtt5Subscription.DEFAULT_RETAIN_AS_PUBLISHED;
 
-    public Mqtt5SubscriptionBuilder(@Nullable final Function<Mqtt5Subscription, P> parentConsumer) {
+    public Mqtt5SubscriptionBuilder(@Nullable final Function<? super Mqtt5Subscription, P> parentConsumer) {
         super(parentConsumer);
     }
 
@@ -54,6 +55,11 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
     public Mqtt5SubscriptionBuilder<P> topicFilter(@NotNull final MqttTopicFilter topicFilter) {
         this.topicFilter = MqttBuilderUtil.topicFilter(topicFilter);
         return this;
+    }
+
+    @NotNull
+    public MqttTopicFilterBuilder<? extends Mqtt5SubscriptionBuilder<P>> topicFilter() {
+        return new MqttTopicFilterBuilder<>("", this::topicFilter);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
@@ -25,6 +25,8 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 
+import java.util.function.Function;
+
 /**
  * MQTT 5 UNSUBSCRIBE packet.
  *
@@ -34,8 +36,13 @@ import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 public interface Mqtt5Unsubscribe extends Mqtt5Message {
 
     @NotNull
-    static Mqtt5UnsubscribeBuilder build() {
-        return new Mqtt5UnsubscribeBuilder();
+    static Mqtt5UnsubscribeBuilder<Void> build() {
+        return new Mqtt5UnsubscribeBuilder<>((Function<Mqtt5Unsubscribe, Void>) null);
+    }
+
+    @NotNull
+    static Mqtt5UnsubscribeBuilder<Void> extend(@NotNull final Mqtt5Unsubscribe unsubscribe) {
+        return new Mqtt5UnsubscribeBuilder<>(unsubscribe);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -20,6 +20,7 @@ package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
@@ -28,32 +29,47 @@ import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
 import org.mqttbee.mqtt.util.MqttBuilderUtil;
+import org.mqttbee.util.FluentBuilder;
+import org.mqttbee.util.MustNotBeImplementedUtil;
+
+import java.util.function.Function;
 
 /**
  * @author Silvio Giebl
  */
-public class Mqtt5UnsubscribeBuilder {
+public class Mqtt5UnsubscribeBuilder<P> extends FluentBuilder<Mqtt5Unsubscribe, P> {
 
-    private final ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder = ImmutableList.builder();
+    private final ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    Mqtt5UnsubscribeBuilder() {
+    public Mqtt5UnsubscribeBuilder(@Nullable final Function<Mqtt5Unsubscribe, P> parentConsumer) {
+        super(parentConsumer);
+        topicFiltersBuilder = ImmutableList.builder();
+    }
+
+    Mqtt5UnsubscribeBuilder(@NotNull final Mqtt5Unsubscribe unsubscribe) {
+        super(null);
+        final MqttUnsubscribe unsubscribeImpl =
+                MustNotBeImplementedUtil.checkNotImplemented(unsubscribe, MqttUnsubscribe.class);
+        final ImmutableList<MqttTopicFilterImpl> topicFilters = unsubscribeImpl.getTopicFilters();
+        topicFiltersBuilder = ImmutableList.builderWithExpectedSize(topicFilters.size() + 1);
+        topicFiltersBuilder.addAll(topicFilters);
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder addTopicFilter(@NotNull final String topicFilter) {
+    public Mqtt5UnsubscribeBuilder<P> addTopicFilter(@NotNull final String topicFilter) {
         topicFiltersBuilder.add(MqttBuilderUtil.topicFilter(topicFilter));
         return this;
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder addTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
+    public Mqtt5UnsubscribeBuilder<P> addTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
         topicFiltersBuilder.add(MqttBuilderUtil.topicFilter(topicFilter));
         return this;
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder reverse(@NotNull final Mqtt5Subscribe subscribe) {
+    public Mqtt5UnsubscribeBuilder<P> reverse(@NotNull final Mqtt5Subscribe subscribe) {
         final ImmutableList<? extends Mqtt5Subscription> subscriptions = subscribe.getSubscriptions();
         for (final Mqtt5Subscription subscription : subscriptions) {
             addTopicFilter(subscription.getTopicFilter());
@@ -62,12 +78,13 @@ public class Mqtt5UnsubscribeBuilder {
     }
 
     @NotNull
-    public Mqtt5UnsubscribeBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
+    public Mqtt5UnsubscribeBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
     }
 
     @NotNull
+    @Override
     public Mqtt5Unsubscribe build() {
         final ImmutableList<MqttTopicFilterImpl> topicFilters = topicFiltersBuilder.build();
         Preconditions.checkState(!topicFilters.isEmpty());

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -23,6 +23,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -81,6 +82,11 @@ public class Mqtt5UnsubscribeBuilder<P> extends FluentBuilder<Mqtt5Unsubscribe, 
     public Mqtt5UnsubscribeBuilder<P> userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
+    }
+
+    @NotNull
+    public Mqtt5UserPropertiesBuilder<? extends Mqtt5UnsubscribeBuilder<P>> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5UnsubscribeBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
@@ -43,7 +44,7 @@ public class Mqtt5UnsubscribeBuilder<P> extends FluentBuilder<Mqtt5Unsubscribe, 
     private final ImmutableList.Builder<MqttTopicFilterImpl> topicFiltersBuilder;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
-    public Mqtt5UnsubscribeBuilder(@Nullable final Function<Mqtt5Unsubscribe, P> parentConsumer) {
+    public Mqtt5UnsubscribeBuilder(@Nullable final Function<? super Mqtt5Unsubscribe, P> parentConsumer) {
         super(parentConsumer);
         topicFiltersBuilder = ImmutableList.builder();
     }
@@ -67,6 +68,11 @@ public class Mqtt5UnsubscribeBuilder<P> extends FluentBuilder<Mqtt5Unsubscribe, 
     public Mqtt5UnsubscribeBuilder<P> addTopicFilter(@NotNull final MqttTopicFilter topicFilter) {
         topicFiltersBuilder.add(MqttBuilderUtil.topicFilter(topicFilter));
         return this;
+    }
+
+    @NotNull
+    public MqttTopicFilterBuilder<? extends Mqtt5UnsubscribeBuilder<P>> addTopicFilter() {
+        return new MqttTopicFilterBuilder<>("", this::addTopicFilter);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
@@ -22,6 +22,7 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5AuthBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5AuthReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
@@ -83,6 +84,12 @@ public class MqttAuthBuilder implements Mqtt5AuthBuilder {
     public MqttAuthBuilder userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         this.userProperties = MqttBuilderUtil.userProperties(userProperties);
         return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5UserPropertiesBuilder<? extends MqttAuthBuilder> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
@@ -110,8 +110,8 @@ public class MqttBuilderUtil {
         final MqttSharedTopicFilterImpl sharedTopicFilter = MqttSharedTopicFilterImpl.from(shareName, topicFilter);
         if (sharedTopicFilter == null) {
             throw new IllegalArgumentException(
-                    "The string: [" + MqttSharedTopicFilter.SHARE_PREFIX + shareName + topicFilter +
-                            "] is not a valid Shared Topic Filter.");
+                    "The string: [" + MqttSharedTopicFilter.SHARE_PREFIX + shareName + MqttTopic.TOPIC_LEVEL_SEPARATOR +
+                            topicFilter + "] is not a valid Shared Topic Filter.");
         }
         return sharedTopicFilter;
     }
@@ -153,6 +153,18 @@ public class MqttBuilderUtil {
     @NotNull
     public static MqttUserPropertiesImpl userProperties(@NotNull final Mqtt5UserProperties userProperties) {
         return MustNotBeImplementedUtil.checkNotImplemented(userProperties, MqttUserPropertiesImpl.class);
+    }
+
+    @NotNull
+    public static MqttUserPropertyImpl userProperty(@NotNull final String name, @NotNull final String value) {
+        return MqttUserPropertyImpl.of(string(name), string(value));
+    }
+
+    @NotNull
+    public static MqttUserPropertyImpl userProperty(
+            @NotNull final MqttUTF8String name, @NotNull final MqttUTF8String value) {
+
+        return MqttUserPropertyImpl.of(string(name), string(value));
     }
 
 }

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -23,6 +23,13 @@ import org.mqttbee.annotations.Nullable;
 import java.util.function.Function;
 
 /**
+ * Base class for builders that implement a fluent builder API.
+ * <p>
+ * A fluent builder knows its parent builder method that consumes the object the builder creates.
+ * Calling {@link #done()} creates the builder's object and hands it over to its parent builder method.
+ *
+ * @param <B> the type of the object the builder creates when {@link #build()} is called
+ * @param <P> the type of the parent builder
  * @author Silvio Giebl
  */
 public abstract class FluentBuilder<B, P> {
@@ -41,11 +48,22 @@ public abstract class FluentBuilder<B, P> {
         this.parentConsumer = parentConsumer;
     }
 
+    /**
+     * Creates the builder's object and hands it over to its parent builder method.
+     * This method must not be called on the root of a fluent builder. Consider calling {@link #build()} instead.
+     *
+     * @return the parent builder.
+     */
     @NotNull
     public P done() {
         return done(build(), parentConsumer);
     }
 
+    /**
+     * Creates this builder's object.
+     *
+     * @return the created object.
+     */
     @NotNull
     public abstract B build();
 

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -35,9 +35,9 @@ public abstract class FluentBuilder<B, P> {
         return parentConsumer.apply(built);
     }
 
-    private final Function<B, P> parentConsumer;
+    protected final Function<? super B, P> parentConsumer;
 
-    protected FluentBuilder(@Nullable final Function<B, P> parentConsumer) {
+    protected FluentBuilder(@Nullable final Function<? super B, P> parentConsumer) {
         this.parentConsumer = parentConsumer;
     }
 

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -34,14 +34,6 @@ import java.util.function.Function;
  */
 public abstract class FluentBuilder<B, P> {
 
-    @NotNull
-    protected static <B, P> P done(@NotNull final B built, @Nullable final Function<B, P> parentConsumer) {
-        if (parentConsumer == null) {
-            throw new IllegalStateException("done must not be called on the root of a fluent builder");
-        }
-        return parentConsumer.apply(built);
-    }
-
     protected final Function<? super B, P> parentConsumer;
 
     protected FluentBuilder(@Nullable final Function<? super B, P> parentConsumer) {
@@ -57,7 +49,10 @@ public abstract class FluentBuilder<B, P> {
      */
     @NotNull
     public P done() {
-        return done(build(), parentConsumer);
+        if (parentConsumer == null) {
+            throw new IllegalStateException("done must not be called on the root of a fluent builder");
+        }
+        return parentConsumer.apply(build());
     }
 
     /**

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -27,6 +27,14 @@ import java.util.function.Function;
  */
 public abstract class FluentBuilder<B, P> {
 
+    @NotNull
+    protected static <B, P> P done(@NotNull final B built, @Nullable final Function<B, P> parentConsumer) {
+        if (parentConsumer == null) {
+            throw new IllegalStateException("done must not be called on the root of a fluent builder");
+        }
+        return parentConsumer.apply(built);
+    }
+
     private final Function<B, P> parentConsumer;
 
     protected FluentBuilder(@Nullable final Function<B, P> parentConsumer) {
@@ -35,10 +43,7 @@ public abstract class FluentBuilder<B, P> {
 
     @NotNull
     public P done() {
-        if (parentConsumer == null) {
-            throw new IllegalStateException("done must not be called on the root of a fluent builder");
-        }
-        return parentConsumer.apply(build());
+        return done(build(), parentConsumer);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -15,36 +15,33 @@
  *
  */
 
-package org.mqttbee.api.mqtt.mqtt3.message.auth;
+package org.mqttbee.util;
 
-import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
+import org.mqttbee.annotations.Nullable;
 
-import java.nio.ByteBuffer;
-import java.util.Optional;
+import java.util.function.Function;
 
 /**
- * Simple authentication and/or authorization related data in the MQTT 3 CONNECT packet.
+ * @author Silvio Giebl
  */
-@DoNotImplement
-public interface Mqtt3SimpleAuth {
+public abstract class FluentBuilder<B, P> {
 
-    @NotNull
-    static Mqtt3SimpleAuthBuilder<Void> builder() {
-        return new Mqtt3SimpleAuthBuilder<>(null);
+    private final Function<B, P> parentConsumer;
+
+    protected FluentBuilder(@Nullable final Function<B, P> parentConsumer) {
+        this.parentConsumer = parentConsumer;
     }
 
-    /**
-     * @return the username.
-     */
     @NotNull
-    MqttUTF8String getUsername();
+    public P done() {
+        if (parentConsumer == null) {
+            throw new IllegalStateException("done must not be called on the root of a fluent builder");
+        }
+        return parentConsumer.apply(build());
+    }
 
-    /**
-     * @return the optional password.
-     */
     @NotNull
-    Optional<ByteBuffer> getPassword();
+    public abstract B build();
 
 }

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -50,7 +50,8 @@ public abstract class FluentBuilder<B, P> {
     @NotNull
     public P done() {
         if (parentConsumer == null) {
-            throw new IllegalStateException("done must not be called on the root of a fluent builder");
+            throw new IllegalStateException(
+                    "done must not be called on the root of a fluent builder, consider calling build() instead");
         }
         return parentConsumer.apply(build());
     }

--- a/src/main/java/org/mqttbee/util/FluentBuilder.java
+++ b/src/main/java/org/mqttbee/util/FluentBuilder.java
@@ -25,8 +25,8 @@ import java.util.function.Function;
 /**
  * Base class for builders that implement a fluent builder API.
  * <p>
- * A fluent builder knows its parent builder method that consumes the object the builder creates.
- * Calling {@link #done()} creates the builder's object and hands it over to its parent builder method.
+ * A fluent builder knows its parent builder method that consumes the object the builder creates. Calling {@link
+ * #done()} creates the builder's object and hands it over to its parent builder method.
  *
  * @param <B> the type of the object the builder creates when {@link #build()} is called
  * @param <P> the type of the parent builder
@@ -50,6 +50,7 @@ public abstract class FluentBuilder<B, P> {
 
     /**
      * Creates the builder's object and hands it over to its parent builder method.
+     * <p>
      * This method must not be called on the root of a fluent builder. Consider calling {@link #build()} instead.
      *
      * @return the parent builder.


### PR DESCRIPTION
**Motivation**
Make writing of MQTT message builders more fluent and simpler with nested builders while still remaining the opportunity to pass already built objects.

**Changes**
- Added FluentBuilder
- Extended FluentBuilder in builders for:
  - MQTT messages (3 & 5)
  - Topic, TopicFilter/SharedTopicFilter
  - UserProperties
  - Ssl/Websocket/ExecutorConfig
- Added fluent builder methods (simpleAuth, restrictions, willPublish, addSubscription, addTopicFilter, topic, topicFilter, userProperties, useSsl, useWebsocket, executorConfig)