### PR TITLE
Feature/fuse netty el and rxjava worker

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
@@ -42,6 +42,6 @@ public interface MqttClientExecutorConfig {
     Optional<Integer> getUserDefinedNettyThreads();
 
     @NotNull
-    Scheduler getApiScheduler();
+    Scheduler getApplicationScheduler();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfig.java
@@ -42,6 +42,6 @@ public interface MqttClientExecutorConfig {
     Optional<Integer> getUserDefinedNettyThreads();
 
     @NotNull
-    Scheduler getRxJavaScheduler();
+    Scheduler getApiScheduler();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -34,7 +34,7 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
 
     private Executor nettyExecutor;
     private int nettyThreads = MqttClientExecutorConfigImpl.DEFAULT_NETTY_THREADS;
-    private Scheduler rxJavaScheduler = MqttClientExecutorConfigImpl.DEFAULT_RX_JAVA_SCHEDULER;
+    private Scheduler apiScheduler = MqttClientExecutorConfigImpl.DEFAULT_RX_JAVA_SCHEDULER;
 
     public MqttClientExecutorConfigBuilder(
             @Nullable final Function<? super MqttClientExecutorConfig, P> parentConsumer) {
@@ -57,16 +57,16 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder<P> apiScheduler(@NotNull final Scheduler rxJavaScheduler) {
-        Preconditions.checkNotNull(rxJavaScheduler);
-        this.rxJavaScheduler = rxJavaScheduler;
+    public MqttClientExecutorConfigBuilder<P> apiScheduler(@NotNull final Scheduler apiScheduler) {
+        Preconditions.checkNotNull(apiScheduler);
+        this.apiScheduler = apiScheduler;
         return this;
     }
 
     @NotNull
     @Override
     public MqttClientExecutorConfig build() {
-        return new MqttClientExecutorConfigImpl(nettyExecutor, nettyThreads, rxJavaScheduler);
+        return new MqttClientExecutorConfigImpl(nettyExecutor, nettyThreads, apiScheduler);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -34,7 +34,7 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
 
     private Executor nettyExecutor;
     private int nettyThreads = MqttClientExecutorConfigImpl.DEFAULT_NETTY_THREADS;
-    private Scheduler apiScheduler = MqttClientExecutorConfigImpl.DEFAULT_RX_JAVA_SCHEDULER;
+    private Scheduler applicationScheduler = MqttClientExecutorConfigImpl.DEFAULT_RX_JAVA_SCHEDULER;
 
     public MqttClientExecutorConfigBuilder(
             @Nullable final Function<? super MqttClientExecutorConfig, P> parentConsumer) {
@@ -57,16 +57,16 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder<P> apiScheduler(@NotNull final Scheduler apiScheduler) {
-        Preconditions.checkNotNull(apiScheduler);
-        this.apiScheduler = apiScheduler;
+    public MqttClientExecutorConfigBuilder<P> applicationScheduler(@NotNull final Scheduler applicationScheduler) {
+        Preconditions.checkNotNull(applicationScheduler);
+        this.applicationScheduler = applicationScheduler;
         return this;
     }
 
     @NotNull
     @Override
     public MqttClientExecutorConfig build() {
-        return new MqttClientExecutorConfigImpl(nettyExecutor, nettyThreads, apiScheduler);
+        return new MqttClientExecutorConfigImpl(nettyExecutor, nettyThreads, applicationScheduler);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -57,7 +57,7 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
     }
 
     @NotNull
-    public MqttClientExecutorConfigBuilder<P> rxJavaScheduler(@NotNull final Scheduler rxJavaScheduler) {
+    public MqttClientExecutorConfigBuilder<P> apiScheduler(@NotNull final Scheduler rxJavaScheduler) {
         Preconditions.checkNotNull(rxJavaScheduler);
         this.rxJavaScheduler = rxJavaScheduler;
         return this;

--- a/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
@@ -38,14 +38,14 @@ public class MqttClientExecutorConfigImpl implements MqttClientExecutorConfig {
 
     private final Executor nettyExecutor;
     private final int nettyThreads;
-    private final Scheduler rxJavaScheduler;
+    private final Scheduler apiScheduler;
 
     public MqttClientExecutorConfigImpl(
-            @Nullable final Executor nettyExecutor, final int nettyThreads, @NotNull final Scheduler rxJavaScheduler) {
+            @Nullable final Executor nettyExecutor, final int nettyThreads, @NotNull final Scheduler apiScheduler) {
 
         this.nettyExecutor = nettyExecutor;
         this.nettyThreads = nettyThreads;
-        this.rxJavaScheduler = rxJavaScheduler;
+        this.apiScheduler = apiScheduler;
     }
 
     @NotNull
@@ -71,7 +71,7 @@ public class MqttClientExecutorConfigImpl implements MqttClientExecutorConfig {
 
     @NotNull
     public Scheduler getApiScheduler() {
-        return rxJavaScheduler;
+        return apiScheduler;
     }
 
 }

--- a/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
@@ -38,14 +38,15 @@ public class MqttClientExecutorConfigImpl implements MqttClientExecutorConfig {
 
     private final Executor nettyExecutor;
     private final int nettyThreads;
-    private final Scheduler apiScheduler;
+    private final Scheduler applicationScheduler;
 
     public MqttClientExecutorConfigImpl(
-            @Nullable final Executor nettyExecutor, final int nettyThreads, @NotNull final Scheduler apiScheduler) {
+            @Nullable final Executor nettyExecutor, final int nettyThreads,
+            @NotNull final Scheduler applicationScheduler) {
 
         this.nettyExecutor = nettyExecutor;
         this.nettyThreads = nettyThreads;
-        this.apiScheduler = apiScheduler;
+        this.applicationScheduler = applicationScheduler;
     }
 
     @NotNull
@@ -70,8 +71,8 @@ public class MqttClientExecutorConfigImpl implements MqttClientExecutorConfig {
     }
 
     @NotNull
-    public Scheduler getApiScheduler() {
-        return apiScheduler;
+    public Scheduler getApplicationScheduler() {
+        return applicationScheduler;
     }
 
 }

--- a/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientExecutorConfigImpl.java
@@ -70,7 +70,7 @@ public class MqttClientExecutorConfigImpl implements MqttClientExecutorConfig {
     }
 
     @NotNull
-    public Scheduler getRxJavaScheduler() {
+    public Scheduler getApiScheduler() {
         return rxJavaScheduler;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
@@ -26,7 +26,7 @@ import org.reactivestreams.Subscriber;
 /**
  * @author Silvio Giebl
  */
-public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subscriber<? super Mqtt5Publish>> {
+class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subscriber<? super Mqtt5Publish>> {
 
     private final MqttGlobalPublishFlowType type;
     private ScNodeList.Handle<MqttGlobalIncomingPublishFlow> handle;
@@ -47,7 +47,7 @@ public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subsc
     }
 
     @NotNull
-    public MqttGlobalPublishFlowType getType() {
+    MqttGlobalPublishFlowType getType() {
         return type;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttGlobalIncomingPublishFlow.java
@@ -41,8 +41,9 @@ public class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow<Subsc
     }
 
     @Override
-    void runRemoveOnCancel() {
+    void runCancel() {
         incomingPublishService.getIncomingPublishFlows().cancelGlobal(this);
+        super.runCancel();
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
@@ -89,12 +89,12 @@ public class MqttIncomingPublishFlows {
         subscriptionFlows.unsubscribe(topicFilter, null);
     }
 
-    public void cancel(@NotNull final MqttSubscriptionFlow flow) {
+    void cancel(@NotNull final MqttSubscriptionFlow flow) {
         subscriptionFlows.cancel(flow);
     }
 
     @NotNull
-    public ScNodeList<MqttIncomingPublishFlow> findMatching(@NotNull final MqttStatefulPublish publish) {
+    ScNodeList<MqttIncomingPublishFlow> findMatching(@NotNull final MqttStatefulPublish publish) {
         final ScNodeList<MqttIncomingPublishFlow> matchingFlows = new ScNodeList<>();
         findMatching(publish, matchingFlows);
         return matchingFlows;
@@ -114,7 +114,7 @@ public class MqttIncomingPublishFlows {
         }
     }
 
-    public void subscribeGlobal(@NotNull final MqttGlobalIncomingPublishFlow flow) {
+    void subscribeGlobal(@NotNull final MqttGlobalIncomingPublishFlow flow) {
         final int type = flow.getType().ordinal();
         ScNodeList<MqttGlobalIncomingPublishFlow> globalFlow = globalFlows[type];
         if (globalFlow == null) {
@@ -124,7 +124,7 @@ public class MqttIncomingPublishFlows {
         flow.setHandle(globalFlow.add(flow));
     }
 
-    public void cancelGlobal(@NotNull final MqttGlobalIncomingPublishFlow flow) {
+    void cancelGlobal(@NotNull final MqttGlobalIncomingPublishFlow flow) {
         flow.getHandle().remove();
         final int type = flow.getType().ordinal();
         final ScNodeList<MqttGlobalIncomingPublishFlow> globalFlow = globalFlows[type];

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlows.java
@@ -106,11 +106,11 @@ public class MqttIncomingPublishFlows {
 
         final MqttTopicImpl topic = publish.getStatelessMessage().getTopic();
         if (subscriptionFlows.findMatching(topic, matchingFlows) || !matchingFlows.isEmpty()) {
-            addAndReference(matchingFlows, globalFlows[MqttGlobalPublishFlowType.ALL_SUBSCRIPTIONS.ordinal()]);
+            add(matchingFlows, globalFlows[MqttGlobalPublishFlowType.ALL_SUBSCRIPTIONS.ordinal()]);
         }
-        addAndReference(matchingFlows, globalFlows[MqttGlobalPublishFlowType.ALL_PUBLISHES.ordinal()]);
+        add(matchingFlows, globalFlows[MqttGlobalPublishFlowType.ALL_PUBLISHES.ordinal()]);
         if (matchingFlows.isEmpty()) {
-            addAndReference(matchingFlows, globalFlows[MqttGlobalPublishFlowType.REMAINING_PUBLISHES.ordinal()]);
+            add(matchingFlows, globalFlows[MqttGlobalPublishFlowType.REMAINING_PUBLISHES.ordinal()]);
         }
     }
 
@@ -133,20 +133,13 @@ public class MqttIncomingPublishFlows {
         }
     }
 
-    static void addAndReference(
-            @NotNull final ScNodeList<MqttIncomingPublishFlow> target, @NotNull final MqttIncomingPublishFlow flow) {
-
-        flow.reference();
-        target.add(flow);
-    }
-
-    private static void addAndReference(
+    private static void add(
             @NotNull final ScNodeList<MqttIncomingPublishFlow> target,
             @Nullable final ScNodeList<? extends MqttIncomingPublishFlow> source) {
 
         if (source != null) {
             for (final MqttIncomingPublishFlow flow : source) {
-                addAndReference(target, flow);
+                target.add(flow);
             }
         }
     }

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlowsWithId.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishFlowsWithId.java
@@ -101,7 +101,7 @@ public class MqttIncomingPublishFlowsWithId extends MqttIncomingPublishFlows {
     }
 
     @Override
-    public void cancel(@NotNull final MqttSubscriptionFlow flow) {
+    void cancel(@NotNull final MqttSubscriptionFlow flow) {
         final int subscriptionIdentifier = flow.getSubscriptionIdentifier();
         if (subscriptionIdentifier != DEFAULT_NO_SUBSCRIPTION_IDENTIFIER) {
             flowsWithIdsMap.remove(subscriptionIdentifier);

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlow.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlow.java
@@ -55,8 +55,9 @@ public class MqttSubscriptionFlow extends MqttIncomingPublishFlow<Subscriber<? s
     }
 
     @Override
-    void runRemoveOnCancel() {
+    void runCancel() {
         incomingPublishService.getIncomingPublishFlows().cancel(this);
+        super.runCancel();
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowList.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowList.java
@@ -98,7 +98,7 @@ public class MqttSubscriptionFlowList implements MqttSubscriptionFlows {
         for (final MqttSubscriptionFlow flow : flows) {
             for (final MqttTopicFilterImpl topicFilter : flow.getTopicFilters()) {
                 if (topicFilter.matches(topic)) {
-                    MqttIncomingPublishFlows.addAndReference(matchingFlows, flow);
+                    matchingFlows.add(flow);
                     break;
                 }
             }

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowTree.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttSubscriptionFlowTree.java
@@ -250,11 +250,11 @@ public class MqttSubscriptionFlowTree implements MqttSubscriptionFlows {
                 @NotNull final ScNodeList<MqttIncomingPublishFlow> matchingFlows) {
 
             if (level == null) {
-                addAndReference(matchingFlows, entries);
-                addAndReference(matchingFlows, multiLevelEntries);
+                add(matchingFlows, entries);
+                add(matchingFlows, multiLevelEntries);
                 return hasSubscription || hasMultiLevelSubscription;
             }
-            addAndReference(matchingFlows, multiLevelEntries);
+            add(matchingFlows, multiLevelEntries);
             boolean subscriptionFound = hasMultiLevelSubscription;
             if (next != null) {
                 if (hasSingleLevelSubscription) {
@@ -269,13 +269,12 @@ public class MqttSubscriptionFlowTree implements MqttSubscriptionFlows {
             return subscriptionFound;
         }
 
-        private static void addAndReference(
+        private static void add(
                 @NotNull final ScNodeList<MqttIncomingPublishFlow> target,
                 @Nullable final ScNodeList<TopicTreeEntry> source) {
 
             if (source != null) {
                 for (final TopicTreeEntry entry : source) {
-                    entry.flow.reference();
                     target.add(entry.flow);
                 }
             }

--- a/src/main/java/org/mqttbee/mqtt/ioc/ChannelModule.java
+++ b/src/main/java/org/mqttbee/mqtt/ioc/ChannelModule.java
@@ -21,7 +21,6 @@ import dagger.Binds;
 import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
-import io.reactivex.Scheduler;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.handler.disconnect.Mqtt3Disconnecter;
 import org.mqttbee.mqtt.handler.disconnect.Mqtt5Disconnecter;
@@ -29,13 +28,11 @@ import org.mqttbee.mqtt.handler.disconnect.MqttDisconnecter;
 import org.mqttbee.mqtt.handler.publish.MqttSubscriptionFlowTree;
 import org.mqttbee.mqtt.handler.publish.MqttSubscriptionFlows;
 
-import javax.inject.Named;
-
 /**
  * @author Silvio Giebl
  */
 @Module
-public abstract class ChannelModule {
+abstract class ChannelModule {
 
     @Provides
     @ChannelScope
@@ -51,13 +48,6 @@ public abstract class ChannelModule {
             default:
                 throw new IllegalStateException();
         }
-    }
-
-    @Provides
-    @ChannelScope
-    @Named("incomingPublish")
-    static Scheduler.Worker provideIncomingPublishRxEventLoop(final MqttClientData clientData) {
-        return clientData.getExecutorConfig().getRxJavaScheduler().createWorker();
     }
 
     @Binds

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
 public class Mqtt3UnsubAckView implements Mqtt3UnsubAck {
 
     public static final ImmutableList<Mqtt5UnsubAckReasonCode> REASON_CODES_ALL_SUCCESS = ImmutableList.of();
-    public static final Mqtt3UnsubAckView INSTANCE = new Mqtt3UnsubAckView();
+    private static final Mqtt3UnsubAckView INSTANCE = new Mqtt3UnsubAckView();
 
     @NotNull
     public static MqttUnsubAck delegate(final int packetIdentifier) {

--- a/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
+++ b/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
@@ -117,7 +117,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
                 clientData.setServerConnectionData(null);
                 clientData.setConnecting(false);
             }
-        }).observeOn(clientData.getExecutorConfig().getApiScheduler());
+        }).observeOn(clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull
@@ -127,7 +127,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
                 MustNotBeImplementedUtil.checkNotImplemented(subscribe, MqttSubscribe.class);
 
         return new MqttSubAckSingle(mqttSubscribe, clientData).observeOn(
-                clientData.getExecutorConfig().getApiScheduler());
+                clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull
@@ -138,7 +138,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
 
         final Flowable<Mqtt5SubscribeResult> subscriptionFlowable =
                 new MqttSubscriptionFlowable(mqttSubscribe, clientData).observeOn(
-                        clientData.getExecutorConfig().getApiScheduler());
+                        clientData.getExecutorConfig().getApplicationScheduler());
         return new FlowableWithSingleSplit<>(subscriptionFlowable, Mqtt5SubAck.class, Mqtt5Publish.class);
     }
 
@@ -148,7 +148,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
         Preconditions.checkNotNull(type);
 
         return new MqttGlobalIncomingPublishFlowable(type, clientData).observeOn(
-                clientData.getExecutorConfig().getApiScheduler());
+                clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull
@@ -158,14 +158,14 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
                 MustNotBeImplementedUtil.checkNotImplemented(unsubscribe, MqttUnsubscribe.class);
 
         return new MqttUnsubAckSingle(mqttUnsubscribe, clientData).observeOn(
-                clientData.getExecutorConfig().getApiScheduler());
+                clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull
     @Override
     public Flowable<Mqtt5PublishResult> publish(@NotNull final Flowable<Mqtt5Publish> publishFlowable) {
         return new MqttIncomingAckFlowable(publishFlowable.map(PUBLISH_MAPPER), clientData).observeOn(
-                clientData.getExecutorConfig().getApiScheduler());
+                clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull
@@ -178,7 +178,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
             } else {
                 emitter.onError(new NotConnectedException());
             }
-        }).observeOn(clientData.getExecutorConfig().getApiScheduler());
+        }).observeOn(clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull
@@ -200,7 +200,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
             } else {
                 emitter.onError(new NotConnectedException());
             }
-        }).observeOn(clientData.getExecutorConfig().getApiScheduler());
+        }).observeOn(clientData.getExecutorConfig().getApplicationScheduler());
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
+++ b/src/main/java/org/mqttbee/mqtt5/Mqtt5ClientImpl.java
@@ -117,7 +117,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
                 clientData.setServerConnectionData(null);
                 clientData.setConnecting(false);
             }
-        }).observeOn(clientData.getExecutorConfig().getRxJavaScheduler());
+        }).observeOn(clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull
@@ -127,7 +127,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
                 MustNotBeImplementedUtil.checkNotImplemented(subscribe, MqttSubscribe.class);
 
         return new MqttSubAckSingle(mqttSubscribe, clientData).observeOn(
-                clientData.getExecutorConfig().getRxJavaScheduler());
+                clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull
@@ -138,7 +138,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
 
         final Flowable<Mqtt5SubscribeResult> subscriptionFlowable =
                 new MqttSubscriptionFlowable(mqttSubscribe, clientData).observeOn(
-                        clientData.getExecutorConfig().getRxJavaScheduler());
+                        clientData.getExecutorConfig().getApiScheduler());
         return new FlowableWithSingleSplit<>(subscriptionFlowable, Mqtt5SubAck.class, Mqtt5Publish.class);
     }
 
@@ -148,7 +148,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
         Preconditions.checkNotNull(type);
 
         return new MqttGlobalIncomingPublishFlowable(type, clientData).observeOn(
-                clientData.getExecutorConfig().getRxJavaScheduler());
+                clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull
@@ -157,14 +157,15 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
         final MqttUnsubscribe mqttUnsubscribe =
                 MustNotBeImplementedUtil.checkNotImplemented(unsubscribe, MqttUnsubscribe.class);
 
-        return new MqttUnsubAckSingle(mqttUnsubscribe, clientData).observeOn(clientData.getExecutorConfig().getRxJavaScheduler());
+        return new MqttUnsubAckSingle(mqttUnsubscribe, clientData).observeOn(
+                clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull
     @Override
     public Flowable<Mqtt5PublishResult> publish(@NotNull final Flowable<Mqtt5Publish> publishFlowable) {
         return new MqttIncomingAckFlowable(publishFlowable.map(PUBLISH_MAPPER), clientData).observeOn(
-                clientData.getExecutorConfig().getRxJavaScheduler());
+                clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull
@@ -177,7 +178,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
             } else {
                 emitter.onError(new NotConnectedException());
             }
-        }).observeOn(clientData.getExecutorConfig().getRxJavaScheduler());
+        }).observeOn(clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull
@@ -199,7 +200,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
             } else {
                 emitter.onError(new NotConnectedException());
             }
-        }).observeOn(clientData.getExecutorConfig().getRxJavaScheduler());
+        }).observeOn(clientData.getExecutorConfig().getApiScheduler());
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/util/collections/ChunkedArrayQueue.java
+++ b/src/main/java/org/mqttbee/util/collections/ChunkedArrayQueue.java
@@ -95,13 +95,17 @@ public class ChunkedArrayQueue<E> implements Iterable<E> {
         return consumerChunk.values[consumerIndex];
     }
 
+    public void clear() {
+        while (poll() != null) {
+        }
+    }
+
     @NotNull
     @Override
     public Iterator<E> iterator() {
         iterator.clear();
         return iterator;
     }
-
 
     private static class Chunk<E> {
 


### PR DESCRIPTION
**Motivation**
Switching threads for incoming Publish messages is inefficient if the messages can be emitted and acknowledged immediately, as the following switches have to be performed: 
Netty Channel EventLoop (decode, QoS handling) -> RxJava Worker (emitting into flows) -> Netty Channel EventLoop (sending the Ack messages)
Using the Netty Channel EventLoop for everything of the registered client reduces the total number of threads needed.

**Changes**
- Fused Netty EL for IncomingPublishService + IncomingPublishFlow + IncomingQoSHandler
- Improved IncomingAckFlow