### PR TITLE
Improvement/replace all remaining publishes

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/MqttGlobalPublishFlowType.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttGlobalPublishFlowType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.api.mqtt;
+
+/**
+ * Type for a global asynchronous stream (flow) of Publish messages. Global means not filtering on the subscriptions of
+ * a Subscribe message.
+ *
+ * @author Silvio Giebl
+ */
+public enum MqttGlobalPublishFlowType {
+
+    /**
+     * Type for a global flow emitting all incoming Publish messages.
+     */
+    ALL_PUBLISHES,
+
+    /**
+     * Type for a global flow emitting all incoming Publish messages which match existing subscriptions.
+     */
+    ALL_SUBSCRIPTIONS,
+
+    /**
+     * Type for a global flow emitting all incoming Publish messages that are not emitted in per subscription or global
+     * {@link #ALL_SUBSCRIPTIONS} flows.
+     */
+    REMAINING_PUBLISHES
+
+}

--- a/src/main/java/org/mqttbee/api/mqtt/MqttGlobalPublishFlowType.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttGlobalPublishFlowType.java
@@ -38,6 +38,17 @@ public enum MqttGlobalPublishFlowType {
     /**
      * Type for a global flow emitting all incoming Publish messages that are not emitted in per subscription or global
      * {@link #ALL_SUBSCRIPTIONS} flows.
+     * <p>
+     * Example (pseudo-code):
+     * <ul>
+     * <li><code>stream1 = client.subscribeWithStream("a/#")</code></li>
+     * <li><code>client.subscribe("b/#")</code></li>
+     * <li><code>stream2 = client.publishes(REMAINING_PUBLISHES)</code></li>
+     * <li>=> incoming Publish messages with topic <code>"a/b"</code> will be emitted only in
+     * <code>stream1</code>.</li>
+     * <li>=> incoming Publish messages with topic <code>"b/c"</code> or <code>"c/d"</code> will be emitted in
+     * <code>stream2</code> as there is no other stream registered for the topic.</li>
+     * </ul>
      */
     REMAINING_PUBLISHES
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
@@ -160,7 +160,8 @@ public interface Mqtt3Client extends MqttClient {
     }
 
     /**
-     * Creates a {@link Flowable} for globally consuming the Publish messages received by this client.
+     * Creates a {@link Flowable} for globally consuming all Publish messages matching the given type received by this
+     * client.
      * <p>
      * The returned {@link Flowable} represents the source of the incoming Publish messages matching the given type.
      * Calling this method does not start consuming yet. This is done lazy and asynchronous when subscribing (in terms

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3Client.java
@@ -22,6 +22,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Single;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.MqttClient;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3ConnectBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAck;
@@ -84,9 +85,9 @@ public interface Mqtt3Client extends MqttClient {
      * message. Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when
      * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
      * <p>
-     * See {@link #allPublishes()} or {@link #remainingPublishes()} to consume the Publish messages. Alternatively, call
-     * {@link #subscribeWithStream(Mqtt3Subscribe)} to consume the Publish messages matching the subscriptions of the
-     * Subscribe message directly.
+     * See {@link #publishes(MqttGlobalPublishFlowType)} to consume the Publish messages. Alternatively, call {@link
+     * #subscribeWithStream(Mqtt3Subscribe)} to consume the Publish messages matching the subscriptions of the Subscribe
+     * message directly.
      *
      * @param subscribe the Subscribe message sent to the broker during subscribe.
      * @return the {@link Single} which
@@ -158,11 +159,22 @@ public interface Mqtt3Client extends MqttClient {
         return new Mqtt3SubscribeBuilder<>(this::subscribeWithStream);
     }
 
+    /**
+     * Creates a {@link Flowable} for globally consuming the Publish messages received by this client.
+     * <p>
+     * The returned {@link Flowable} represents the source of the incoming Publish messages matching the given type.
+     * Calling this method does not start consuming yet. This is done lazy and asynchronous when subscribing (in terms
+     * of Reactive Streams) to the returned {@link Flowable}.
+     *
+     * @param type the type of the returned flow of Publish messages.
+     * @return the {@link Flowable} which
+     *         <ul>
+     *         <li>emits the incoming Publish messages matching the given type and</li>
+     *         <li>completes when this client is disconnected.</li>
+     *         </ul>
+     */
     @NotNull
-    Flowable<Mqtt3Publish> remainingPublishes();
-
-    @NotNull
-    Flowable<Mqtt3Publish> allPublishes();
+    Flowable<Mqtt3Publish> publishes(@NotNull MqttGlobalPublishFlowType type);
 
     /**
      * Creates a {@link Single} for unsubscribing this client with the given Unsubscribe message.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
@@ -22,6 +22,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Single;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.MqttClient;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5ConnectBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
@@ -87,9 +88,9 @@ public interface Mqtt5Client extends MqttClient {
      * message. Calling this method does not subscribe yet. Subscribing is performed lazy and asynchronous when
      * subscribing (in terms of Reactive Streams) to the returned {@link Single}.
      * <p>
-     * See {@link #allPublishes()} or {@link #remainingPublishes()} to consume the Publish messages. Alternatively, call
-     * {@link #subscribeWithStream(Mqtt5Subscribe)} to consume the Publish messages matching the subscriptions of the
-     * Subscribe message directly.
+     * See {@link #publishes(MqttGlobalPublishFlowType)} to consume the Publish messages. Alternatively, call {@link
+     * #subscribeWithStream(Mqtt5Subscribe)} to consume the Publish messages matching the subscriptions of the Subscribe
+     * message directly.
      *
      * @param subscribe the Subscribe message sent to the broker during subscribe.
      * @return the {@link Single} which
@@ -161,11 +162,22 @@ public interface Mqtt5Client extends MqttClient {
         return new Mqtt5SubscribeBuilder<>(this::subscribeWithStream);
     }
 
+    /**
+     * Creates a {@link Flowable} for globally consuming the Publish messages received by this client.
+     * <p>
+     * The returned {@link Flowable} represents the source of the incoming Publish messages matching the given type.
+     * Calling this method does not start consuming yet. This is done lazy and asynchronous when subscribing (in terms
+     * of Reactive Streams) to the returned {@link Flowable}.
+     *
+     * @param type the type of the returned flow of Publish messages.
+     * @return the {@link Flowable} which
+     *         <ul>
+     *         <li>emits the incoming Publish messages matching the given type and</li>
+     *         <li>completes when this client is disconnected.</li>
+     *         </ul>
+     */
     @NotNull
-    Flowable<Mqtt5Publish> remainingPublishes();
-
-    @NotNull
-    Flowable<Mqtt5Publish> allPublishes();
+    Flowable<Mqtt5Publish> publishes(@NotNull MqttGlobalPublishFlowType type);
 
     /**
      * Creates a {@link Single} for unsubscribing this client with the given Unsubscribe message.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5Client.java
@@ -163,7 +163,8 @@ public interface Mqtt5Client extends MqttClient {
     }
 
     /**
-     * Creates a {@link Flowable} for globally consuming the Publish messages received by this client.
+     * Creates a {@link Flowable} for globally consuming all Publish messages matching the given type received by this
+     * client.
      * <p>
      * The returned {@link Flowable} represents the source of the incoming Publish messages matching the given type.
      * Calling this method does not start consuming yet. This is done lazy and asynchronous when subscribing (in terms

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
@@ -18,6 +18,7 @@
 package org.mqttbee.mqtt.handler.publish;
 
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import org.mqttbee.util.collections.ScNodeList;
 import org.reactivestreams.Subscriber;
@@ -27,17 +28,13 @@ import org.reactivestreams.Subscriber;
  */
 public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subscriber<? super Mqtt5Publish>> {
 
-    public static final int TYPE_ALL_SUBSCRIPTIONS = 0;
-    public static final int TYPE_ALL_PUBLISHES = 1;
-    public static final int TYPE_REMAINING_PUBLISHES = 2;
-    static final int TYPE_COUNT = 3;
-
-    private final int type;
+    private final MqttGlobalPublishFlowType type;
     private ScNodeList.Handle<MqttGlobalIncomingPublishFlow> handle;
 
     MqttGlobalIncomingPublishFlow(
             @NotNull final Subscriber<? super Mqtt5Publish> subscriber,
-            @NotNull final MqttIncomingPublishService incomingPublishService, final int type) {
+            @NotNull final MqttIncomingPublishService incomingPublishService,
+            @NotNull final MqttGlobalPublishFlowType type) {
 
         super(incomingPublishService, subscriber);
         this.type = type;
@@ -48,7 +45,8 @@ public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subsc
         incomingPublishService.getIncomingPublishFlows().cancelGlobal(this);
     }
 
-    public int getType() {
+    @NotNull
+    public MqttGlobalPublishFlowType getType() {
         return type;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlowable.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlowable.java
@@ -20,6 +20,7 @@ package org.mqttbee.mqtt.handler.publish;
 import io.reactivex.Flowable;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.exceptions.NotConnectedException;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import org.mqttbee.mqtt.MqttClientConnectionData;
@@ -32,10 +33,12 @@ import org.reactivestreams.Subscriber;
  */
 public class MqttGlobalIncomingPublishFlowable extends Flowable<Mqtt5Publish> {
 
-    private final int type;
+    private final MqttGlobalPublishFlowType type;
     private final MqttClientData clientData;
 
-    public MqttGlobalIncomingPublishFlowable(final int type, @NotNull final MqttClientData clientData) {
+    public MqttGlobalIncomingPublishFlowable(
+            @NotNull final MqttGlobalPublishFlowType type, @NotNull final MqttClientData clientData) {
+
         this.type = type;
         this.clientData = clientData;
     }

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
@@ -20,6 +20,7 @@ package org.mqttbee.mqtt.handler.publish;
 import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -53,7 +54,7 @@ public class MqttIncomingPublishFlows {
     @SuppressWarnings("unchecked")
     MqttIncomingPublishFlows(@NotNull final MqttSubscriptionFlows subscriptionFlows) {
         this.subscriptionFlows = subscriptionFlows;
-        globalFlows = new ScNodeList[MqttGlobalIncomingPublishFlow.TYPE_COUNT];
+        globalFlows = new ScNodeList[MqttGlobalPublishFlowType.values().length];
     }
 
     public void subscribe(
@@ -105,16 +106,16 @@ public class MqttIncomingPublishFlows {
 
         final MqttTopicImpl topic = publish.getStatelessMessage().getTopic();
         if (subscriptionFlows.findMatching(topic, matchingFlows) || !matchingFlows.isEmpty()) {
-            addAndReference(matchingFlows, globalFlows[MqttGlobalIncomingPublishFlow.TYPE_ALL_SUBSCRIPTIONS]);
+            addAndReference(matchingFlows, globalFlows[MqttGlobalPublishFlowType.ALL_SUBSCRIPTIONS.ordinal()]);
         }
-        addAndReference(matchingFlows, globalFlows[MqttGlobalIncomingPublishFlow.TYPE_ALL_PUBLISHES]);
+        addAndReference(matchingFlows, globalFlows[MqttGlobalPublishFlowType.ALL_PUBLISHES.ordinal()]);
         if (matchingFlows.isEmpty()) {
-            addAndReference(matchingFlows, globalFlows[MqttGlobalIncomingPublishFlow.TYPE_REMAINING_PUBLISHES]);
+            addAndReference(matchingFlows, globalFlows[MqttGlobalPublishFlowType.REMAINING_PUBLISHES.ordinal()]);
         }
     }
 
     public void subscribeGlobal(@NotNull final MqttGlobalIncomingPublishFlow flow) {
-        final int type = flow.getType();
+        final int type = flow.getType().ordinal();
         ScNodeList<MqttGlobalIncomingPublishFlow> globalFlow = globalFlows[type];
         if (globalFlow == null) {
             globalFlow = new ScNodeList<>();
@@ -125,7 +126,7 @@ public class MqttIncomingPublishFlows {
 
     public void cancelGlobal(@NotNull final MqttGlobalIncomingPublishFlow flow) {
         flow.getHandle().remove();
-        final int type = flow.getType();
+        final int type = flow.getType().ordinal();
         final ScNodeList<MqttGlobalIncomingPublishFlow> globalFlow = globalFlows[type];
         if (globalFlow.isEmpty()) {
             globalFlows[type] = null;

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
@@ -58,7 +58,7 @@ public class MqttIncomingPublishFlows {
 
     public void subscribe(
             @NotNull final MqttStatefulSubscribe subscribe, @NotNull final MqttSubAck subAck,
-            @NotNull final MqttSubscriptionFlow flow) {
+            @Nullable final MqttSubscriptionFlow flow) {
 
         final ImmutableList<MqttSubscription> subscriptions = subscribe.getStatelessMessage().getSubscriptions();
         final ImmutableList<Mqtt5SubAckReasonCode> reasonCodes = subAck.getReasonCodes();
@@ -69,7 +69,7 @@ public class MqttIncomingPublishFlows {
         }
     }
 
-    void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttSubscriptionFlow flow) {
+    void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @Nullable final MqttSubscriptionFlow flow) {
         subscriptionFlows.subscribe(topicFilter, flow);
     }
 
@@ -104,7 +104,7 @@ public class MqttIncomingPublishFlows {
             @NotNull final ScNodeList<MqttIncomingPublishFlow> matchingFlows) {
 
         final MqttTopicImpl topic = publish.getStatelessMessage().getTopic();
-        if (subscriptionFlows.findMatching(topic, matchingFlows)) {
+        if (subscriptionFlows.findMatching(topic, matchingFlows) || !matchingFlows.isEmpty()) {
             addAndReference(matchingFlows, globalFlows[MqttGlobalIncomingPublishFlow.TYPE_ALL_SUBSCRIPTIONS]);
         }
         addAndReference(matchingFlows, globalFlows[MqttGlobalIncomingPublishFlow.TYPE_ALL_PUBLISHES]);
@@ -131,7 +131,6 @@ public class MqttIncomingPublishFlows {
             globalFlows[type] = null;
         }
     }
-
 
     static void addAndReference(
             @NotNull final ScNodeList<MqttIncomingPublishFlow> target, @NotNull final MqttIncomingPublishFlow flow) {

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowList.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowList.java
@@ -46,12 +46,14 @@ public class MqttSubscriptionFlowList implements MqttSubscriptionFlows {
     }
 
     @Override
-    public void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttSubscriptionFlow flow) {
-        final ScNodeList<MqttTopicFilterImpl> topicFilters = flow.getTopicFilters();
-        if (topicFilters.isEmpty()) {
-            flows.add(flow);
+    public void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @Nullable final MqttSubscriptionFlow flow) {
+        if (flow != null) {
+            final ScNodeList<MqttTopicFilterImpl> topicFilters = flow.getTopicFilters();
+            if (topicFilters.isEmpty()) {
+                flows.add(flow);
+            }
+            topicFilters.add(topicFilter);
         }
-        topicFilters.add(topicFilter);
         subscribedTopicFilters.add(topicFilter);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowTree.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowTree.java
@@ -46,9 +46,9 @@ public class MqttSubscriptionFlowTree implements MqttSubscriptionFlows {
     }
 
     @Override
-    public void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttSubscriptionFlow flow) {
+    public void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @Nullable final MqttSubscriptionFlow flow) {
         final MqttTopicLevel level = MqttTopicLevel.root(topicFilter);
-        final TopicTreeEntry entry = new TopicTreeEntry(flow, topicFilter);
+        final TopicTreeEntry entry = (flow == null) ? null : new TopicTreeEntry(flow, topicFilter);
         if (rootNode == null) {
             rootNode = new TopicTreeNode(ROOT_LEVEL, level, entry);
         } else {
@@ -116,24 +116,28 @@ public class MqttSubscriptionFlowTree implements MqttSubscriptionFlows {
 
         private TopicTreeNode(
                 @NotNull final ByteArray parentLevel, @Nullable final MqttTopicLevel level,
-                @NotNull final TopicTreeEntry entry) {
+                @Nullable final TopicTreeEntry entry) {
 
             this.parentLevel = parentLevel;
             subscribe(level, entry);
         }
 
-        private void subscribe(@Nullable final MqttTopicLevel level, @NotNull final TopicTreeEntry entry) {
+        private void subscribe(@Nullable final MqttTopicLevel level, @Nullable final TopicTreeEntry entry) {
             if (level == null) {
                 if (entries == null) {
                     entries = new ScNodeList<>();
                 }
-                entries.add(entry);
+                if (entry != null) {
+                    entries.add(entry);
+                }
                 hasSubscription = true;
             } else if (level.isMultiLevelWildcard()) {
                 if (multiLevelEntries == null) {
                     multiLevelEntries = new ScNodeList<>();
                 }
-                multiLevelEntries.add(entry);
+                if (entry != null) {
+                    multiLevelEntries.add(entry);
+                }
                 hasMultiLevelSubscription = true;
             } else {
                 final TopicTreeNode node;

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlows.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlows.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 @NotThreadSafe
 public interface MqttSubscriptionFlows {
 
-    void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @NotNull MqttSubscriptionFlow flow);
+    void subscribe(@NotNull final MqttTopicFilterImpl topicFilter, @Nullable MqttSubscriptionFlow flow);
 
     void unsubscribe(
             @NotNull final MqttTopicFilterImpl topicFilter,

--- a/src/main/java/org/mqttbee/mqtt/handler/subscribe/MqttSubscriptionHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/subscribe/MqttSubscriptionHandler.java
@@ -202,10 +202,11 @@ public class MqttSubscriptionHandler extends ChannelInboundHandlerAdapter {
             if (!subAckFlow.isCancelled()) {
                 subAckFlow.onSuccess(subAck);
             }
-            final MqttSubscriptionFlow subscriptionFlow = statefulSubscribeWithFlow.getSubscriptionFlow();
-            if ((subscriptionFlow != null) && !subscriptionFlow.isCancelled()) {
-                subscriptionFlows.subscribe(subscribe, subAck, subscriptionFlow);
+            MqttSubscriptionFlow subscriptionFlow = statefulSubscribeWithFlow.getSubscriptionFlow();
+            if ((subscriptionFlow != null) && subscriptionFlow.isCancelled()) {
+                subscriptionFlow = null;
             }
+            subscriptionFlows.subscribe(subscribe, subAck, subscriptionFlow);
         } else {
             final String errorMessage;
             switch (reasonCodesState) {

--- a/src/main/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientView.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientView.java
@@ -22,6 +22,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.mqtt3.Mqtt3Client;
 import org.mqttbee.api.mqtt.mqtt3.Mqtt3ClientData;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
@@ -107,16 +108,8 @@ public class Mqtt3ClientView implements Mqtt3Client {
 
     @NotNull
     @Override
-    public Flowable<Mqtt3Publish> remainingPublishes() {
-        return delegate.remainingPublishes()
-                .onErrorResumeNext(EXCEPTION_MAPPER_FLOWABLE_PUBLISH)
-                .map(Mqtt3PublishView.MAPPER);
-    }
-
-    @NotNull
-    @Override
-    public Flowable<Mqtt3Publish> allPublishes() {
-        return delegate.allPublishes()
+    public Flowable<Mqtt3Publish> publishes(@NotNull final MqttGlobalPublishFlowType type) {
+        return delegate.publishes(type)
                 .onErrorResumeNext(EXCEPTION_MAPPER_FLOWABLE_PUBLISH)
                 .map(Mqtt3PublishView.MAPPER);
     }

--- a/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
+++ b/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
@@ -17,12 +17,14 @@
 
 package org.mqttbee.mqtt5;
 
+import com.google.common.base.Preconditions;
 import io.netty.bootstrap.Bootstrap;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.exceptions.AlreadyConnectedException;
 import org.mqttbee.api.mqtt.exceptions.NotConnectedException;
 import org.mqttbee.api.mqtt.mqtt5.Mqtt5Client;
@@ -41,7 +43,6 @@ import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.handler.MqttChannelInitializer;
 import org.mqttbee.mqtt.handler.auth.MqttReAuthEvent;
 import org.mqttbee.mqtt.handler.disconnect.MqttDisconnectUtil;
-import org.mqttbee.mqtt.handler.publish.MqttGlobalIncomingPublishFlow;
 import org.mqttbee.mqtt.handler.publish.MqttGlobalIncomingPublishFlowable;
 import org.mqttbee.mqtt.handler.publish.MqttIncomingAckFlowable;
 import org.mqttbee.mqtt.handler.publish.MqttSubscriptionFlowable;
@@ -143,17 +144,11 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
 
     @NotNull
     @Override
-    public Flowable<Mqtt5Publish> remainingPublishes() {
-        return new MqttGlobalIncomingPublishFlowable(MqttGlobalIncomingPublishFlow.TYPE_REMAINING_PUBLISHES, clientData)
-                .observeOn(clientData.getExecutorConfig().getRxJavaScheduler());
-    }
+    public Flowable<Mqtt5Publish> publishes(@NotNull final MqttGlobalPublishFlowType type) {
+        Preconditions.checkNotNull(type);
 
-    @NotNull
-    @Override
-    public Flowable<Mqtt5Publish> allPublishes() {
-        return new MqttGlobalIncomingPublishFlowable(
-                MqttGlobalIncomingPublishFlow.TYPE_ALL_PUBLISHES, clientData).observeOn(
-                clientData.getExecutorConfig().getRxJavaScheduler()); // TODO all subscriptions?
+        return new MqttGlobalIncomingPublishFlowable(type, clientData).observeOn(
+                clientData.getExecutorConfig().getRxJavaScheduler());
     }
 
     @NotNull
@@ -162,8 +157,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
         final MqttUnsubscribe mqttUnsubscribe =
                 MustNotBeImplementedUtil.checkNotImplemented(unsubscribe, MqttUnsubscribe.class);
 
-        return new MqttUnsubAckSingle(mqttUnsubscribe, clientData).observeOn(
-                clientData.getExecutorConfig().getRxJavaScheduler());
+        return new MqttUnsubAckSingle(mqttUnsubscribe, clientData).observeOn(clientData.getExecutorConfig().getRxJavaScheduler());
     }
 
     @NotNull

--- a/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
+++ b/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
@@ -22,7 +22,10 @@ import io.reactivex.Single;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
 import org.mqttbee.api.mqtt.datatypes.MqttQoS;
 import org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
@@ -94,22 +97,14 @@ class Mqtt3ClientViewExceptionsTest {
                 mqtt5MessageException);
     }
 
-    @Test
-    void remainingPublishes() {
+    @ParameterizedTest
+    @EnumSource(MqttGlobalPublishFlowType.class)
+    void publishes(final MqttGlobalPublishFlowType type) {
         final Mqtt5MessageException mqtt5MessageException =
                 new Mqtt5MessageException(Mqtt5Connect.builder().build(), "reason from original exception");
-        given(mqtt5Client.remainingPublishes()).willReturn(Flowable.error(mqtt5MessageException));
+        given(mqtt5Client.publishes(type)).willReturn(Flowable.error(mqtt5MessageException));
 
-        assertMqtt3Exception(() -> mqtt3Client.remainingPublishes().blockingSubscribe(), mqtt5MessageException);
-    }
-
-    @Test
-    void allPublishes() {
-        final Mqtt5MessageException mqtt5MessageException =
-                new Mqtt5MessageException(Mqtt5Connect.builder().build(), "reason from original exception");
-        given(mqtt5Client.allPublishes()).willReturn(Flowable.error(mqtt5MessageException));
-
-        assertMqtt3Exception(() -> mqtt3Client.allPublishes().blockingSubscribe(), mqtt5MessageException);
+        assertMqtt3Exception(() -> mqtt3Client.publishes(type).blockingSubscribe(), mqtt5MessageException);
     }
 
     @Test


### PR DESCRIPTION
**Motivation**
Mqtt3/5Client had two methods for globally consuming Publish messages: `allPublishes`, `remainingPublishes`
A method for globally consuming all Publish messages that match at least one subscription was missing.
Instead of adding more methods to the interface (which almost all do the same) `allPublishes` and `remainingPublishes` was replaced by the method `publishes(MqttGlobalPublishFlowType)`.

**Changes**
- Added an enum for `MqttGlobalPublishFlowType` with values: `ALL_PUBLISHES`, `ALL_SUBSCRIPTIONS`, `REMAINING_PUBLISHES`
- Replaced `allPublishes` and `remainingPublishes` with `publishes(MqttGlobalPublishFlowType)`
- Fixed the logic for the ALL_SUBSCRIPTIONS type: If a flow is null or already cancelled, the subscription is still registered, but no flow is added.
