### PR TITLE
Feature/keepalive with timeunit

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
@@ -48,7 +48,7 @@ public interface Mqtt3Connect extends Mqtt3Message {
     }
 
     /**
-     * @return the keep alive the client wants to use.
+     * @return the keep alive in seconds the client wants to use.
      */
     int getKeepAlive();
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -17,6 +17,7 @@
 
 package org.mqttbee.api.mqtt.mqtt3.message.connect;
 
+import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
@@ -30,7 +31,9 @@ import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 import org.mqttbee.mqtt.message.publish.mqtt3.Mqtt3PublishView;
 import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
+import org.mqttbee.util.UnsignedDataTypes;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -38,7 +41,7 @@ import java.util.function.Function;
  */
 public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
 
-    private int keepAlive = Mqtt3Connect.DEFAULT_KEEP_ALIVE;
+    private int keepAliveSeconds = Mqtt3Connect.DEFAULT_KEEP_ALIVE;
     private boolean isCleanSession = Mqtt3Connect.DEFAULT_CLEAN_SESSION;
     private MqttSimpleAuth simpleAuth;
     private MqttWillPublish willPublish;
@@ -51,15 +54,17 @@ public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
         super(null);
         final Mqtt3ConnectView connectView =
                 MustNotBeImplementedUtil.checkNotImplemented(connect, Mqtt3ConnectView.class);
-        keepAlive = connectView.getKeepAlive();
+        keepAliveSeconds = connectView.getKeepAlive();
         isCleanSession = connectView.isCleanSession();
         simpleAuth = connectView.getDelegate().getRawSimpleAuth();
         willPublish = connectView.getDelegate().getRawWillPublish();
     }
 
     @NotNull
-    public Mqtt3ConnectBuilder<P> keepAlive(final int keepAlive) {
-        this.keepAlive = keepAlive;
+    public Mqtt3ConnectBuilder<P> keepAlive(final int keepAlive, @NotNull final TimeUnit timeUnit) {
+        final long keepAliveSeconds = timeUnit.toSeconds(keepAlive);
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAliveSeconds));
+        this.keepAliveSeconds = (int) keepAliveSeconds;
         return this;
     }
 
@@ -98,7 +103,7 @@ public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
     @NotNull
     @Override
     public Mqtt3Connect build() {
-        return Mqtt3ConnectView.of(keepAlive, isCleanSession, simpleAuth, willPublish);
+        return Mqtt3ConnectView.of(keepAliveSeconds, isCleanSession, simpleAuth, willPublish);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
@@ -57,7 +57,7 @@ public interface Mqtt5Connect extends Mqtt5Message {
     }
 
     /**
-     * @return the keep alive the client wants to use.
+     * @return the keep alive in seconds the client wants to use.
      */
     int getKeepAlive();
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
@@ -67,7 +67,7 @@ public interface Mqtt5Connect extends Mqtt5Message {
     boolean isCleanStart();
 
     /**
-     * @return the session expiry interval the client wants to use. The default is {@link
+     * @return the session expiry interval in seconds the client wants to use. The default is {@link
      * #DEFAULT_SESSION_EXPIRY_INTERVAL}. If it is {@link #NO_SESSION_EXPIRY} the session does not expire.
      */
     long getSessionExpiryInterval();

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -37,13 +37,14 @@ import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.MustNotBeImplementedUtil;
 import org.mqttbee.util.UnsignedDataTypes;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect.*;
 
 public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
 
-    private int keepAlive = DEFAULT_KEEP_ALIVE;
+    private int keepAliveSeconds = DEFAULT_KEEP_ALIVE;
     private boolean isCleanStart = DEFAULT_CLEAN_START;
     private long sessionExpiryInterval = DEFAULT_SESSION_EXPIRY_INTERVAL;
     private boolean isResponseInformationRequested = DEFAULT_RESPONSE_INFORMATION_REQUESTED;
@@ -61,7 +62,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     Mqtt5ConnectBuilder(@NotNull final Mqtt5Connect connect) {
         super(null);
         final MqttConnect connectImpl = MustNotBeImplementedUtil.checkNotImplemented(connect, MqttConnect.class);
-        keepAlive = connectImpl.getKeepAlive();
+        keepAliveSeconds = connectImpl.getKeepAlive();
         isCleanStart = connectImpl.isCleanStart();
         sessionExpiryInterval = connectImpl.getSessionExpiryInterval();
         isResponseInformationRequested = connectImpl.isResponseInformationRequested();
@@ -74,9 +75,10 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder<P> keepAlive(final int keepAlive) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAlive));
-        this.keepAlive = keepAlive;
+    public Mqtt5ConnectBuilder<P> keepAlive(final int keepAlive, @NotNull final TimeUnit timeUnit) {
+        final long keepAliveSeconds = timeUnit.toSeconds(keepAlive);
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAliveSeconds));
+        this.keepAliveSeconds = (int) keepAliveSeconds;
         return this;
     }
 
@@ -158,7 +160,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     @NotNull
     @Override
     public Mqtt5Connect build() {
-        return new MqttConnect(keepAlive, isCleanStart, sessionExpiryInterval, isResponseInformationRequested,
+        return new MqttConnect(keepAliveSeconds, isCleanStart, sessionExpiryInterval, isResponseInformationRequested,
                 isProblemInformationRequested, restrictions, simpleAuth, enhancedAuthProvider, willPublish,
                 userProperties);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -46,7 +46,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
 
     private int keepAliveSeconds = DEFAULT_KEEP_ALIVE;
     private boolean isCleanStart = DEFAULT_CLEAN_START;
-    private long sessionExpiryInterval = DEFAULT_SESSION_EXPIRY_INTERVAL;
+    private long sessionExpiryIntervalSeconds = DEFAULT_SESSION_EXPIRY_INTERVAL;
     private boolean isResponseInformationRequested = DEFAULT_RESPONSE_INFORMATION_REQUESTED;
     private boolean isProblemInformationRequested = DEFAULT_PROBLEM_INFORMATION_REQUESTED;
     private MqttConnectRestrictions restrictions = MqttConnectRestrictions.DEFAULT;
@@ -64,7 +64,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
         final MqttConnect connectImpl = MustNotBeImplementedUtil.checkNotImplemented(connect, MqttConnect.class);
         keepAliveSeconds = connectImpl.getKeepAlive();
         isCleanStart = connectImpl.isCleanStart();
-        sessionExpiryInterval = connectImpl.getSessionExpiryInterval();
+        sessionExpiryIntervalSeconds = connectImpl.getSessionExpiryInterval();
         isResponseInformationRequested = connectImpl.isResponseInformationRequested();
         isProblemInformationRequested = connectImpl.isProblemInformationRequested();
         restrictions = connectImpl.getRestrictions();
@@ -89,9 +89,10 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     }
 
     @NotNull
-    public Mqtt5ConnectBuilder<P> sessionExpiryInterval(final long sessionExpiryInterval) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryInterval));
-        this.sessionExpiryInterval = sessionExpiryInterval;
+    public Mqtt5ConnectBuilder<P> sessionExpiryInterval(final long sessionExpiryInterval, @NotNull final TimeUnit timeUnit) {
+        final long sessionExpiryIntervalSeconds = timeUnit.toSeconds(sessionExpiryInterval);
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryIntervalSeconds));
+        this.sessionExpiryIntervalSeconds = sessionExpiryIntervalSeconds;
         return this;
     }
 
@@ -160,7 +161,7 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     @NotNull
     @Override
     public Mqtt5Connect build() {
-        return new MqttConnect(keepAliveSeconds, isCleanStart, sessionExpiryInterval, isResponseInformationRequested,
+        return new MqttConnect(keepAliveSeconds, isCleanStart, sessionExpiryIntervalSeconds, isResponseInformationRequested,
                 isProblemInformationRequested, restrictions, simpleAuth, enhancedAuthProvider, willPublish,
                 userProperties);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
@@ -46,7 +46,7 @@ public interface Mqtt5Disconnect extends Mqtt5Message {
     Mqtt5DisconnectReasonCode getReasonCode();
 
     /**
-     * @return the optional expiry interval for the session, the client disconnects from with this DISCONNECT packet.
+     * @return the optional expiry interval for the session in seconds, the client disconnects from with this DISCONNECT packet.
      */
     @NotNull
     Optional<Long> getSessionExpiryInterval();

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
@@ -46,7 +46,7 @@ public interface Mqtt5Disconnect extends Mqtt5Message {
     Mqtt5DisconnectReasonCode getReasonCode();
 
     /**
-     * @return the optional expiry interval for the session in seconds, the client disconnects from with this DISCONNECT packet.
+     * @return the optional session expiry interval in seconds, the client disconnects from with this DISCONNECT packet.
      */
     @NotNull
     Optional<Long> getSessionExpiryInterval();

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -30,6 +30,7 @@ import org.mqttbee.mqtt.util.MqttBuilderUtil;
 import org.mqttbee.util.FluentBuilder;
 import org.mqttbee.util.UnsignedDataTypes;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE;
@@ -41,7 +42,7 @@ import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReaso
 public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P> {
 
     private boolean withWillMessage = false;
-    private long sessionExpiryInterval = MqttDisconnect.SESSION_EXPIRY_INTERVAL_FROM_CONNECT;
+    private long sessionExpiryIntervalSeconds = MqttDisconnect.SESSION_EXPIRY_INTERVAL_FROM_CONNECT;
     private MqttUTF8StringImpl serverReference;
     private MqttUTF8StringImpl reasonString;
     private MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.NO_USER_PROPERTIES;
@@ -57,9 +58,10 @@ public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P>
     }
 
     @NotNull
-    public Mqtt5DisconnectBuilder<P> sessionExpiryInterval(final long sessionExpiryInterval) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryInterval));
-        this.sessionExpiryInterval = sessionExpiryInterval;
+    public Mqtt5DisconnectBuilder<P> sessionExpiryInterval(final long sessionExpiryInterval, @NotNull final  TimeUnit timeUnit) {
+        final long sessionExpiryIntervalSeconds = timeUnit.toSeconds(sessionExpiryInterval);
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryIntervalSeconds));
+        this.sessionExpiryIntervalSeconds = sessionExpiryIntervalSeconds;
         return this;
     }
 
@@ -103,7 +105,7 @@ public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P>
     public Mqtt5Disconnect build() {
         final Mqtt5DisconnectReasonCode reasonCode =
                 withWillMessage ? DISCONNECT_WITH_WILL_MESSAGE : NORMAL_DISCONNECTION;
-        return new MqttDisconnect(reasonCode, sessionExpiryInterval, serverReference, reasonString, userProperties);
+        return new MqttDisconnect(reasonCode, sessionExpiryIntervalSeconds, serverReference, reasonString, userProperties);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -85,7 +85,7 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
     boolean isRetain();
 
     /**
-     * @return the optional message expiry interval of this PUBLISH packet.
+     * @return the optional message expiry interval in seconds of this PUBLISH packet.
      */
     @NotNull
     Optional<Long> getMessageExpiryInterval();

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -37,6 +37,7 @@ import org.mqttbee.util.MustNotBeImplementedUtil;
 import org.mqttbee.util.UnsignedDataTypes;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.mqttbee.mqtt.message.publish.MqttPublish.DEFAULT_TOPIC_ALIAS_USAGE;
@@ -51,7 +52,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     ByteBuffer payload;
     MqttQoS qos;
     boolean retain;
-    long messageExpiryInterval = MESSAGE_EXPIRY_INTERVAL_INFINITY;
+    long messageExpiryIntervalSeconds = MESSAGE_EXPIRY_INTERVAL_INFINITY;
     Mqtt5PayloadFormatIndicator payloadFormatIndicator;
     MqttUTF8StringImpl contentType;
     MqttTopicImpl responseTopic;
@@ -70,7 +71,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
         payload = publishImpl.getRawPayload();
         qos = publishImpl.getQos();
         retain = publishImpl.isRetain();
-        messageExpiryInterval = publishImpl.getRawMessageExpiryInterval();
+        messageExpiryIntervalSeconds = publishImpl.getRawMessageExpiryInterval();
         payloadFormatIndicator = publishImpl.getRawPayloadFormatIndicator();
         contentType = publishImpl.getRawContentType();
         responseTopic = publishImpl.getRawResponseTopic();
@@ -121,9 +122,10 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder<P> messageExpiryInterval(final long messageExpiryInterval) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(messageExpiryInterval));
-        this.messageExpiryInterval = messageExpiryInterval;
+    public Mqtt5PublishBuilder<P> messageExpiryInterval(final long messageExpiryInterval, @NotNull final TimeUnit timeUnit) {
+        final long messageExpiryIntervalSeconds = timeUnit.toSeconds(messageExpiryInterval);
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(messageExpiryIntervalSeconds));
+        this.messageExpiryIntervalSeconds = messageExpiryIntervalSeconds;
         return this;
     }
 
@@ -199,7 +201,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     public Mqtt5Publish build() {
         Preconditions.checkNotNull(topic);
         Preconditions.checkNotNull(qos);
-        return new MqttPublish(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator, contentType,
+        return new MqttPublish(topic, payload, qos, retain, messageExpiryIntervalSeconds, payloadFormatIndicator, contentType,
                 responseTopic, correlationData, topicAliasUsage, userProperties);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -200,7 +200,7 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     public Mqtt5WillPublish build() {
         Preconditions.checkNotNull(topic);
         Preconditions.checkNotNull(qos);
-        return new MqttWillPublish(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator,
+        return new MqttWillPublish(topic, payload, qos, retain, messageExpiryIntervalSeconds, payloadFormatIndicator,
                 contentType, responseTopic, correlationData, userProperties, delayInterval);
     }
 

--- a/src/main/java/org/mqttbee/util/UnsignedDataTypes.java
+++ b/src/main/java/org/mqttbee/util/UnsignedDataTypes.java
@@ -25,10 +25,6 @@ public class UnsignedDataTypes {
     public static final int UNSIGNED_SHORT_MAX_VALUE = 0xFFFF;
     public static final long UNSIGNED_INT_MAX_VALUE = 0xFFFF_FFFFL;
 
-    public static boolean isUnsignedShort(final int value) {
-        return isUnsignedShort((long) value);
-    }
-
     public static boolean isUnsignedShort(final long value) {
         return (value >= 0) && (value <= UNSIGNED_SHORT_MAX_VALUE);
     }

--- a/src/main/java/org/mqttbee/util/UnsignedDataTypes.java
+++ b/src/main/java/org/mqttbee/util/UnsignedDataTypes.java
@@ -26,6 +26,10 @@ public class UnsignedDataTypes {
     public static final long UNSIGNED_INT_MAX_VALUE = 0xFFFF_FFFFL;
 
     public static boolean isUnsignedShort(final int value) {
+        return isUnsignedShort((long) value);
+    }
+
+    public static boolean isUnsignedShort(final long value) {
         return (value >= 0) && (value <= UNSIGNED_SHORT_MAX_VALUE);
     }
 

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -46,6 +46,7 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -129,7 +130,7 @@ class Mqtt3ClientExample {
         final Mqtt3Client client = getClient();
 
         // create a CONNECT message with keep alive of 10 seconds
-        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().keepAlive(10).build();
+        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().keepAlive(10, TimeUnit.SECONDS).build();
         // define what to do on connect, this does not connect yet
         final Single<Mqtt3ConnAck> connectScenario =
                 client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected subscriber"));
@@ -175,7 +176,7 @@ class Mqtt3ClientExample {
         final Mqtt3Client client = getClient();
 
         // create a CONNECT message with keep alive of 10 seconds
-        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().keepAlive(10).build();
+        final Mqtt3Connect connectMessage = Mqtt3Connect.builder().keepAlive(10, TimeUnit.SECONDS).build();
         // define what to do on connect, this does not connect yet
         final Single<Mqtt3ConnAck> connectScenario =
                 client.connect(connectMessage).doOnSuccess(connAck -> System.out.println("connected publisher"));


### PR DESCRIPTION
**Motivation**
Use time units to avoid confusion when accepting time duration's on the API.

**Changes**
* keepAlive uses TimeUnit
* sessionExpiryInterval uses TimeUnit