### PR TITLE
rename QoS into Qos to use correct camel case #151

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttQos.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttQos.java
@@ -24,7 +24,7 @@ import org.mqttbee.annotations.Nullable;
  *
  * @author Silvio Giebl
  */
-public enum MqttQoS {
+public enum MqttQos {
 
     /**
      * QoS for at most once delivery according to the capabilities of the underlying network.
@@ -53,8 +53,8 @@ public enum MqttQoS {
      * @return the QoS belonging to the given byte code or null if the byte code is not a valid QoS code.
      */
     @Nullable
-    public static MqttQoS fromCode(final int code) {
-        final MqttQoS[] values = values();
+    public static MqttQos fromCode(final int code) {
+        final MqttQos[] values = values();
         if (code < 0 || code >= values.length) {
             return null;
         }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
@@ -19,7 +19,7 @@ package org.mqttbee.api.mqtt.mqtt3.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
@@ -67,7 +67,7 @@ public interface Mqtt3Publish extends Mqtt3Message, Mqtt3SubscribeResult {
      * @return the QoS of this PUBLISH packet.
      */
     @NotNull
-    MqttQoS getQos();
+    MqttQos getQos();
 
     /**
      * @return whether this PUBLISH packet is a retained message.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -20,7 +20,7 @@ package org.mqttbee.api.mqtt.mqtt3.message.publish;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
@@ -40,7 +40,7 @@ public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
 
     private MqttTopicImpl topic;
     private ByteBuffer payload;
-    private MqttQoS qos;
+    private MqttQos qos;
     private boolean retain;
 
     public Mqtt3PublishBuilder(@Nullable final Function<? super Mqtt3Publish, P> parentConsumer) {
@@ -87,7 +87,7 @@ public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
     }
 
     @NotNull
-    public Mqtt3PublishBuilder<P> qos(@NotNull final MqttQoS qos) {
+    public Mqtt3PublishBuilder<P> qos(@NotNull final MqttQos qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscription.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscription.java
@@ -19,7 +19,7 @@ package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 
 /**
@@ -45,6 +45,6 @@ public interface Mqtt3Subscription {
      * @return the QoS of this subscription.
      */
     @NotNull
-    MqttQoS getQoS();
+    MqttQos getQos();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -20,7 +20,7 @@ package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -36,7 +36,7 @@ import java.util.function.Function;
 public class Mqtt3SubscriptionBuilder<P> extends FluentBuilder<Mqtt3Subscription, P> {
 
     private MqttTopicFilterImpl topicFilter;
-    private MqttQoS qos;
+    private MqttQos qos;
 
     public Mqtt3SubscriptionBuilder(@Nullable final Function<? super Mqtt3Subscription, P> parentConsumer) {
         super(parentConsumer);
@@ -60,7 +60,7 @@ public class Mqtt3SubscriptionBuilder<P> extends FluentBuilder<Mqtt3Subscription
     }
 
     @NotNull
-    public Mqtt3SubscriptionBuilder<P> qos(@NotNull final MqttQoS qos) {
+    public Mqtt3SubscriptionBuilder<P> qos(@NotNull final MqttQos qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ServerConnectionData.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ServerConnectionData.java
@@ -19,7 +19,7 @@ package org.mqttbee.api.mqtt.mqtt5;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 
 /**
  * @author Silvio Giebl
@@ -34,7 +34,7 @@ public interface Mqtt5ServerConnectionData {
     int getMaximumPacketSize();
 
     @NotNull
-    MqttQoS getMaximumQoS();
+    MqttQos getMaximumQos();
 
     boolean isRetainAvailable();
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientDataBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/Mqtt5AdvancedClientDataBuilder.java
@@ -18,10 +18,10 @@
 package org.mqttbee.api.mqtt.mqtt5.advanced;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5IncomingQoS1ControlProvider;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5OutgoingQoS1ControlProvider;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5IncomingQoS2ControlProvider;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5OutgoingQoS2ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5IncomingQos1ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5OutgoingQos1ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5IncomingQos2ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5OutgoingQos2ControlProvider;
 import org.mqttbee.mqtt.advanced.MqttAdvancedClientData;
 
 /**
@@ -29,47 +29,47 @@ import org.mqttbee.mqtt.advanced.MqttAdvancedClientData;
  */
 public class Mqtt5AdvancedClientDataBuilder {
 
-    private Mqtt5IncomingQoS1ControlProvider incomingQoS1ControlProvider;
-    private Mqtt5OutgoingQoS1ControlProvider outgoingQoS1ControlProvider;
-    private Mqtt5IncomingQoS2ControlProvider incomingQoS2ControlProvider;
-    private Mqtt5OutgoingQoS2ControlProvider outgoingQoS2ControlProvider;
+    private Mqtt5IncomingQos1ControlProvider incomingQos1ControlProvider;
+    private Mqtt5OutgoingQos1ControlProvider outgoingQos1ControlProvider;
+    private Mqtt5IncomingQos2ControlProvider incomingQos2ControlProvider;
+    private Mqtt5OutgoingQos2ControlProvider outgoingQos2ControlProvider;
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder incomingQoS1ControlProvider(
-            @NotNull final Mqtt5IncomingQoS1ControlProvider incomingQoS1ControlProvider) {
+    public Mqtt5AdvancedClientDataBuilder incomingQos1ControlProvider(
+            @NotNull final Mqtt5IncomingQos1ControlProvider incomingQos1ControlProvider) {
 
-        this.incomingQoS1ControlProvider = incomingQoS1ControlProvider;
+        this.incomingQos1ControlProvider = incomingQos1ControlProvider;
         return this;
     }
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder outgoingQoS1ControlProvider(
-            @NotNull final Mqtt5OutgoingQoS1ControlProvider outgoingQoS1ControlProvider) {
+    public Mqtt5AdvancedClientDataBuilder outgoingQos1ControlProvider(
+            @NotNull final Mqtt5OutgoingQos1ControlProvider outgoingQos1ControlProvider) {
 
-        this.outgoingQoS1ControlProvider = outgoingQoS1ControlProvider;
+        this.outgoingQos1ControlProvider = outgoingQos1ControlProvider;
         return this;
     }
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder incomingQoS2ControlProvider(
-            @NotNull final Mqtt5IncomingQoS2ControlProvider incomingQoS2ControlProvider) {
+    public Mqtt5AdvancedClientDataBuilder incomingQos2ControlProvider(
+            @NotNull final Mqtt5IncomingQos2ControlProvider incomingQos2ControlProvider) {
 
-        this.incomingQoS2ControlProvider = incomingQoS2ControlProvider;
+        this.incomingQos2ControlProvider = incomingQos2ControlProvider;
         return this;
     }
 
     @NotNull
-    public Mqtt5AdvancedClientDataBuilder outgoingQoS2ControlProvider(
-            @NotNull final Mqtt5OutgoingQoS2ControlProvider outgoingQoS2ControlProvider) {
+    public Mqtt5AdvancedClientDataBuilder outgoingQos2ControlProvider(
+            @NotNull final Mqtt5OutgoingQos2ControlProvider outgoingQos2ControlProvider) {
 
-        this.outgoingQoS2ControlProvider = outgoingQoS2ControlProvider;
+        this.outgoingQos2ControlProvider = outgoingQos2ControlProvider;
         return this;
     }
 
     @NotNull
     public Mqtt5AdvancedClientData builder() {
-        return new MqttAdvancedClientData(incomingQoS1ControlProvider, outgoingQoS1ControlProvider,
-                incomingQoS2ControlProvider, outgoingQoS2ControlProvider);
+        return new MqttAdvancedClientData(incomingQos1ControlProvider, outgoingQos1ControlProvider,
+                incomingQos2ControlProvider, outgoingQos2ControlProvider);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5IncomingQos1ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5IncomingQos1ControlProvider.java
@@ -26,7 +26,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckBuilder;
  *
  * @author Silvio Giebl
  */
-public interface Mqtt5IncomingQoS1ControlProvider {
+public interface Mqtt5IncomingQos1ControlProvider {
 
     /**
      * Called when a server sent a PUBLISH message with QoS 1.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5OutgoingQos1ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos1/Mqtt5OutgoingQos1ControlProvider.java
@@ -15,30 +15,25 @@
  *
  */
 
-package org.mqttbee.mqtt.persistence;
+package org.mqttbee.api.mqtt.mqtt5.advanced.qos1;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
-import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
-import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
-
-import java.util.concurrent.CompletableFuture;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAck;
 
 /**
+ * Interface for providers for controlling the QoS 1 control flow for outgoing PUBLISH messages.
+ *
  * @author Silvio Giebl
  */
-public interface OutgoingQoSFlowPersistence {
+public interface Mqtt5OutgoingQos1ControlProvider {
 
-    @NotNull
-    CompletableFuture<Void> store(@NotNull MqttStatefulPublish publish);
-
-    @NotNull
-    CompletableFuture<Void> store(@NotNull MqttPubRel pubRel);
-
-    @NotNull
-    CompletableFuture<MqttQoSMessage> get(int packetIdentifier);
-
-    @NotNull
-    CompletableFuture<Void> discard(int packetIdentifier);
+    /**
+     * Called when a server sent a PUBACK message for a Publish with QoS 1.
+     * <p>
+     * This method must not block.
+     *
+     * @param pubAck the PUBACK message sent by the server.
+     */
+    void onPubAck(@NotNull Mqtt5PubAck pubAck);
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5IncomingQos2ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5IncomingQos2ControlProvider.java
@@ -28,7 +28,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRel;
  *
  * @author Silvio Giebl
  */
-public interface Mqtt5IncomingQoS2ControlProvider {
+public interface Mqtt5IncomingQos2ControlProvider {
 
     /**
      * Called when a server sent a PUBLISH message with QoS 2.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5OutgoingQos2ControlProvider.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/advanced/qos2/Mqtt5OutgoingQos2ControlProvider.java
@@ -27,7 +27,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRelBuilder;
  *
  * @author Silvio Giebl
  */
-public interface Mqtt5OutgoingQoS2ControlProvider {
+public interface Mqtt5OutgoingQos2ControlProvider {
 
     /**
      * Called when a server sent a PUBREC message for a PUBLISH with QoS 2.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAckRestrictions.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/connack/Mqtt5ConnAckRestrictions.java
@@ -18,7 +18,7 @@
 package org.mqttbee.api.mqtt.mqtt5.message.connect.connack;
 
 import org.mqttbee.annotations.DoNotImplement;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.util.UnsignedDataTypes;
 
@@ -44,7 +44,7 @@ public interface Mqtt5ConnAckRestrictions {
     /**
      * The default maximum QoS the server accepts from the client.
      */
-    MqttQoS DEFAULT_MAXIMUM_QOS = MqttQoS.EXACTLY_ONCE;
+    MqttQos DEFAULT_MAXIMUM_QOS = MqttQos.EXACTLY_ONCE;
     /**
      * The default for whether the server accepts retained messages.
      */
@@ -83,7 +83,7 @@ public interface Mqtt5ConnAckRestrictions {
     /**
      * @return the maximum QoS the server accepts from the client. The default is {@link #DEFAULT_MAXIMUM_QOS}.
      */
-    MqttQoS getMaximumQoS();
+    MqttQos getMaximumQos();
 
     /**
      * @return whether the server accepts retained messages. The default is {@link #DEFAULT_RETAIN_AVAILABLE}.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -19,7 +19,7 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -77,7 +77,7 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
      * @return the QoS of this PUBLISH packet.
      */
     @NotNull
-    MqttQoS getQos();
+    MqttQos getQos();
 
     /**
      * @return whether this PUBLISH packet is a retained message.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -20,7 +20,7 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
@@ -50,7 +50,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
 
     MqttTopicImpl topic;
     ByteBuffer payload;
-    MqttQoS qos;
+    MqttQos qos;
     boolean retain;
     long messageExpiryIntervalSeconds = MESSAGE_EXPIRY_INTERVAL_INFINITY;
     Mqtt5PayloadFormatIndicator payloadFormatIndicator;
@@ -110,7 +110,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder<P> qos(@NotNull final MqttQoS qos) {
+    public Mqtt5PublishBuilder<P> qos(@NotNull final MqttQos qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishResult.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishResult.java
@@ -38,13 +38,13 @@ public interface Mqtt5PublishResult {
     Throwable getError();
 
 
-    interface Mqtt5QoS1Result extends Mqtt5PublishResult {
+    interface Mqtt5Qos1Result extends Mqtt5PublishResult {
         @NotNull
         Mqtt5PubAck getPubAck();
     }
 
 
-    interface Mqtt5QoS2Result extends Mqtt5PublishResult {
+    interface Mqtt5Qos2Result extends Mqtt5PublishResult {
         @NotNull
         Mqtt5PubComp getPubComp();
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -20,7 +20,7 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
@@ -100,7 +100,7 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
 
     @NotNull
     @Override
-    public Mqtt5WillPublishBuilder<P> qos(@NotNull final MqttQoS qos) {
+    public Mqtt5WillPublishBuilder<P> qos(@NotNull final MqttQos qos) {
         super.qos(qos);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscription.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscription.java
@@ -19,7 +19,7 @@ package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 
 /**
@@ -59,7 +59,7 @@ public interface Mqtt5Subscription {
      * @return the QoS of this subscription.
      */
     @NotNull
-    MqttQoS getQoS();
+    MqttQos getQos();
 
     /**
      * @return whether the client must not receive messages published by itself. The default is {@link

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -20,7 +20,7 @@ package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 import com.google.common.base.Preconditions;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -36,7 +36,7 @@ import java.util.function.Function;
 public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription, P> {
 
     private MqttTopicFilterImpl topicFilter;
-    private MqttQoS qos;
+    private MqttQos qos;
     private boolean noLocal = Mqtt5Subscription.DEFAULT_NO_LOCAL;
     private Mqtt5RetainHandling retainHandling = Mqtt5Subscription.DEFAULT_RETAIN_HANDLING;
     private boolean retainAsPublished = Mqtt5Subscription.DEFAULT_RETAIN_AS_PUBLISHED;
@@ -63,7 +63,7 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
     }
 
     @NotNull
-    public Mqtt5SubscriptionBuilder<P> qos(@NotNull final MqttQoS qos) {
+    public Mqtt5SubscriptionBuilder<P> qos(@NotNull final MqttQos qos) {
         this.qos = Preconditions.checkNotNull(qos);
         return this;
     }

--- a/src/main/java/org/mqttbee/mqtt/MqttServerConnectionData.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttServerConnectionData.java
@@ -20,7 +20,7 @@ package org.mqttbee.mqtt;
 import io.netty.channel.Channel;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt3.Mqtt3ServerConnectionData;
 import org.mqttbee.api.mqtt.mqtt5.Mqtt5ServerConnectionData;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
@@ -46,7 +46,7 @@ public class MqttServerConnectionData implements Mqtt5ServerConnectionData, Mqtt
     private final int receiveMaximum;
     private final MqttTopicAliasMapping topicAliasMapping;
     private final int maximumPacketSize;
-    private final MqttQoS maximumQoS;
+    private final MqttQos maximumQos;
     private final boolean isRetainAvailable;
     private final boolean isWildcardSubscriptionAvailable;
     private final boolean isSubscriptionIdentifierAvailable;
@@ -54,12 +54,12 @@ public class MqttServerConnectionData implements Mqtt5ServerConnectionData, Mqtt
 
     public MqttServerConnectionData(
             final int receiveMaximum, final int topicAliasMaximum, final int maximumPacketSize,
-            final MqttQoS maximumQoS, final boolean isRetainAvailable, final boolean isWildcardSubscriptionAvailable,
+            final MqttQos maximumQos, final boolean isRetainAvailable, final boolean isWildcardSubscriptionAvailable,
             final boolean isSubscriptionIdentifierAvailable, final boolean isSharedSubscriptionAvailable) {
         this.receiveMaximum = receiveMaximum;
         this.maximumPacketSize = maximumPacketSize;
         this.topicAliasMapping = topicAliasMaximum == 0 ? null : new MqttTopicAliasMapping(topicAliasMaximum);
-        this.maximumQoS = maximumQoS;
+        this.maximumQos = maximumQos;
         this.isRetainAvailable = isRetainAvailable;
         this.isWildcardSubscriptionAvailable = isWildcardSubscriptionAvailable;
         this.isSubscriptionIdentifierAvailable = isSubscriptionIdentifierAvailable;
@@ -88,8 +88,8 @@ public class MqttServerConnectionData implements Mqtt5ServerConnectionData, Mqtt
 
     @NotNull
     @Override
-    public MqttQoS getMaximumQoS() {
-        return maximumQoS;
+    public MqttQos getMaximumQos() {
+        return maximumQos;
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/advanced/MqttAdvancedClientData.java
+++ b/src/main/java/org/mqttbee/mqtt/advanced/MqttAdvancedClientData.java
@@ -19,51 +19,51 @@ package org.mqttbee.mqtt.advanced;
 
 import org.mqttbee.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt5.advanced.Mqtt5AdvancedClientData;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5IncomingQoS1ControlProvider;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5OutgoingQoS1ControlProvider;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5IncomingQoS2ControlProvider;
-import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5OutgoingQoS2ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5IncomingQos1ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos1.Mqtt5OutgoingQos1ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5IncomingQos2ControlProvider;
+import org.mqttbee.api.mqtt.mqtt5.advanced.qos2.Mqtt5OutgoingQos2ControlProvider;
 
 /**
  * @author Silvio Giebl
  */
 public class MqttAdvancedClientData implements Mqtt5AdvancedClientData {
 
-    private final Mqtt5IncomingQoS1ControlProvider incomingQoS1ControlProvider;
-    private final Mqtt5OutgoingQoS1ControlProvider outgoingQoS1ControlProvider;
-    private final Mqtt5IncomingQoS2ControlProvider incomingQoS2ControlProvider;
-    private final Mqtt5OutgoingQoS2ControlProvider outgoingQoS2ControlProvider;
+    private final Mqtt5IncomingQos1ControlProvider incomingQos1ControlProvider;
+    private final Mqtt5OutgoingQos1ControlProvider outgoingQos1ControlProvider;
+    private final Mqtt5IncomingQos2ControlProvider incomingQos2ControlProvider;
+    private final Mqtt5OutgoingQos2ControlProvider outgoingQos2ControlProvider;
 
     public MqttAdvancedClientData(
-            @Nullable final Mqtt5IncomingQoS1ControlProvider incomingQoS1ControlProvider,
-            @Nullable final Mqtt5OutgoingQoS1ControlProvider outgoingQoS1ControlProvider,
-            @Nullable final Mqtt5IncomingQoS2ControlProvider incomingQoS2ControlProvider,
-            @Nullable final Mqtt5OutgoingQoS2ControlProvider outgoingQoS2ControlProvider) {
+            @Nullable final Mqtt5IncomingQos1ControlProvider incomingQos1ControlProvider,
+            @Nullable final Mqtt5OutgoingQos1ControlProvider outgoingQos1ControlProvider,
+            @Nullable final Mqtt5IncomingQos2ControlProvider incomingQos2ControlProvider,
+            @Nullable final Mqtt5OutgoingQos2ControlProvider outgoingQos2ControlProvider) {
 
-        this.incomingQoS1ControlProvider = incomingQoS1ControlProvider;
-        this.outgoingQoS1ControlProvider = outgoingQoS1ControlProvider;
-        this.incomingQoS2ControlProvider = incomingQoS2ControlProvider;
-        this.outgoingQoS2ControlProvider = outgoingQoS2ControlProvider;
+        this.incomingQos1ControlProvider = incomingQos1ControlProvider;
+        this.outgoingQos1ControlProvider = outgoingQos1ControlProvider;
+        this.incomingQos2ControlProvider = incomingQos2ControlProvider;
+        this.outgoingQos2ControlProvider = outgoingQos2ControlProvider;
     }
 
     @Nullable
-    public Mqtt5IncomingQoS1ControlProvider getIncomingQoS1ControlProvider() {
-        return incomingQoS1ControlProvider;
+    public Mqtt5IncomingQos1ControlProvider getIncomingQos1ControlProvider() {
+        return incomingQos1ControlProvider;
     }
 
     @Nullable
-    public Mqtt5OutgoingQoS1ControlProvider getOutgoingQoS1ControlProvider() {
-        return outgoingQoS1ControlProvider;
+    public Mqtt5OutgoingQos1ControlProvider getOutgoingQos1ControlProvider() {
+        return outgoingQos1ControlProvider;
     }
 
     @Nullable
-    public Mqtt5IncomingQoS2ControlProvider getIncomingQoS2ControlProvider() {
-        return incomingQoS2ControlProvider;
+    public Mqtt5IncomingQos2ControlProvider getIncomingQos2ControlProvider() {
+        return incomingQos2ControlProvider;
     }
 
     @Nullable
-    public Mqtt5OutgoingQoS2ControlProvider getOutgoingQoS2ControlProvider() {
-        return outgoingQoS2ControlProvider;
+    public Mqtt5OutgoingQos2ControlProvider getOutgoingQos2ControlProvider() {
+        return outgoingQos2ControlProvider;
     }
 
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/MqttMessageDecoderUtil.java
@@ -19,7 +19,7 @@ package org.mqttbee.mqtt.codec.decoder;
 
 import io.netty.buffer.ByteBuf;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
 
 import static org.mqttbee.mqtt.message.publish.MqttStatefulPublish.NO_PACKET_IDENTIFIER_QOS_0;
@@ -62,21 +62,21 @@ public class MqttMessageDecoderUtil {
     }
 
     @NotNull
-    public static MqttQoS decodePublishQoS(final int flags, final boolean dup) throws MqttDecoderException {
-        final MqttQoS qos = MqttQoS.fromCode((flags & 0b0110) >> 1);
+    public static MqttQos decodePublishQos(final int flags, final boolean dup) throws MqttDecoderException {
+        final MqttQos qos = MqttQos.fromCode((flags & 0b0110) >> 1);
         if (qos == null) {
             throw new MqttDecoderException("wrong QoS");
         }
-        if ((qos == MqttQoS.AT_MOST_ONCE) && dup) {
+        if ((qos == MqttQos.AT_MOST_ONCE) && dup) {
             throw new MqttDecoderException(Mqtt5DisconnectReasonCode.PROTOCOL_ERROR, "DUP flag must be 0 if QoS is 0");
         }
         return qos;
     }
 
-    public static int decodePublishPacketIdentifier(@NotNull final MqttQoS qos, @NotNull final ByteBuf in)
+    public static int decodePublishPacketIdentifier(@NotNull final MqttQos qos, @NotNull final ByteBuf in)
             throws MqttDecoderException {
 
-        if (qos == MqttQoS.AT_MOST_ONCE) {
+        if (qos == MqttQos.AT_MOST_ONCE) {
             return NO_PACKET_IDENTIFIER_QOS_0;
         }
         if (in.readableBytes() < 2) {

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3PublishDecoder.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.mqtt.MqttClientConnectionData;
 import org.mqttbee.mqtt.codec.decoder.MqttDecoderException;
 import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoder;
@@ -60,7 +60,7 @@ public class Mqtt3PublishDecoder implements MqttMessageDecoder {
         final Channel channel = clientConnectionData.getChannel();
 
         final boolean dup = (flags & 0b1000) != 0;
-        final MqttQoS qos = decodePublishQoS(flags, dup);
+        final MqttQos qos = decodePublishQos(flags, dup);
         final boolean retain = (flags & 0b0001) != 0;
 
         if (in.readableBytes() < MIN_REMAINING_LENGTH) {

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoder.java
@@ -22,7 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCode;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckRestrictions;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
@@ -98,8 +98,8 @@ public class Mqtt5ConnAckDecoder implements MqttMessageDecoder {
         boolean receiveMaximumPresent = false;
         int topicAliasMaximum = Mqtt5ConnAckRestrictions.DEFAULT_TOPIC_ALIAS_MAXIMUM;
         boolean topicAliasMaximumPresent = false;
-        MqttQoS maximumQoS = Mqtt5ConnAckRestrictions.DEFAULT_MAXIMUM_QOS;
-        boolean maximumQoSPresent = false;
+        MqttQos maximumQos = Mqtt5ConnAckRestrictions.DEFAULT_MAXIMUM_QOS;
+        boolean maximumQosPresent = false;
         boolean retainAvailable = Mqtt5ConnAckRestrictions.DEFAULT_RETAIN_AVAILABLE;
         boolean retainAvailablePresent = false;
         int maximumPacketSize = Mqtt5ConnAckRestrictions.DEFAULT_MAXIMUM_PACKET_SIZE_NO_LIMIT;
@@ -166,13 +166,13 @@ public class Mqtt5ConnAckDecoder implements MqttMessageDecoder {
                     break;
 
                 case MAXIMUM_QOS:
-                    final short maximumQoSCode = unsignedByteOnlyOnce(maximumQoSPresent, "maximum QoS", in);
-                    if (maximumQoSCode != 0 && maximumQoSCode != 1) {
-                        throw new MqttDecoderException(Mqtt5DisconnectReasonCode.PROTOCOL_ERROR, "wrong maximum QoS");
+                    final short maximumQosCode = unsignedByteOnlyOnce(maximumQosPresent, "maximum Qos", in);
+                    if (maximumQosCode != 0 && maximumQosCode != 1) {
+                        throw new MqttDecoderException(Mqtt5DisconnectReasonCode.PROTOCOL_ERROR, "wrong maximum Qos");
                     }
-                    maximumQoS = MqttQoS.fromCode(maximumQoSCode);
-                    maximumQoSPresent = true;
-                    restrictionsPresent |= maximumQoS != Mqtt5ConnAckRestrictions.DEFAULT_MAXIMUM_QOS;
+                    maximumQos = MqttQos.fromCode(maximumQosCode);
+                    maximumQosPresent = true;
+                    restrictionsPresent |= maximumQos != Mqtt5ConnAckRestrictions.DEFAULT_MAXIMUM_QOS;
                     break;
 
                 case RETAIN_AVAILABLE:
@@ -257,7 +257,7 @@ public class Mqtt5ConnAckDecoder implements MqttMessageDecoder {
 
         MqttConnAckRestrictions restrictions = MqttConnAckRestrictions.DEFAULT;
         if (restrictionsPresent) {
-            restrictions = new MqttConnAckRestrictions(receiveMaximum, topicAliasMaximum, maximumPacketSize, maximumQoS,
+            restrictions = new MqttConnAckRestrictions(receiveMaximum, topicAliasMaximum, maximumPacketSize, maximumQos,
                             retainAvailable, wildCardSubscriptionAvailable, subscriptionIdentifierAvailable,
                             sharedSubscriptionAvailable);
         }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
@@ -24,7 +24,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage;
@@ -69,7 +69,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
         final Channel channel = clientConnectionData.getChannel();
 
         final boolean dup = (flags & 0b1000) != 0;
-        final MqttQoS qos = decodePublishQoS(flags, dup);
+        final MqttQos qos = decodePublishQos(flags, dup);
         final boolean retain = (flags & 0b0001) != 0;
 
         if (in.readableBytes() < MIN_REMAINING_LENGTH) {

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PublishEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PublishEncoder.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
@@ -51,7 +51,7 @@ public class Mqtt3PublishEncoder extends Mqtt3MessageEncoder<MqttStatefulPublish
 
         remainingLength += stateless.getTopic().encodedLength();
 
-        if (stateless.getQos() != MqttQoS.AT_MOST_ONCE) {
+        if (stateless.getQos() != MqttQos.AT_MOST_ONCE) {
             remainingLength += 2;
         }
 
@@ -114,7 +114,7 @@ public class Mqtt3PublishEncoder extends Mqtt3MessageEncoder<MqttStatefulPublish
 
         stateless.getTopic().to(out);
 
-        if (stateless.getQos() != MqttQoS.AT_MOST_ONCE) {
+        if (stateless.getQos() != MqttQos.AT_MOST_ONCE) {
             out.writeShort(message.getPacketIdentifier());
         }
     }

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3SubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3SubscribeEncoder.java
@@ -77,7 +77,7 @@ public class Mqtt3SubscribeEncoder extends Mqtt3MessageEncoder<MqttStatefulSubsc
         for (int i = 0; i < subscriptions.size(); i++) {
             final MqttSubscription subscription = subscriptions.get(i);
             subscription.getTopicFilter().to(out);
-            out.writeByte(subscription.getQoS().getCode());
+            out.writeByte(subscription.getQos().getCode());
         }
     }
 

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoder.java
@@ -22,7 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.mqtt.datatypes.MqttBinaryData;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
@@ -62,7 +62,7 @@ public class Mqtt5PublishEncoder extends Mqtt5MessageWithUserPropertiesEncoder<M
             remainingLength = MqttBinaryData.EMPTY_LENGTH;
         }
 
-        if (stateless.getQos() != MqttQoS.AT_MOST_ONCE) {
+        if (stateless.getQos() != MqttQos.AT_MOST_ONCE) {
             remainingLength += 2;
         }
 
@@ -166,7 +166,7 @@ public class Mqtt5PublishEncoder extends Mqtt5MessageWithUserPropertiesEncoder<M
             MqttBinaryData.encodeEmpty(out);
         }
 
-        if (stateless.getQos() != MqttQoS.AT_MOST_ONCE) {
+        if (stateless.getQos() != MqttQos.AT_MOST_ONCE) {
             out.writeShort(message.getPacketIdentifier());
         }
 

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoder.java
@@ -117,7 +117,7 @@ public class Mqtt5SubscribeEncoder extends Mqtt5MessageWithUserPropertiesEncoder
             if (subscription.isNoLocal()) {
                 subscriptionOptions |= 0b0000_0100;
             }
-            subscriptionOptions |= subscription.getQoS().getCode();
+            subscriptionOptions |= subscription.getQos().getCode();
 
             out.writeByte(subscriptionOptions);
         }

--- a/src/main/java/org/mqttbee/mqtt/handler/connect/MqttConnectHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/connect/MqttConnectHandler.java
@@ -35,8 +35,8 @@ import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
 import org.mqttbee.mqtt.handler.disconnect.ChannelCloseEvent;
 import org.mqttbee.mqtt.handler.disconnect.MqttDisconnectUtil;
 import org.mqttbee.mqtt.handler.ping.MqttPingHandler;
-import org.mqttbee.mqtt.handler.publish.MqttIncomingQoSHandler;
-import org.mqttbee.mqtt.handler.publish.MqttOutgoingQoSHandler;
+import org.mqttbee.mqtt.handler.publish.MqttIncomingQosHandler;
+import org.mqttbee.mqtt.handler.publish.MqttOutgoingQosHandler;
 import org.mqttbee.mqtt.handler.subscribe.MqttSubscriptionHandler;
 import org.mqttbee.mqtt.handler.util.ChannelInboundHandlerWithTimeout;
 import org.mqttbee.mqtt.ioc.ChannelComponent;
@@ -193,9 +193,9 @@ public class MqttConnectHandler extends ChannelInboundHandlerWithTimeout {
                 pipeline.addAfter(
                         MqttPingHandler.NAME, MqttSubscriptionHandler.NAME, channelComponent.subscriptionHandler());
                 pipeline.addAfter(
-                        MqttPingHandler.NAME, MqttIncomingQoSHandler.NAME, channelComponent.incomingQoSHandler());
+                        MqttPingHandler.NAME, MqttIncomingQosHandler.NAME, channelComponent.incomingQosHandler());
                 pipeline.addAfter(
-                        MqttPingHandler.NAME, MqttOutgoingQoSHandler.NAME, channelComponent.outgoingQoSHandler());
+                        MqttPingHandler.NAME, MqttOutgoingQosHandler.NAME, channelComponent.outgoingQosHandler());
                 pipeline.addLast(MqttDisconnectOnConnAckHandler.NAME, channelComponent.disconnectOnConnAckHandler());
 
                 connAckEmitter.onSuccess(connAck);
@@ -288,7 +288,7 @@ public class MqttConnectHandler extends ChannelInboundHandlerWithTimeout {
 
         clientData.setServerConnectionData(
                 new MqttServerConnectionData(restrictions.getReceiveMaximum(), restrictions.getTopicAliasMaximum(),
-                        restrictions.getMaximumPacketSize(), restrictions.getMaximumQoS(),
+                        restrictions.getMaximumPacketSize(), restrictions.getMaximumQos(),
                         restrictions.isRetainAvailable(), restrictions.isWildcardSubscriptionAvailable(),
                         restrictions.isSubscriptionIdentifierAvailable(),
                         restrictions.isSharedSubscriptionAvailable()));

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishService.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttIncomingPublishService.java
@@ -41,7 +41,7 @@ public class MqttIncomingPublishService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MqttIncomingPublishService.class);
 
-    private final MqttIncomingQoSHandler incomingQoSHandler; // TODO temp
+    private final MqttIncomingQosHandler incomingQosHandler; // TODO temp
     private final MqttIncomingPublishFlows incomingPublishFlows;
     private final EventLoop nettyEventLoop;
 
@@ -54,13 +54,13 @@ public class MqttIncomingPublishService {
 
     @Inject
     MqttIncomingPublishService(
-            final MqttIncomingQoSHandler incomingQoSHandler, final MqttIncomingPublishFlows incomingPublishFlows,
+            final MqttIncomingQosHandler incomingQosHandler, final MqttIncomingPublishFlows incomingPublishFlows,
             final MqttClientData clientData) {
 
         final MqttClientConnectionData clientConnectionData = clientData.getRawClientConnectionData();
         assert clientConnectionData != null;
 
-        this.incomingQoSHandler = incomingQoSHandler; // TODO temp
+        this.incomingQosHandler = incomingQosHandler; // TODO temp
         this.incomingPublishFlows = incomingPublishFlows;
         nettyEventLoop = clientConnectionData.getChannel().eventLoop();
 
@@ -87,7 +87,7 @@ public class MqttIncomingPublishService {
         }
         emit(publish.getStatelessMessage(), flows);
         if (acknowledge && flows.isEmpty()) {
-            incomingQoSHandler.ack(publish);
+            incomingQosHandler.ack(publish);
         } else {
             queue.offer(new QueueEntry(publish, flows));
         }
@@ -109,7 +109,7 @@ public class MqttIncomingPublishService {
             emit(publish.getStatelessMessage(), flows);
             if (acknowledge && flows.isEmpty()) {
                 queueIt.remove();
-                incomingQoSHandler.ack(publish); // TODO temp
+                incomingQosHandler.ack(publish); // TODO temp
             } else {
                 acknowledge = false;
                 if (blockingFlowCount == referencedFlowCount) {

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttOutgoingPublishService.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttOutgoingPublishService.java
@@ -40,7 +40,7 @@ public class MqttOutgoingPublishService implements FlowableSubscriber<MqttPublis
 
     private static final int MAX_CONCURRENT_PUBLISH_FLOWABLES = 64;
 
-    private final MqttOutgoingQoSHandler outgoingQoSHandler;
+    private final MqttOutgoingQosHandler outgoingQosHandler;
     private final EventLoop nettyEventLoop;
 
     private Subscription subscription;
@@ -49,7 +49,7 @@ public class MqttOutgoingPublishService implements FlowableSubscriber<MqttPublis
 
     @Inject
     MqttOutgoingPublishService(
-            final MqttOutgoingQoSHandler outgoingQoSHandler, final MqttPublishFlowables publishFlowables,
+            final MqttOutgoingQosHandler outgoingQosHandler, final MqttPublishFlowables publishFlowables,
             final MqttClientData clientData) {
 
         final MqttServerConnectionData serverConnectionData = clientData.getRawServerConnectionData();
@@ -57,10 +57,10 @@ public class MqttOutgoingPublishService implements FlowableSubscriber<MqttPublis
         final MqttClientConnectionData clientConnectionData = clientData.getRawClientConnectionData();
         assert clientConnectionData != null;
 
-        this.outgoingQoSHandler = outgoingQoSHandler;
+        this.outgoingQosHandler = outgoingQosHandler;
         nettyEventLoop = clientConnectionData.getChannel().eventLoop();
 
-        receiveMaximum = MqttOutgoingQoSHandler.getPubReceiveMaximum(serverConnectionData.getReceiveMaximum());
+        receiveMaximum = MqttOutgoingQosHandler.getPubReceiveMaximum(serverConnectionData.getReceiveMaximum());
 
         publishFlowables.flatMap(f -> f, true, MAX_CONCURRENT_PUBLISH_FLOWABLES).subscribe(this);
     }
@@ -73,7 +73,7 @@ public class MqttOutgoingPublishService implements FlowableSubscriber<MqttPublis
 
     @Override
     public void onNext(final MqttPublishWithFlow publishWithFlow) {
-        outgoingQoSHandler.publish(publishWithFlow);
+        outgoingQosHandler.publish(publishWithFlow);
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/handler/subscribe/MqttSubscriptionHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/subscribe/MqttSubscriptionHandler.java
@@ -31,7 +31,7 @@ import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttServerConnectionData;
 import org.mqttbee.mqtt.handler.disconnect.MqttDisconnectUtil;
 import org.mqttbee.mqtt.handler.publish.MqttIncomingPublishFlows;
-import org.mqttbee.mqtt.handler.publish.MqttOutgoingQoSHandler;
+import org.mqttbee.mqtt.handler.publish.MqttOutgoingQosHandler;
 import org.mqttbee.mqtt.handler.publish.MqttSubscriptionFlow;
 import org.mqttbee.mqtt.handler.subscribe.MqttSubscribeWithFlow.MqttStatefulSubscribeWithFlow;
 import org.mqttbee.mqtt.handler.subscribe.MqttUnsubscribeWithFlow.MqttStatefulUnsubscribeWithFlow;
@@ -86,7 +86,7 @@ public class MqttSubscriptionHandler extends ChannelInboundHandlerAdapter {
         assert serverConnectionData != null;
 
         final int minPacketIdentifier =
-                MqttOutgoingQoSHandler.getPubReceiveMaximum(serverConnectionData.getReceiveMaximum()) + 1;
+                MqttOutgoingQosHandler.getPubReceiveMaximum(serverConnectionData.getReceiveMaximum()) + 1;
         final int maxPacketIdentifier = minPacketIdentifier + MAX_SUB_PENDING - 1;
         packetIdentifiers = new Ranges(minPacketIdentifier, maxPacketIdentifier);
         subscriptionIdentifiers = new Ranges(1, clientConnectionData.getSubscriptionIdentifierMaximum());

--- a/src/main/java/org/mqttbee/mqtt/ioc/ChannelComponent.java
+++ b/src/main/java/org/mqttbee/mqtt/ioc/ChannelComponent.java
@@ -78,9 +78,9 @@ public interface ChannelComponent {
 
     MqttSubscriptionHandler subscriptionHandler();
 
-    MqttIncomingQoSHandler incomingQoSHandler();
+    MqttIncomingQosHandler incomingQosHandler();
 
-    MqttOutgoingQoSHandler outgoingQoSHandler();
+    MqttOutgoingQosHandler outgoingQosHandler();
 
     MqttIncomingPublishService incomingPublishService();
 

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckRestrictions.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckRestrictions.java
@@ -18,7 +18,7 @@
 package org.mqttbee.mqtt.message.connect.connack;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckRestrictions;
 
 import javax.annotation.concurrent.Immutable;
@@ -39,7 +39,7 @@ public class MqttConnAckRestrictions implements Mqtt5ConnAckRestrictions {
     private final int receiveMaximum;
     private final int topicAliasMaximum;
     private final int maximumPacketSize;
-    private final MqttQoS maximumQoS;
+    private final MqttQos maximumQos;
     private final boolean isRetainAvailable;
     private final boolean isWildcardSubscriptionAvailable;
     private final boolean isSubscriptionIdentifierAvailable;
@@ -47,13 +47,13 @@ public class MqttConnAckRestrictions implements Mqtt5ConnAckRestrictions {
 
     public MqttConnAckRestrictions(
             final int receiveMaximum, final int topicAliasMaximum, final int maximumPacketSize,
-            final MqttQoS maximumQoS, final boolean isRetainAvailable, final boolean isWildcardSubscriptionAvailable,
+            final MqttQos maximumQos, final boolean isRetainAvailable, final boolean isWildcardSubscriptionAvailable,
             final boolean isSubscriptionIdentifierAvailable, final boolean isSharedSubscriptionAvailable) {
 
         this.receiveMaximum = receiveMaximum;
         this.topicAliasMaximum = topicAliasMaximum;
         this.maximumPacketSize = maximumPacketSize;
-        this.maximumQoS = maximumQoS;
+        this.maximumQos = maximumQos;
         this.isRetainAvailable = isRetainAvailable;
         this.isWildcardSubscriptionAvailable = isWildcardSubscriptionAvailable;
         this.isSubscriptionIdentifierAvailable = isSubscriptionIdentifierAvailable;
@@ -76,8 +76,8 @@ public class MqttConnAckRestrictions implements Mqtt5ConnAckRestrictions {
     }
 
     @Override
-    public MqttQoS getMaximumQoS() {
-        return maximumQoS;
+    public MqttQos getMaximumQos() {
+        return maximumQos;
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
@@ -20,7 +20,7 @@ package org.mqttbee.mqtt.message.publish;
 import com.google.common.primitives.ImmutableIntArray;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
@@ -46,7 +46,7 @@ public class MqttPublish extends MqttMessageWithUserPropertiesImpl implements Mq
 
     private final MqttTopicImpl topic;
     private final ByteBuffer payload;
-    private final MqttQoS qos;
+    private final MqttQos qos;
     private final boolean isRetain;
     private final long messageExpiryInterval;
     private final Mqtt5PayloadFormatIndicator payloadFormatIndicator;
@@ -56,7 +56,7 @@ public class MqttPublish extends MqttMessageWithUserPropertiesImpl implements Mq
     private final TopicAliasUsage topicAliasUsage;
 
     public MqttPublish(
-            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQoS qos,
+            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQos qos,
             final boolean isRetain, final long messageExpiryInterval,
             @Nullable final Mqtt5PayloadFormatIndicator payloadFormatIndicator,
             @Nullable final MqttUTF8StringImpl contentType, @Nullable final MqttTopicImpl responseTopic,
@@ -104,7 +104,7 @@ public class MqttPublish extends MqttMessageWithUserPropertiesImpl implements Mq
 
     @NotNull
     @Override
-    public MqttQoS getQos() {
+    public MqttQos getQos() {
         return qos;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishResult.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishResult.java
@@ -56,12 +56,12 @@ public class MqttPublishResult implements Mqtt5PublishResult {
     }
 
 
-    public static class MqttQoS1Result extends MqttPublishResult implements Mqtt5QoS1Result {
+    public static class MqttQos1Result extends MqttPublishResult implements Mqtt5Qos1Result {
 
         @NotNull
         private final MqttPubAck pubAck;
 
-        public MqttQoS1Result(
+        public MqttQos1Result(
                 @NotNull final MqttPublish publish, @Nullable final Throwable error, @NotNull final MqttPubAck pubAck) {
 
             super(publish, error);
@@ -77,12 +77,12 @@ public class MqttPublishResult implements Mqtt5PublishResult {
     }
 
 
-    public static class MqttQoS2Result extends MqttPublishResult implements Mqtt5QoS2Result {
+    public static class MqttQos2Result extends MqttPublishResult implements Mqtt5Qos2Result {
 
         @NotNull
         private final MqttPubComp pubComp;
 
-        public MqttQoS2Result(
+        public MqttQos2Result(
                 @NotNull final MqttPublish publish, @Nullable final Throwable error,
                 @NotNull final MqttPubComp pubComp) {
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttQosMessage.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttQosMessage.java
@@ -15,25 +15,13 @@
  *
  */
 
-package org.mqttbee.mqtt.persistence;
-
-import org.mqttbee.annotations.NotNull;
-import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
-
-import java.util.concurrent.CompletableFuture;
+package org.mqttbee.mqtt.message.publish;
 
 /**
  * @author Silvio Giebl
  */
-public interface IncomingQoSFlowPersistence {
+public interface MqttQosMessage {
 
-    @NotNull
-    CompletableFuture<Void> store(@NotNull MqttPubRec pubRec);
-
-    @NotNull
-    CompletableFuture<MqttPubRec> get(int packetIdentifier);
-
-    @NotNull
-    CompletableFuture<Void> discard(int packetIdentifier);
+    int getPacketIdentifier();
 
 }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttStatefulPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttStatefulPublish.java
@@ -27,7 +27,7 @@ import javax.annotation.concurrent.Immutable;
  * @author Silvio Giebl
  */
 @Immutable
-public class MqttStatefulPublish extends MqttStatefulMessageWithId<MqttPublish> implements MqttQoSMessage {
+public class MqttStatefulPublish extends MqttStatefulMessageWithId<MqttPublish> implements MqttQosMessage {
 
     public static final int NO_PACKET_IDENTIFIER_QOS_0 = -1;
     public static final int DEFAULT_NO_TOPIC_ALIAS = -1;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
@@ -19,7 +19,7 @@ package org.mqttbee.mqtt.message.publish;
 
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublish;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage;
@@ -39,7 +39,7 @@ public class MqttWillPublish extends MqttPublish implements Mqtt5WillPublish {
     private final long delayInterval;
 
     public MqttWillPublish(
-            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQoS qos,
+            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQos qos,
             final boolean isRetain, final long messageExpiryInterval,
             @Nullable final Mqtt5PayloadFormatIndicator payloadFormatIndicator,
             @Nullable final MqttUTF8StringImpl contentType, @Nullable final MqttTopicImpl responseTopic,

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -20,7 +20,7 @@ package org.mqttbee.mqtt.message.publish.mqtt3;
 import io.reactivex.functions.Function;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish;
@@ -50,7 +50,7 @@ public class Mqtt3PublishView implements Mqtt3Publish {
 
     @NotNull
     public static MqttPublish delegate(
-            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQoS qos,
+            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQos qos,
             final boolean isRetain) {
 
         return new MqttPublish(topic, payload, qos, isRetain, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null,
@@ -72,7 +72,7 @@ public class Mqtt3PublishView implements Mqtt3Publish {
 
     @NotNull
     public static Mqtt3PublishView of(
-            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQoS qos,
+            @NotNull final MqttTopicImpl topic, @Nullable final ByteBuffer payload, @NotNull final MqttQos qos,
             final boolean isRetain) {
 
         return new Mqtt3PublishView(delegate(topic, payload, qos, isRetain));
@@ -114,7 +114,7 @@ public class Mqtt3PublishView implements Mqtt3Publish {
 
     @NotNull
     @Override
-    public MqttQoS getQos() {
+    public MqttQos getQos() {
         return delegate.getQos();
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAck.java
@@ -24,7 +24,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties.MqttMessageWithIdAndReasonCode;
-import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
+import org.mqttbee.mqtt.message.publish.MqttQosMessage;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public class MqttPubAck extends MqttMessageWithIdAndReasonCode<Mqtt5PubAckReasonCode>
-        implements Mqtt5PubAck, MqttQoSMessage {
+        implements Mqtt5PubAck, MqttQosMessage {
 
     @NotNull
     public static final Mqtt5PubAckReasonCode DEFAULT_REASON_CODE = Mqtt5PubAckReasonCode.SUCCESS;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubComp.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubComp.java
@@ -24,7 +24,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp.Mqtt5PubCompReasonCode
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties.MqttMessageWithIdAndReasonCode;
-import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
+import org.mqttbee.mqtt.message.publish.MqttQosMessage;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public class MqttPubComp extends MqttMessageWithIdAndReasonCode<Mqtt5PubCompReasonCode>
-        implements Mqtt5PubComp, MqttQoSMessage {
+        implements Mqtt5PubComp, MqttQosMessage {
 
     @NotNull
     public static final Mqtt5PubCompReasonCode DEFAULT_REASON_CODE = Mqtt5PubCompReasonCode.SUCCESS;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRec.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRec.java
@@ -24,7 +24,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRecReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties.MqttMessageWithIdAndReasonCode;
-import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
+import org.mqttbee.mqtt.message.publish.MqttQosMessage;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public class MqttPubRec extends MqttMessageWithIdAndReasonCode<Mqtt5PubRecReasonCode>
-        implements Mqtt5PubRec, MqttQoSMessage {
+        implements Mqtt5PubRec, MqttQosMessage {
 
     @NotNull
     public static final Mqtt5PubRecReasonCode DEFAULT_REASON_CODE = Mqtt5PubRecReasonCode.SUCCESS;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRel.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRel.java
@@ -24,7 +24,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRelReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties.MqttMessageWithIdAndReasonCode;
-import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
+import org.mqttbee.mqtt.message.publish.MqttQosMessage;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -33,7 +33,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public class MqttPubRel extends MqttMessageWithIdAndReasonCode<Mqtt5PubRelReasonCode>
-        implements Mqtt5PubRel, MqttQoSMessage {
+        implements Mqtt5PubRel, MqttQosMessage {
 
     @NotNull
     public static final Mqtt5PubRelReasonCode DEFAULT_REASON_CODE = Mqtt5PubRelReasonCode.SUCCESS;

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscription.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscription.java
@@ -18,7 +18,7 @@
 package org.mqttbee.mqtt.message.subscribe;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5RetainHandling;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -32,13 +32,13 @@ import javax.annotation.concurrent.Immutable;
 public class MqttSubscription implements Mqtt5Subscription {
 
     private final MqttTopicFilterImpl topicFilter;
-    private final MqttQoS qos;
+    private final MqttQos qos;
     private final boolean isNoLocal;
     private final Mqtt5RetainHandling retainHandling;
     private final boolean isRetainAsPublished;
 
     public MqttSubscription(
-            @NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQoS qos, final boolean isNoLocal,
+            @NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQos qos, final boolean isNoLocal,
             @NotNull final Mqtt5RetainHandling retainHandling, final boolean isRetainAsPublished) {
 
         this.topicFilter = topicFilter;
@@ -56,7 +56,7 @@ public class MqttSubscription implements Mqtt5Subscription {
 
     @NotNull
     @Override
-    public MqttQoS getQoS() {
+    public MqttQos getQos() {
         return qos;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscriptionView.java
@@ -18,7 +18,7 @@
 package org.mqttbee.mqtt.message.subscribe.mqtt3;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscription;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5RetainHandling;
@@ -32,12 +32,12 @@ public class Mqtt3SubscriptionView implements Mqtt3Subscription {
 
     @NotNull
     private static MqttSubscription delegate(
-            @NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQoS qos) {
+            @NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQos qos) {
         return new MqttSubscription(topicFilter, qos, false, Mqtt5RetainHandling.SEND, false);
     }
 
     @NotNull
-    public static Mqtt3SubscriptionView of(@NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQoS qos) {
+    public static Mqtt3SubscriptionView of(@NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQos qos) {
         return new Mqtt3SubscriptionView(delegate(topicFilter, qos));
     }
 
@@ -60,8 +60,8 @@ public class Mqtt3SubscriptionView implements Mqtt3Subscription {
 
     @NotNull
     @Override
-    public MqttQoS getQoS() {
-        return delegate.getQoS();
+    public MqttQos getQos() {
+        return delegate.getQos();
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt/persistence/IncomingQosFlowPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt/persistence/IncomingQosFlowPersistence.java
@@ -15,13 +15,25 @@
  *
  */
 
-package org.mqttbee.mqtt.message.publish;
+package org.mqttbee.mqtt.persistence;
+
+import org.mqttbee.annotations.NotNull;
+import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author Silvio Giebl
  */
-public interface MqttQoSMessage {
+public interface IncomingQosFlowPersistence {
 
-    int getPacketIdentifier();
+    @NotNull
+    CompletableFuture<Void> store(@NotNull MqttPubRec pubRec);
+
+    @NotNull
+    CompletableFuture<MqttPubRec> get(int packetIdentifier);
+
+    @NotNull
+    CompletableFuture<Void> discard(int packetIdentifier);
 
 }

--- a/src/main/java/org/mqttbee/mqtt/persistence/MqttPersistenceModule.java
+++ b/src/main/java/org/mqttbee/mqtt/persistence/MqttPersistenceModule.java
@@ -22,8 +22,8 @@ import dagger.Module;
 import dagger.Provides;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.mqtt.ioc.ChannelScope;
-import org.mqttbee.mqtt.persistence.memory.IncomingQoSFlowMemoryPersistence;
-import org.mqttbee.mqtt.persistence.memory.OutgoingQoSFlowMemoryPersistence;
+import org.mqttbee.mqtt.persistence.memory.IncomingQosFlowMemoryPersistence;
+import org.mqttbee.mqtt.persistence.memory.OutgoingQosFlowMemoryPersistence;
 
 /**
  * @author Silvio Giebl
@@ -33,16 +33,16 @@ public class MqttPersistenceModule {
 
     @Provides
     @ChannelScope
-    static OutgoingQoSFlowPersistence provideOutgoingQoSFlowPersistence(
-            @NotNull final Lazy<OutgoingQoSFlowMemoryPersistence> memoryPersistence) {
+    static OutgoingQosFlowPersistence provideOutgoingQosFlowPersistence(
+            @NotNull final Lazy<OutgoingQosFlowMemoryPersistence> memoryPersistence) {
 
         return memoryPersistence.get(); // TODO file persistence
     }
 
     @Provides
     @ChannelScope
-    static IncomingQoSFlowPersistence provideIncomingQoSFlowPersistence(
-            @NotNull final Lazy<IncomingQoSFlowMemoryPersistence> memoryPersistence) {
+    static IncomingQosFlowPersistence provideIncomingQosFlowPersistence(
+            @NotNull final Lazy<IncomingQosFlowMemoryPersistence> memoryPersistence) {
 
         return memoryPersistence.get(); // TODO file persistence
     }

--- a/src/main/java/org/mqttbee/mqtt/persistence/OutgoingQosFlowPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt/persistence/OutgoingQosFlowPersistence.java
@@ -15,25 +15,30 @@
  *
  */
 
-package org.mqttbee.api.mqtt.mqtt5.advanced.qos1;
+package org.mqttbee.mqtt.persistence;
 
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAck;
+import org.mqttbee.mqtt.message.publish.MqttQosMessage;
+import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
+import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface for providers for controlling the QoS 1 control flow for outgoing PUBLISH messages.
- *
  * @author Silvio Giebl
  */
-public interface Mqtt5OutgoingQoS1ControlProvider {
+public interface OutgoingQosFlowPersistence {
 
-    /**
-     * Called when a server sent a PUBACK message for a Publish with QoS 1.
-     * <p>
-     * This method must not block.
-     *
-     * @param pubAck the PUBACK message sent by the server.
-     */
-    void onPubAck(@NotNull Mqtt5PubAck pubAck);
+    @NotNull
+    CompletableFuture<Void> store(@NotNull MqttStatefulPublish publish);
+
+    @NotNull
+    CompletableFuture<Void> store(@NotNull MqttPubRel pubRel);
+
+    @NotNull
+    CompletableFuture<MqttQosMessage> get(int packetIdentifier);
+
+    @NotNull
+    CompletableFuture<Void> discard(int packetIdentifier);
 
 }

--- a/src/main/java/org/mqttbee/mqtt/persistence/memory/IncomingQosFlowMemoryPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt/persistence/memory/IncomingQosFlowMemoryPersistence.java
@@ -20,7 +20,7 @@ package org.mqttbee.mqtt.persistence.memory;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.mqtt.ioc.ChannelScope;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
-import org.mqttbee.mqtt.persistence.IncomingQoSFlowPersistence;
+import org.mqttbee.mqtt.persistence.IncomingQosFlowPersistence;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -31,12 +31,12 @@ import java.util.concurrent.CompletableFuture;
  * @author Silvio Giebl
  */
 @ChannelScope
-public class IncomingQoSFlowMemoryPersistence implements IncomingQoSFlowPersistence {
+public class IncomingQosFlowMemoryPersistence implements IncomingQosFlowPersistence {
 
     private final Map<Integer, MqttPubRec> messages;
 
     @Inject
-    IncomingQoSFlowMemoryPersistence() {
+    IncomingQosFlowMemoryPersistence() {
         messages = new HashMap<>();
     }
 

--- a/src/main/java/org/mqttbee/mqtt/persistence/memory/OutgoingQosFlowMemoryPersistence.java
+++ b/src/main/java/org/mqttbee/mqtt/persistence/memory/OutgoingQosFlowMemoryPersistence.java
@@ -21,10 +21,10 @@ import org.mqttbee.annotations.NotNull;
 import org.mqttbee.mqtt.MqttClientConnectionData;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.ioc.ChannelScope;
-import org.mqttbee.mqtt.message.publish.MqttQoSMessage;
+import org.mqttbee.mqtt.message.publish.MqttQosMessage;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
-import org.mqttbee.mqtt.persistence.OutgoingQoSFlowPersistence;
+import org.mqttbee.mqtt.persistence.OutgoingQosFlowPersistence;
 import org.mqttbee.util.collections.IntMap;
 
 import javax.inject.Inject;
@@ -34,12 +34,12 @@ import java.util.concurrent.CompletableFuture;
  * @author Silvio Giebl
  */
 @ChannelScope
-public class OutgoingQoSFlowMemoryPersistence implements OutgoingQoSFlowPersistence {
+public class OutgoingQosFlowMemoryPersistence implements OutgoingQosFlowPersistence {
 
-    private final IntMap<MqttQoSMessage> messages;
+    private final IntMap<MqttQosMessage> messages;
 
     @Inject
-    OutgoingQoSFlowMemoryPersistence(final MqttClientData clientData) {
+    OutgoingQosFlowMemoryPersistence(final MqttClientData clientData) {
         final MqttClientConnectionData clientConnectionData = clientData.getRawClientConnectionData();
         assert clientConnectionData != null;
         this.messages = new IntMap<>(1, clientConnectionData.getReceiveMaximum());
@@ -61,7 +61,7 @@ public class OutgoingQoSFlowMemoryPersistence implements OutgoingQoSFlowPersiste
 
     @NotNull
     @Override
-    public CompletableFuture<MqttQoSMessage> get(final int packetIdentifier) {
+    public CompletableFuture<MqttQosMessage> get(final int packetIdentifier) {
         return CompletableFuture.completedFuture(messages.get(packetIdentifier));
     }
 

--- a/src/test/java/org/mqttbee/api/mqtt/datatypes/MqttQosTest.java
+++ b/src/test/java/org/mqttbee/api/mqtt/datatypes/MqttQosTest.java
@@ -24,46 +24,46 @@ import static org.junit.Assert.*;
 /**
  * @author Silvio Giebl
  */
-public class MqttQoSTest {
+public class MqttQosTest {
 
     @Test
     public void test_getCode_atMostOnce() {
-        assertEquals(0, MqttQoS.AT_MOST_ONCE.getCode());
+        assertEquals(0, MqttQos.AT_MOST_ONCE.getCode());
     }
 
     @Test
     public void test_getCode_atLeastOnce() {
-        assertEquals(1, MqttQoS.AT_LEAST_ONCE.getCode());
+        assertEquals(1, MqttQos.AT_LEAST_ONCE.getCode());
     }
 
     @Test
     public void test_getCode_exactlyOnce() {
-        assertEquals(2, MqttQoS.EXACTLY_ONCE.getCode());
+        assertEquals(2, MqttQos.EXACTLY_ONCE.getCode());
     }
 
     @Test
     public void test_fromCode_0() {
-        assertSame(MqttQoS.AT_MOST_ONCE, MqttQoS.fromCode(0));
+        assertSame(MqttQos.AT_MOST_ONCE, MqttQos.fromCode(0));
     }
 
     @Test
     public void test_fromCode_1() {
-        assertSame(MqttQoS.AT_LEAST_ONCE, MqttQoS.fromCode(1));
+        assertSame(MqttQos.AT_LEAST_ONCE, MqttQos.fromCode(1));
     }
 
     @Test
     public void test_fromCode_2() {
-        assertSame(MqttQoS.EXACTLY_ONCE, MqttQoS.fromCode(2));
+        assertSame(MqttQos.EXACTLY_ONCE, MqttQos.fromCode(2));
     }
 
     @Test
     public void test_fromCode_3() {
-        assertNull(MqttQoS.fromCode(3));
+        assertNull(MqttQos.fromCode(3));
     }
 
     @Test
     public void test_fromCode_negative() {
-        assertNull(MqttQoS.fromCode(-1));
+        assertNull(MqttQos.fromCode(-1));
     }
 
 }

--- a/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3ClientExample.java
@@ -26,7 +26,7 @@ import org.mqttbee.api.mqtt.MqttClient;
 import org.mqttbee.api.mqtt.MqttClientBuilder;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
 import org.mqttbee.api.mqtt.MqttWebsocketConfig;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt3.Mqtt3Client;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAck;
@@ -125,7 +125,7 @@ class Mqtt3ClientExample {
     }
 
     Completable subscribeTo(
-            final String topic, final MqttQoS qos, final int countToPublish, final CountDownLatch subscribedLatch) {
+            final String topic, final MqttQos qos, final int countToPublish, final CountDownLatch subscribedLatch) {
 
         final Mqtt3Client client = getClient();
 
@@ -172,7 +172,7 @@ class Mqtt3ClientExample {
         return !(port == 1883 || port == 8883 || port == 8884);
     }
 
-    Completable publish(final String topic, final MqttQoS qos, final int countToPublish) {
+    Completable publish(final String topic, final MqttQos qos, final int countToPublish) {
         final Mqtt3Client client = getClient();
 
         // create a CONNECT message with keep alive of 10 seconds
@@ -241,7 +241,7 @@ class Mqtt3ClientExample {
         final String command = getProperty(COMMAND, SUBSCRIBE);
         final int count = Integer.valueOf(getProperty(COUNT, "100"));
         final String topic = getProperty(TOPIC, "a/b");
-        final MqttQoS qos = MqttQoS.fromCode(Integer.parseInt(getProperty(QOS, "1")));
+        final MqttQos qos = MqttQos.fromCode(Integer.parseInt(getProperty(QOS, "1")));
 
         final String server = getProperty(SERVER, "test.mosquitto.org");
         final int port = Integer.valueOf(getProperty(PORT, "1883"));

--- a/src/test/java/org/mqttbee/example/Mqtt3SmokeTest.java
+++ b/src/test/java/org/mqttbee/example/Mqtt3SmokeTest.java
@@ -19,7 +19,7 @@ package org.mqttbee.example;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.util.KeyStoreUtil;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -46,7 +46,7 @@ class Mqtt3SmokeTest {
     private static final String TRUSTSTORE_PATH = "testkeys/mosquitto/cacerts.jks";
     private static final String TRUSTSTORE_PASS = "testcas";
     private final String server = "test.mosquitto.org";
-    private final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+    private final MqttQos qos = MqttQos.AT_LEAST_ONCE;
     private final String topic;
     private final Mqtt3ClientExample subscribeInstance;
     private Mqtt3ClientExample publishInstance;

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoderTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5EnhancedAuth;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
@@ -140,7 +140,7 @@ class Mqtt5ConnAckDecoderTest extends AbstractMqtt5DecoderTest {
 
         final Mqtt5ConnAckRestrictions restrictions = connAck.getRestrictions();
         assertEquals(100, restrictions.getReceiveMaximum());
-        assertEquals(MqttQoS.AT_LEAST_ONCE, restrictions.getMaximumQoS());
+        assertEquals(MqttQos.AT_LEAST_ONCE, restrictions.getMaximumQos());
         assertEquals(false, restrictions.isRetainAvailable());
         assertEquals(100, restrictions.getMaximumPacketSize());
         assertEquals(5, restrictions.getTopicAliasMaximum());
@@ -2052,7 +2052,7 @@ class Mqtt5ConnAckDecoderTest extends AbstractMqtt5DecoderTest {
 
         assertEquals(0, connAck.getRestrictions().getTopicAliasMaximum());
         assertEquals(65_535, connAck.getRestrictions().getReceiveMaximum());
-        assertEquals(MqttQoS.EXACTLY_ONCE, connAck.getRestrictions().getMaximumQoS());
+        assertEquals(MqttQos.EXACTLY_ONCE, connAck.getRestrictions().getMaximumQos());
         assertEquals(true, connAck.getRestrictions().isRetainAvailable());
         assertEquals(true, connAck.getRestrictions().isWildcardSubscriptionAvailable());
         assertEquals(true, connAck.getRestrictions().isSubscriptionIdentifierAvailable());

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -22,7 +22,7 @@ import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.Test;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
@@ -107,7 +107,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertNotNull(publish);
 
         assertEquals("topic", publish.getTopic().toString());
-        assertEquals(MqttQoS.AT_LEAST_ONCE, publish.getQos());
+        assertEquals(MqttQos.AT_LEAST_ONCE, publish.getQos());
         assertEquals(true, publish.isRetain());
         assertTrue(publish.getMessageExpiryInterval().isPresent());
         assertEquals(10, (long) publish.getMessageExpiryInterval().get());
@@ -161,7 +161,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertNotNull(publish);
 
         assertEquals("topic", publish.getTopic().toString());
-        assertEquals(MqttQoS.AT_MOST_ONCE, publish.getQos());
+        assertEquals(MqttQos.AT_MOST_ONCE, publish.getQos());
         assertEquals(true, publish.isRetain());
         assertFalse(publish.getMessageExpiryInterval().isPresent());
         assertTrue(publish.getPayloadFormatIndicator().isPresent());
@@ -221,7 +221,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
                 0x01, 0
         };
         final MqttPublish decodeQos0 = decode(encodedQos0);
-        assertEquals(MqttQoS.AT_MOST_ONCE, decodeQos0.getQos());
+        assertEquals(MqttQos.AT_MOST_ONCE, decodeQos0.getQos());
 
         final byte[] encodedQos1 = {
                 // fixed header
@@ -240,7 +240,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
                 0x01, 0
         };
         final MqttPublish decodeQos1 = decode(encodedQos1);
-        assertEquals(MqttQoS.AT_LEAST_ONCE, decodeQos1.getQos());
+        assertEquals(MqttQos.AT_LEAST_ONCE, decodeQos1.getQos());
 
         final byte[] encodedQos2 = {
                 // fixed header
@@ -259,7 +259,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
                 0x01, 0
         };
         final MqttPublish decodeQos2 = decode(encodedQos2);
-        assertEquals(MqttQoS.EXACTLY_ONCE, decodeQos2.getQos());
+        assertEquals(MqttQos.EXACTLY_ONCE, decodeQos2.getQos());
     }
 
     @Test

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/AbstractMqtt5EncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/AbstractMqtt5EncoderTest.java
@@ -22,7 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.mqtt.MqttClientData;
 import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
 import org.mqttbee.mqtt.MqttServerConnectionData;
@@ -74,7 +74,7 @@ public class AbstractMqtt5EncoderTest {
 
     protected void createServerConnectionData(final int maximumPacketSize) {
         clientData.setServerConnectionData(
-                new MqttServerConnectionData(10, 3, maximumPacketSize, MqttQoS.EXACTLY_ONCE, true, true, true, true));
+                new MqttServerConnectionData(10, 3, maximumPacketSize, MqttQos.EXACTLY_ONCE, true, true, true, true));
     }
 
     protected void encode(final Object message, final byte[] expected) {

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoderTest.java
@@ -21,7 +21,7 @@ import com.google.common.primitives.Bytes;
 import io.netty.buffer.ByteBuf;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.Test;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
@@ -94,7 +94,7 @@ class Mqtt3ConnectEncoderTest extends AbstractMqtt5EncoderTest {
         final byte[] expected = Bytes.concat(pahoConnect.getHeader(), pahoConnect.getPayload());
 
         final MqttWillPublish willMessage = new MqttWillPublish(Objects.requireNonNull(MqttTopicImpl.from(willTopic)),
-                ByteBuffer.wrap(myLastWill.getBytes()), Objects.requireNonNull(MqttQoS.fromCode(qosWill)), isRetained,
+                ByteBuffer.wrap(myLastWill.getBytes()), Objects.requireNonNull(MqttQos.fromCode(qosWill)), isRetained,
                 MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null,
                 MqttUserPropertiesImpl.NO_USER_PROPERTIES, 0);
 

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.EncoderException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.exceptions.MqttBinaryDataExceededException;
 import org.mqttbee.api.mqtt.exceptions.MqttVariableByteIntegerExceededException;
@@ -160,12 +160,12 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
 
         final MqttTopicImpl willTopic = requireNonNull(MqttTopicImpl.from("topic"));
         final ByteBuffer willPayload = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-        final MqttQoS willQoS = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos willQos = MqttQos.AT_LEAST_ONCE;
         final MqttUTF8StringImpl willContentType = requireNonNull(MqttUTF8StringImpl.from("text"));
         final MqttTopicImpl willResponseTopic = requireNonNull(MqttTopicImpl.from("response"));
         final ByteBuffer willCorrelationData = ByteBuffer.wrap(new byte[]{5, 4, 3, 2, 1});
         final MqttWillPublish willPublish =
-                new MqttWillPublish(willTopic, willPayload, willQoS, true, 10, Mqtt5PayloadFormatIndicator.UTF_8,
+                new MqttWillPublish(willTopic, willPayload, willQos, true, 10, Mqtt5PayloadFormatIndicator.UTF_8,
                         willContentType, willResponseTopic, willCorrelationData, userProperties, 5);
 
         final MqttConnectRestrictions restrictions = new MqttConnectRestrictions(5, 10, 100);
@@ -381,7 +381,7 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
         final MqttTopicImpl willTopic = requireNonNull(MqttTopicImpl.from("topic"));
         final ByteBuffer willPayload = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
         final MqttClientIdentifierImpl clientIdentifier = requireNonNull(MqttClientIdentifierImpl.from("test"));
-        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, willPayload, MqttQoS.AT_MOST_ONCE, false,
+        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, willPayload, MqttQos.AT_MOST_ONCE, false,
                 MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null,
                 MqttUserPropertiesImpl.NO_USER_PROPERTIES, 0);
         final MqttConnect connect = new MqttConnect(0, false, 0, false, true, DEFAULT, null, null, willPublish,
@@ -397,7 +397,7 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
         final MqttTopicImpl willTopic = requireNonNull(MqttTopicImpl.from("topic"));
         final ByteBuffer willPayload = ByteBuffer.wrap(new byte[65536]);
         final MqttClientIdentifierImpl clientIdentifier = requireNonNull(MqttClientIdentifierImpl.from("test"));
-        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, willPayload, MqttQoS.AT_MOST_ONCE, false,
+        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, willPayload, MqttQos.AT_MOST_ONCE, false,
                 MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null,
                 MqttUserPropertiesImpl.NO_USER_PROPERTIES, 0);
         final MqttConnect connect = new MqttConnect(0, false, 0, false, true, DEFAULT, null, null, willPublish,
@@ -413,7 +413,7 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
         final MqttTopicImpl willTopic = requireNonNull(MqttTopicImpl.from("topic"));
         final ByteBuffer correlationData = ByteBuffer.wrap(new byte[65536]);
         final MqttClientIdentifierImpl clientIdentifier = requireNonNull(MqttClientIdentifierImpl.from("test"));
-        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, null, MqttQoS.AT_MOST_ONCE, false,
+        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, null, MqttQos.AT_MOST_ONCE, false,
                 MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, correlationData,
                 MqttUserPropertiesImpl.NO_USER_PROPERTIES, 0);
         final MqttConnect connect = new MqttConnect(0, false, 0, false, true, DEFAULT, null, null, willPublish,
@@ -431,7 +431,7 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
 
         final MqttTopicImpl willTopic = requireNonNull(MqttTopicImpl.from("topic"));
         final MqttClientIdentifierImpl clientIdentifier = requireNonNull(MqttClientIdentifierImpl.from("test"));
-        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, null, MqttQoS.AT_MOST_ONCE, false,
+        final MqttWillPublish willPublish = new MqttWillPublish(willTopic, null, MqttQos.AT_MOST_ONCE, false,
                 MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, tooManyUserProperties, 0);
         final MqttConnect connect = new MqttConnect(0, false, 0, false, true, DEFAULT, null, null, willPublish,
                 MqttUserPropertiesImpl.NO_USER_PROPERTIES);

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
@@ -22,7 +22,7 @@ import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.exceptions.MqttMaximumPacketSizeExceededException;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
 import org.mqttbee.mqtt.datatypes.*;
@@ -91,7 +91,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
-                        MqttQoS.AT_MOST_ONCE, false, 10, Mqtt5PayloadFormatIndicator.UNSPECIFIED,
+                        MqttQos.AT_MOST_ONCE, false, 10, Mqtt5PayloadFormatIndicator.UNSPECIFIED,
                         requireNonNull(MqttUTF8StringImpl.from("myContentType")),
                         requireNonNull(MqttTopicImpl.from("responseTopic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
                         HAS_NOT, userProperties);
@@ -120,7 +120,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
-                        MqttQoS.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
+                        MqttQos.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
                         Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, HAS_NOT, NO_USER_PROPERTIES);
 
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -144,7 +144,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_MOST_ONCE, true,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_MOST_ONCE, true,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, false, ImmutableIntArray.of());
@@ -170,7 +170,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, true, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -196,7 +196,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -222,7 +222,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 17, true, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -248,7 +248,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null, null,
                         null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -276,7 +276,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false, 1000,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false, 1000,
                         Mqtt5PayloadFormatIndicator.UTF_8, null, null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
@@ -303,7 +303,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8,
                         MqttUTF8StringImpl.from("myContentType"), null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -331,7 +331,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null,
                         MqttTopicImpl.from("responseTopic"), null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -361,7 +361,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final ByteBuffer correlationData = ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5});
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null, null,
                         correlationData, HAS_NOT, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -387,7 +387,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, MAY, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, 8, true, ImmutableIntArray.of());
     }
@@ -410,7 +410,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, MUST_NOT,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, ImmutableIntArray.of());
@@ -434,7 +434,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, DEFAULT_TOPIC_ALIAS_USAGE,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 2, true, ImmutableIntArray.of());
@@ -460,7 +460,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, MAY, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, 8, false, ImmutableIntArray.of());
     }
@@ -490,7 +490,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttUserPropertiesImpl userProperties = getUserProperties(2);
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null, null,
                         null, HAS_NOT, userProperties);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -516,7 +516,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, HAS_NOT,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of(3));
@@ -544,7 +544,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         };
 
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, HAS_NOT,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of(3, 4));
@@ -601,19 +601,19 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
                 0x01, 0
         };
         final MqttPublish publishQos0 =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_MOST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_MOST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expectedQos0, publishQos0, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
 
         final MqttPublish publishQos1 =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_LEAST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expectedQos1, publishQos1, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
 
         final MqttPublish publishQos2 =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.EXACTLY_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.EXACTLY_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, null, HAS_NOT, NO_USER_PROPERTIES);
         encode(expectedQos2, publishQos2, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -624,7 +624,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         createServerConnectionData(100);
         final ByteBuffer correlationData = ByteBuffer.wrap(new byte[100]);
         final MqttPublish publish =
-                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQoS.AT_MOST_ONCE, false,
+                new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_MOST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
                         null, correlationData, HAS_NOT, NO_USER_PROPERTIES);
 
@@ -665,7 +665,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
-                        MqttQoS.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
+                        MqttQos.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
                         Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, HAS_NOT, userProperties);
 
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
@@ -711,7 +711,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
-                        MqttQoS.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
+                        MqttQos.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
                         Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, correlationData, HAS_NOT, userProperties);
 
         encode(expected.array(), publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoderTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.exceptions.MqttMaximumPacketSizeExceededException;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5RetainHandling;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -85,7 +85,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         final MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.of(ImmutableList.of(mqtt5UserProperty));
 
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final boolean isNoLocal = true;
         final Mqtt5RetainHandling retainHandling = Mqtt5RetainHandling.SEND_IF_SUBSCRIPTION_DOES_NOT_EXIST;
         final boolean isRetainAsPublished = true;
@@ -124,7 +124,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
                 MqttUserPropertiesImpl.of(ImmutableList.of(mqtt5UserProperty, mqtt5UserProperty));
 
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final ImmutableList<MqttSubscription> subscriptions = ImmutableList.of(
                 new MqttSubscription(requireNonNull(topicFiler), qos, DEFAULT_NO_LOCAL, DEFAULT_RETAIN_HANDLING,
                         DEFAULT_RETAIN_AS_PUBLISHED));
@@ -159,7 +159,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         final MqttUserPropertiesImpl userProperties = MqttUserPropertiesImpl.of(ImmutableList.of(mqtt5UserProperty));
 
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final ImmutableList<MqttSubscription> subscriptions = ImmutableList.of(
                 new MqttSubscription(requireNonNull(topicFiler), qos, DEFAULT_NO_LOCAL, DEFAULT_RETAIN_HANDLING,
                         DEFAULT_RETAIN_AS_PUBLISHED));
@@ -168,8 +168,8 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
     }
 
     @ParameterizedTest
-    @EnumSource(MqttQoS.class)
-    void encode_subscriptionOptionsQos(final MqttQoS qos) {
+    @EnumSource(MqttQos.class)
+    void encode_subscriptionOptionsQos(final MqttQos qos) {
         final byte[] expected = {
                 // fixed header
                 // type, reserved
@@ -222,7 +222,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
         final boolean isNoLocal = noLocal == 1;
         final Mqtt5RetainHandling retainHandling = Mqtt5RetainHandling.SEND;
-        final MqttQoS qos = MqttQoS.AT_MOST_ONCE;
+        final MqttQos qos = MqttQos.AT_MOST_ONCE;
         final ImmutableList<MqttSubscription> subscriptions = ImmutableList.of(
                 new MqttSubscription(requireNonNull(topicFiler), qos, isNoLocal, retainHandling,
                         DEFAULT_RETAIN_AS_PUBLISHED));
@@ -253,7 +253,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         expected[14] |= retainHandling.getCode() << 4;
 
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final boolean isNoLocal = true;
         final ImmutableList<MqttSubscription> subscriptions = ImmutableList.of(
                 new MqttSubscription(requireNonNull(topicFiler), qos, isNoLocal, retainHandling,
@@ -284,7 +284,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         };
 
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final ImmutableList<MqttSubscription> subscriptions = ImmutableList.of(
                 new MqttSubscription(requireNonNull(topicFiler), qos, DEFAULT_NO_LOCAL, DEFAULT_RETAIN_HANDLING,
                         DEFAULT_RETAIN_AS_PUBLISHED));
@@ -315,7 +315,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         };
 
         final MqttTopicFilterImpl topicFiler = MqttTopicFilterImpl.from("topic/#");
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final boolean isNoLocal = true;
         final ImmutableList<MqttSubscription> subscriptions = ImmutableList.of(
                 new MqttSubscription(requireNonNull(topicFiler), qos, isNoLocal, DEFAULT_RETAIN_HANDLING,
@@ -346,7 +346,7 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
         final String leftoverTopic = new String(leftoverTopicBytes);
 
         final MqttTopicFilterImpl topicFilter = MqttTopicFilterImpl.from(topic);
-        final MqttQoS qos = MqttQoS.AT_LEAST_ONCE;
+        final MqttQos qos = MqttQos.AT_LEAST_ONCE;
         final List<MqttSubscription> maxSizeSubscriptions = Collections.nCopies(numberOfMaxTopicFilters,
                 new MqttSubscription(requireNonNull(topicFilter), qos, DEFAULT_NO_LOCAL, DEFAULT_RETAIN_HANDLING,
                         DEFAULT_RETAIN_AS_PUBLISHED));

--- a/src/test/java/org/mqttbee/mqtt/message/publish/MqttPublishTest.java
+++ b/src/test/java/org/mqttbee/mqtt/message/publish/MqttPublishTest.java
@@ -18,7 +18,7 @@
 package org.mqttbee.mqtt.message.publish;
 
 import org.junit.Test;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
 
@@ -36,7 +36,7 @@ import static org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl.NO_USER_PROPERTI
 public class MqttPublishTest {
 
     public static MqttPublish createPublishFromPayload(final ByteBuffer payload) {
-        return new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), payload, MqttQoS.AT_MOST_ONCE, false,
+        return new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), payload, MqttQos.AT_MOST_ONCE, false,
             MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 HAS_NOT, NO_USER_PROPERTIES);
     }

--- a/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
+++ b/src/test/java/org/mqttbee/mqtt/mqtt3/Mqtt3ClientViewExceptionsTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.MqttGlobalPublishFlowType;
-import org.mqttbee.api.mqtt.datatypes.MqttQoS;
+import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt3.exceptions.Mqtt3MessageException;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
@@ -75,7 +75,7 @@ class Mqtt3ClientViewExceptionsTest {
 
         final Mqtt3Subscribe subscribe = Mqtt3Subscribe.builder()
                 .addSubscription(
-                        Mqtt3Subscription.builder().topicFilter("topic").qos(MqttQoS.AT_LEAST_ONCE).build())
+                        Mqtt3Subscription.builder().topicFilter("topic").qos(MqttQos.AT_LEAST_ONCE).build())
                 .build();
         assertMqtt3Exception(() -> mqtt3Client.subscribe(subscribe).toCompletable().blockingAwait(),
                 mqtt5MessageException);
@@ -91,7 +91,7 @@ class Mqtt3ClientViewExceptionsTest {
 
         final Mqtt3Subscribe subscribe = Mqtt3Subscribe.builder()
                 .addSubscription(
-                        Mqtt3Subscription.builder().topicFilter("topic").qos(MqttQoS.AT_LEAST_ONCE).build())
+                        Mqtt3Subscription.builder().topicFilter("topic").qos(MqttQos.AT_LEAST_ONCE).build())
                 .build();
         assertMqtt3Exception(() -> mqtt3Client.subscribeWithStream(subscribe).blockingSubscribe(),
                 mqtt5MessageException);
@@ -124,7 +124,7 @@ class Mqtt3ClientViewExceptionsTest {
         given(mqtt5Client.publish(any())).willReturn(Flowable.error(mqtt5MessageException));
 
         final Flowable<Mqtt3Publish> publish =
-                Flowable.just(Mqtt3Publish.builder().topic("topic").qos(MqttQoS.AT_LEAST_ONCE).build());
+                Flowable.just(Mqtt3Publish.builder().topic("topic").qos(MqttQos.AT_LEAST_ONCE).build());
         assertMqtt3Exception(() -> mqtt3Client.publish(publish).blockingSubscribe(), mqtt5MessageException);
     }
 


### PR DESCRIPTION
**Motivation**
Use correct camel case for QoS, i.e. Qos.

**Changes**
* rename files, types, methods and variables from QoS into Qos