### PR TITLE
Improved PubAck/Rec/Rel/CompBuilder

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/puback/Mqtt5PubAckBuilder.java
@@ -19,7 +19,9 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish.puback;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 
 /**
  * @author Silvio Giebl
@@ -29,5 +31,16 @@ public interface Mqtt5PubAckBuilder {
 
     @NotNull
     Mqtt5PubAckBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
+
+    @NotNull
+    default Mqtt5UserPropertiesBuilder<Mqtt5PubAckBuilder> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
+    }
+
+    @NotNull
+    Mqtt5PubAckReasonCode getReasonCode();
+
+    @NotNull
+    MqttUTF8String getReasonString();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubcomp/Mqtt5PubCompBuilder.java
@@ -19,7 +19,9 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 
 /**
  * @author Silvio Giebl
@@ -29,5 +31,16 @@ public interface Mqtt5PubCompBuilder {
 
     @NotNull
     Mqtt5PubCompBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
+
+    @NotNull
+    default Mqtt5UserPropertiesBuilder<Mqtt5PubCompBuilder> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
+    }
+
+    @NotNull
+    Mqtt5PubCompReasonCode getReasonCode();
+
+    @NotNull
+    MqttUTF8String getReasonString();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrec/Mqtt5PubRecBuilder.java
@@ -19,7 +19,9 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 
 /**
  * @author Silvio Giebl
@@ -29,5 +31,16 @@ public interface Mqtt5PubRecBuilder {
 
     @NotNull
     Mqtt5PubRecBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
+
+    @NotNull
+    default Mqtt5UserPropertiesBuilder<Mqtt5PubRecBuilder> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
+    }
+
+    @NotNull
+    Mqtt5PubRecReasonCode getReasonCode();
+
+    @NotNull
+    MqttUTF8String getReasonString();
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/pubrel/Mqtt5PubRelBuilder.java
@@ -19,7 +19,9 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel;
 
 import org.mqttbee.annotations.DoNotImplement;
 import org.mqttbee.annotations.NotNull;
+import org.mqttbee.api.mqtt.datatypes.MqttUTF8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 
 /**
  * @author Silvio Giebl
@@ -29,5 +31,16 @@ public interface Mqtt5PubRelBuilder {
 
     @NotNull
     Mqtt5PubRelBuilder userProperties(@NotNull Mqtt5UserProperties userProperties);
+
+    @NotNull
+    default Mqtt5UserPropertiesBuilder<Mqtt5PubRelBuilder> userProperties() {
+        return new Mqtt5UserPropertiesBuilder<>(this::userProperties);
+    }
+
+    @NotNull
+    Mqtt5PubRelReasonCode getReasonCode();
+
+    @NotNull
+    MqttUTF8String getReasonString();
 
 }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAckBuilder.java
@@ -49,15 +49,32 @@ public class MqttPubAckBuilder implements Mqtt5PubAckBuilder {
     }
 
     @NotNull
-    public MqttPubAckBuilder withReasonCode(@NotNull final Mqtt5PubAckReasonCode reasonCode) {
+    public MqttPubAckBuilder reasonCode(@NotNull final Mqtt5PubAckReasonCode reasonCode) {
         this.reasonCode = reasonCode;
         return this;
     }
 
     @NotNull
-    public MqttPubAckBuilder withReasonString(@Nullable final MqttUTF8StringImpl reasonString) {
+    public MqttPubAckBuilder reasonString(@Nullable final MqttUTF8StringImpl reasonString) {
         this.reasonString = reasonString;
         return this;
+    }
+
+    @NotNull
+    @Override
+    public MqttUTF8StringImpl getReasonString() {
+        return reasonString;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5PubAckReasonCode getReasonCode() {
+        return reasonCode;
+    }
+
+    @NotNull
+    public MqttStatefulPublish getPublish() {
+        return publish;
     }
 
     public MqttPubAck build() {

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubCompBuilder.java
@@ -49,15 +49,32 @@ public class MqttPubCompBuilder implements Mqtt5PubCompBuilder {
     }
 
     @NotNull
-    public MqttPubCompBuilder withReasonCode(@NotNull final Mqtt5PubCompReasonCode reasonCode) {
+    public MqttPubCompBuilder reasonCode(@NotNull final Mqtt5PubCompReasonCode reasonCode) {
         this.reasonCode = reasonCode;
         return this;
     }
 
     @NotNull
-    public MqttPubCompBuilder withReasonString(@Nullable final MqttUTF8StringImpl reasonString) {
+    public MqttPubCompBuilder reasonString(@Nullable final MqttUTF8StringImpl reasonString) {
         this.reasonString = reasonString;
         return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5PubCompReasonCode getReasonCode() {
+        return reasonCode;
+    }
+
+    @NotNull
+    @Override
+    public MqttUTF8StringImpl getReasonString() {
+        return reasonString;
+    }
+
+    @NotNull
+    public MqttPubRel getPubRel() {
+        return pubRel;
     }
 
     public MqttPubComp build() {

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRecBuilder.java
@@ -49,15 +49,32 @@ public class MqttPubRecBuilder implements Mqtt5PubRecBuilder {
     }
 
     @NotNull
-    public MqttPubRecBuilder withReasonCode(@NotNull final Mqtt5PubRecReasonCode reasonCode) {
+    public MqttPubRecBuilder reasonCode(@NotNull final Mqtt5PubRecReasonCode reasonCode) {
         this.reasonCode = reasonCode;
         return this;
     }
 
     @NotNull
-    public MqttPubRecBuilder withReasonString(@Nullable final MqttUTF8StringImpl reasonString) {
+    public MqttPubRecBuilder reasonString(@Nullable final MqttUTF8StringImpl reasonString) {
         this.reasonString = reasonString;
         return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5PubRecReasonCode getReasonCode() {
+        return reasonCode;
+    }
+
+    @NotNull
+    @Override
+    public MqttUTF8StringImpl getReasonString() {
+        return reasonString;
+    }
+
+    @NotNull
+    public MqttStatefulPublish getPublish() {
+        return publish;
     }
 
     public MqttPubRec build() {

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRelBuilder.java
@@ -49,15 +49,32 @@ public class MqttPubRelBuilder implements Mqtt5PubRelBuilder {
     }
 
     @NotNull
-    public MqttPubRelBuilder withReasonCode(@NotNull final Mqtt5PubRelReasonCode reasonCode) {
+    public MqttPubRelBuilder reasonCode(@NotNull final Mqtt5PubRelReasonCode reasonCode) {
         this.reasonCode = reasonCode;
         return this;
     }
 
     @NotNull
-    public MqttPubRelBuilder withReasonString(@Nullable final MqttUTF8StringImpl reasonString) {
+    public MqttPubRelBuilder reasonString(@Nullable final MqttUTF8StringImpl reasonString) {
         this.reasonString = reasonString;
         return this;
+    }
+
+    @NotNull
+    @Override
+    public Mqtt5PubRelReasonCode getReasonCode() {
+        return reasonCode;
+    }
+
+    @NotNull
+    @Override
+    public MqttUTF8StringImpl getReasonString() {
+        return reasonString;
+    }
+
+    @NotNull
+    public MqttPubRec getPubRec() {
+        return pubRec;
     }
 
     public MqttPubRel build() {


### PR DESCRIPTION
**Motivation**
PubAck/Rec/Rel/CompBuilder did still contain "with" prefixes for some methods and did not define fluent builder methods.
As these builders are passed to callbacks, getters for preset values were missing.

**Changes**
- Added fluent builder methods
- Removed "with" prefixes
- Added getter