### PR TITLE
Cleanup/precondition error msgs

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientBuilder.java
@@ -61,7 +61,7 @@ public class MqttClientBuilder {
 
     @NotNull
     public MqttClientBuilder serverHost(@NotNull final String host) {
-        this.serverHost = Preconditions.checkNotNull(host);
+        this.serverHost = Preconditions.checkNotNull(host, "Server host must not be null.");
         return this;
     }
 
@@ -86,7 +86,7 @@ public class MqttClientBuilder {
                 serverPort = DEFAULT_SERVER_PORT_WEBSOCKET_SSL;
             }
         }
-        this.sslConfig = Preconditions.checkNotNull(sslConfig);
+        this.sslConfig = Preconditions.checkNotNull(sslConfig, "SSL config must not be null.");
         return this;
     }
 
@@ -109,7 +109,7 @@ public class MqttClientBuilder {
                 serverPort = DEFAULT_SERVER_PORT_WEBSOCKET_SSL;
             }
         }
-        this.websocketConfig = Preconditions.checkNotNull(websocketConfig);
+        this.websocketConfig = Preconditions.checkNotNull(websocketConfig, "WebSocket config must not be null.");
         return this;
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -44,7 +44,7 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
 
     @NotNull
     public MqttClientExecutorConfigBuilder<P> nettyExecutor(@NotNull final Executor nettyExecutor) {
-        Preconditions.checkNotNull(nettyExecutor);
+        Preconditions.checkNotNull(nettyExecutor, "Netty executor must not be null.");
         this.nettyExecutor = nettyExecutor;
         return this;
     }
@@ -59,7 +59,7 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
 
     @NotNull
     public MqttClientExecutorConfigBuilder<P> applicationScheduler(@NotNull final Scheduler applicationScheduler) {
-        Preconditions.checkNotNull(applicationScheduler);
+        Preconditions.checkNotNull(applicationScheduler, "Application scheduler must not be null.");
         this.applicationScheduler = applicationScheduler;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientExecutorConfigBuilder.java
@@ -51,7 +51,8 @@ public class MqttClientExecutorConfigBuilder<P> extends FluentBuilder<MqttClient
 
     @NotNull
     public MqttClientExecutorConfigBuilder<P> nettyThreads(final int nettyThreads) {
-        Preconditions.checkArgument(nettyThreads > 0);
+        Preconditions.checkArgument(nettyThreads > 0, "Number of Netty threads must be bigger than 0. Found: %s.",
+                nettyThreads);
         this.nettyThreads = nettyThreads;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicBuilder.java
@@ -38,7 +38,7 @@ public class MqttTopicBuilder<P> extends FluentBuilder<MqttTopic, P> {
 
     @NotNull
     public MqttTopicBuilder<P> addLevel(@NotNull final String subTopic) {
-        Preconditions.checkNotNull(subTopic);
+        Preconditions.checkNotNull(subTopic, "Subtopic must not be null.");
         stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(subTopic);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilterBuilder.java
@@ -40,7 +40,7 @@ public class MqttTopicFilterBuilder<P> extends FluentBuilder<MqttTopicFilter, P>
 
     @NotNull
     public MqttTopicFilterBuilder<P> addLevel(@NotNull final String subTopic) {
-        Preconditions.checkNotNull(subTopic);
+        Preconditions.checkNotNull(subTopic, "Subtopic must not be null.");
         stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(subTopic);
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3ClientBuilder.java
@@ -40,9 +40,9 @@ public class Mqtt3ClientBuilder extends MqttClientBuilder {
             @Nullable final MqttClientSslConfig sslConfig, @Nullable final MqttWebsocketConfig websocketConfig,
             @NotNull final MqttClientExecutorConfigImpl executorConfig) {
 
-        Preconditions.checkNotNull(identifier);
-        Preconditions.checkNotNull(serverHost);
-        Preconditions.checkNotNull(executorConfig);
+        Preconditions.checkNotNull(identifier, "Identifier must not be null.");
+        Preconditions.checkNotNull(serverHost, "Server host must not be null.");
+        Preconditions.checkNotNull(executorConfig, "Executor config must not be null.");
 
         this.identifier = identifier;
         this.serverHost = serverHost;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3ConnectBuilder.java
@@ -63,7 +63,9 @@ public class Mqtt3ConnectBuilder<P> extends FluentBuilder<Mqtt3Connect, P> {
     @NotNull
     public Mqtt3ConnectBuilder<P> keepAlive(final int keepAlive, @NotNull final TimeUnit timeUnit) {
         final long keepAliveSeconds = timeUnit.toSeconds(keepAlive);
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAliveSeconds));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAliveSeconds),
+                "The value of keep alive converted in seconds must not exceed the value range of unsigned short. Found: %s which is bigger than %s (max unsigned short).",
+                keepAliveSeconds, UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE);
         this.keepAliveSeconds = (int) keepAliveSeconds;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -88,7 +88,7 @@ public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
 
     @NotNull
     public Mqtt3PublishBuilder<P> qos(@NotNull final MqttQos qos) {
-        this.qos = Preconditions.checkNotNull(qos);
+        this.qos = Preconditions.checkNotNull(qos, "QoS must not be null.");
         return this;
     }
 
@@ -101,8 +101,8 @@ public class Mqtt3PublishBuilder<P> extends FluentBuilder<Mqtt3Publish, P> {
     @NotNull
     @Override
     public Mqtt3Publish build() {
-        Preconditions.checkNotNull(topic);
-        Preconditions.checkNotNull(qos);
+        Preconditions.checkNotNull(topic, "Topic must not be null.");
+        Preconditions.checkNotNull(qos, "QoS must not be null.");
         return Mqtt3PublishView.of(topic, payload, qos, retain);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -61,15 +61,15 @@ public class Mqtt3SubscriptionBuilder<P> extends FluentBuilder<Mqtt3Subscription
 
     @NotNull
     public Mqtt3SubscriptionBuilder<P> qos(@NotNull final MqttQos qos) {
-        this.qos = Preconditions.checkNotNull(qos);
+        this.qos = Preconditions.checkNotNull(qos, "QoS must not be null.");
         return this;
     }
 
     @NotNull
     @Override
     public Mqtt3Subscription build() {
-        Preconditions.checkNotNull(topicFilter);
-        Preconditions.checkNotNull(qos);
+        Preconditions.checkNotNull(topicFilter, "Topic filter must not be null.");
+        Preconditions.checkNotNull(qos, "QoS must not be null.");
         return Mqtt3SubscriptionView.of(topicFilter, qos);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5ClientBuilder.java
@@ -46,9 +46,9 @@ public class Mqtt5ClientBuilder extends MqttClientBuilder {
             @Nullable final MqttClientSslConfig sslConfig, @Nullable final MqttWebsocketConfig websocketConfig,
             @NotNull final MqttClientExecutorConfigImpl executorConfig) {
 
-        Preconditions.checkNotNull(identifier);
-        Preconditions.checkNotNull(serverHost);
-        Preconditions.checkNotNull(executorConfig);
+        Preconditions.checkNotNull(identifier, "Identifier must not be null.");
+        Preconditions.checkNotNull(serverHost, "Server host must not be null.");
+        Preconditions.checkNotNull(executorConfig, "Executor config must not be null.");
 
         this.identifier = identifier;
         this.serverHost = serverHost;

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
@@ -51,7 +51,7 @@ public interface Mqtt5UserProperties {
      */
     @NotNull
     static Mqtt5UserProperties of(@NotNull final Mqtt5UserProperty... userProperties) {
-        Preconditions.checkNotNull(userProperties);
+        Preconditions.checkNotNull(userProperties, "User properties must not be null.");
 
         final ImmutableList.Builder<MqttUserPropertyImpl> builder =
                 ImmutableList.builderWithExpectedSize(userProperties.length);

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectBuilder.java
@@ -77,7 +77,9 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
     @NotNull
     public Mqtt5ConnectBuilder<P> keepAlive(final int keepAlive, @NotNull final TimeUnit timeUnit) {
         final long keepAliveSeconds = timeUnit.toSeconds(keepAlive);
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAliveSeconds));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(keepAliveSeconds),
+                "The value of keep alive converted in seconds must not exceed the value range of unsigned short. Found: %s which is bigger than %s (max unsigned short).",
+                keepAliveSeconds, UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE);
         this.keepAliveSeconds = (int) keepAliveSeconds;
         return this;
     }
@@ -93,7 +95,10 @@ public class Mqtt5ConnectBuilder<P> extends FluentBuilder<Mqtt5Connect, P> {
             final long sessionExpiryInterval, @NotNull final TimeUnit timeUnit) {
 
         final long sessionExpiryIntervalSeconds = timeUnit.toSeconds(sessionExpiryInterval);
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryIntervalSeconds));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryIntervalSeconds),
+                "The value of session expiry interval converted in seconds must not exceed the value range of unsigned int. Found: %s which is bigger than %s (max unsigned int).",
+                keepAliveSeconds, UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE);
+
         this.sessionExpiryIntervalSeconds = sessionExpiryIntervalSeconds;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5ConnectRestrictionsBuilder.java
@@ -43,21 +43,29 @@ public class Mqtt5ConnectRestrictionsBuilder<P> extends FluentBuilder<Mqtt5Conne
 
     @NotNull
     public Mqtt5ConnectRestrictionsBuilder<P> receiveMaximum(final int receiveMaximum) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(receiveMaximum));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(receiveMaximum),
+                "The value of receive maximum must not exceed the value range of unsigned short. Found: %s which is bigger than %s (max unsigned short).",
+                receiveMaximum, UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE);
+
         this.receiveMaximum = receiveMaximum;
         return this;
     }
 
     @NotNull
     public Mqtt5ConnectRestrictionsBuilder<P> topicAliasMaximum(final int topicAliasMaximum) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(topicAliasMaximum));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedShort(topicAliasMaximum),
+                "The value of topic alias maximum must not exceed the value range of unsigned short. Found: %s which is bigger than %s (max unsigned short).",
+                topicAliasMaximum, UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE);
+
         this.topicAliasMaximum = topicAliasMaximum;
         return this;
     }
 
     @NotNull
     public Mqtt5ConnectRestrictionsBuilder<P> maximumPacketSize(final int maximumPacketSize) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(maximumPacketSize));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(maximumPacketSize),
+                "The value of maximum packet size must not exceed the value range of unsigned int. Found: %s which is bigger than %s (max unsigned int).",
+                maximumPacketSize, UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE);
         this.maximumPacketSize = maximumPacketSize;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -62,7 +62,10 @@ public class Mqtt5DisconnectBuilder<P> extends FluentBuilder<Mqtt5Disconnect, P>
             final long sessionExpiryInterval, @NotNull final TimeUnit timeUnit) {
 
         final long sessionExpiryIntervalSeconds = timeUnit.toSeconds(sessionExpiryInterval);
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryIntervalSeconds));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(sessionExpiryIntervalSeconds),
+                "The value of session expiry interval converted in seconds must not exceed the value range of unsigned int. Found: %s which is bigger than %s (max unsigned int).",
+                sessionExpiryInterval, UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE);
+
         this.sessionExpiryIntervalSeconds = sessionExpiryIntervalSeconds;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -43,7 +43,7 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
      * The default handling for using a topic alias.
      */
     @NotNull
-    TopicAliasUsage DEFAULT_TOPIC_ALIAS_USAGE = TopicAliasUsage.MUST_NOT;
+    TopicAliasUsage DEFAULT_TOPIC_ALIAS_USAGE = TopicAliasUsage.NO;
 
     @NotNull
     static Mqtt5PublishBuilder<Void> builder() {

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -118,7 +118,7 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
      * @return the handling for using a topic alias.
      */
     @NotNull
-    TopicAliasUsage getTopicAliasUsage();
+    TopicAliasUsage usesTopicAlias();
 
     /**
      * @return the optional user properties of this PUBLISH packet.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -185,8 +185,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
 
     @NotNull
     public Mqtt5PublishBuilder<P> topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
-        Preconditions.checkArgument(
-                topicAliasUsage == MUST_NOT || topicAliasUsage == MAY || topicAliasUsage == MAY_OVERWRITE);
+        Preconditions.checkArgument(topicAliasUsage == NO || topicAliasUsage == IF_AVAILABLE || topicAliasUsage == YES);
         this.topicAliasUsage = topicAliasUsage;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -185,7 +185,6 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
 
     @NotNull
     public Mqtt5PublishBuilder<P> topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
-        Preconditions.checkArgument(topicAliasUsage == NO || topicAliasUsage == IF_AVAILABLE || topicAliasUsage == YES);
         this.topicAliasUsage = topicAliasUsage;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -112,7 +112,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
 
     @NotNull
     public Mqtt5PublishBuilder<P> qos(@NotNull final MqttQos qos) {
-        this.qos = Preconditions.checkNotNull(qos);
+        this.qos = Preconditions.checkNotNull(qos, "QoS must not be null.");
         return this;
     }
 
@@ -205,8 +205,8 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     @NotNull
     @Override
     public Mqtt5Publish build() {
-        Preconditions.checkNotNull(topic);
-        Preconditions.checkNotNull(qos);
+        Preconditions.checkNotNull(topic, "Topic must not be null.");
+        Preconditions.checkNotNull(qos, "QoS must not be null.");
         return new MqttPublish(topic, payload, qos, retain, messageExpiryIntervalSeconds, payloadFormatIndicator,
                 contentType, responseTopic, correlationData, topicAliasUsage, userProperties);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -127,7 +127,9 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
             final long messageExpiryInterval, @NotNull final TimeUnit timeUnit) {
 
         final long messageExpiryIntervalSeconds = timeUnit.toSeconds(messageExpiryInterval);
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(messageExpiryIntervalSeconds));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(messageExpiryIntervalSeconds),
+                "The value of session expiry interval converted in seconds must not exceed the value range of unsigned int. Found: %s which is bigger than %s (max unsigned int).",
+                messageExpiryIntervalSeconds, UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE);
         this.messageExpiryIntervalSeconds = messageExpiryIntervalSeconds;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -40,7 +40,6 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage.*;
 import static org.mqttbee.mqtt.message.publish.MqttPublish.DEFAULT_TOPIC_ALIAS_USAGE;
 import static org.mqttbee.mqtt.message.publish.MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY;
 
@@ -77,7 +76,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
         contentType = publishImpl.getRawContentType();
         responseTopic = publishImpl.getRawResponseTopic();
         correlationData = publishImpl.getRawCorrelationData();
-        topicAliasUsage = publishImpl.getTopicAliasUsage();
+        topicAliasUsage = publishImpl.usesTopicAlias();
         userProperties = publishImpl.getUserProperties();
     }
 
@@ -184,7 +183,7 @@ public class Mqtt5PublishBuilder<P> extends FluentBuilder<Mqtt5Publish, P> {
     }
 
     @NotNull
-    public Mqtt5PublishBuilder<P> topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
+    public Mqtt5PublishBuilder<P> useTopicAlias(@NotNull final TopicAliasUsage topicAliasUsage) {
         this.topicAliasUsage = topicAliasUsage;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -212,8 +212,8 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     @NotNull
     @Override
     public Mqtt5WillPublish build() {
-        Preconditions.checkNotNull(topic);
-        Preconditions.checkNotNull(qos);
+        Preconditions.checkNotNull(topic, "Topic must not be null.");
+        Preconditions.checkNotNull(qos, "QoS must not be null.");
         return new MqttWillPublish(topic, payload, qos, retain, messageExpiryIntervalSeconds, payloadFormatIndicator,
                 contentType, responseTopic, correlationData, userProperties, delayIntervalSeconds);
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -181,7 +181,7 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     @NotNull
     @Override
     @Deprecated
-    public Mqtt5WillPublishBuilder<P> topicAliasUsage(@NotNull final TopicAliasUsage topicAliasUsage) {
+    public Mqtt5WillPublishBuilder<P> useTopicAlias(@NotNull final TopicAliasUsage topicAliasUsage) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -201,7 +201,10 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     @NotNull
     public Mqtt5WillPublishBuilder<P> delayInterval(final long delayInterval, @NotNull final TimeUnit timeUnit) {
         final long delayIntervalSeconds = timeUnit.toSeconds(delayInterval);
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayIntervalSeconds));
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayIntervalSeconds),
+                "The value of delay interval converted in seconds must not exceed the value range of unsigned int. Found: %s which is bigger than %s (max unsigned int).",
+                delayIntervalSeconds, UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE);
+
         this.delayIntervalSeconds = delayIntervalSeconds;
         return this;
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublishBuilder.java
@@ -50,7 +50,7 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
                 (parentConsumer == null) ? null : publish -> parentConsumer.apply((Mqtt5WillPublish) publish));
     }
 
-    private long delayInterval = DEFAULT_DELAY_INTERVAL;
+    private long delayIntervalSeconds = DEFAULT_DELAY_INTERVAL;
 
     public Mqtt5WillPublishBuilder(@Nullable final Function<? super Mqtt5Publish, P> parentConsumer) {
         super(parentConsumer);
@@ -59,7 +59,7 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     Mqtt5WillPublishBuilder(@NotNull final Mqtt5Publish publish) {
         super(publish);
         if (publish instanceof Mqtt5WillPublish) {
-            delayInterval =
+            delayIntervalSeconds =
                     MustNotBeImplementedUtil.checkNotImplemented(publish, MqttWillPublish.class).getDelayInterval();
         }
     }
@@ -199,9 +199,10 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
     }
 
     @NotNull
-    public Mqtt5WillPublishBuilder<P> delayInterval(final long delayInterval) {
-        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayInterval));
-        this.delayInterval = delayInterval;
+    public Mqtt5WillPublishBuilder<P> delayInterval(final long delayInterval, @NotNull final TimeUnit timeUnit) {
+        final long delayIntervalSeconds = timeUnit.toSeconds(delayInterval);
+        Preconditions.checkArgument(UnsignedDataTypes.isUnsignedInt(delayIntervalSeconds));
+        this.delayIntervalSeconds = delayIntervalSeconds;
         return this;
     }
 
@@ -211,7 +212,7 @@ public class Mqtt5WillPublishBuilder<P> extends Mqtt5PublishBuilder<P> {
         Preconditions.checkNotNull(topic);
         Preconditions.checkNotNull(qos);
         return new MqttWillPublish(topic, payload, qos, retain, messageExpiryIntervalSeconds, payloadFormatIndicator,
-                contentType, responseTopic, correlationData, userProperties, delayInterval);
+                contentType, responseTopic, correlationData, userProperties, delayIntervalSeconds);
     }
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/TopicAliasUsage.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/TopicAliasUsage.java
@@ -21,29 +21,27 @@ package org.mqttbee.api.mqtt.mqtt5.message.publish;
  * The handling for using a topic alias.
  *
  * @author Silvio Giebl
+ * @author Christian Hoff
  */
 public enum TopicAliasUsage {
 
     /**
-     * Indicates that an outgoing PUBLISH packet must not use a topic alias.
+     * Indicates that a PUBLISH packet (incoming or outgoing) uses a topic alias. In case of an outgoing PUBLISH packet
+     * and if all topic aliases are in use, it will override an existing topic alias.
+     *
+     * @see org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckRestrictions#getTopicAliasMaximum()
      */
-    MUST_NOT,
+    YES,
     /**
-     * Indicates that an outgoing PUBLISH packet may use a topic alias.
+     * Indicates that a PUBLISH packet (incoming or outgoing) does not use a topic alias.
      */
-    MAY,
+    NO,
     /**
-     * Indicates that an outgoing PUBLISH packet may use a topic alias and also may overwrite an existing topic alias
-     * mapping.
+     * Indicates that an outgoing PUBLISH packet will use a topic alias, if there are some unused topic aliases
+     * available.
+     *
+     * @see org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckRestrictions#getTopicAliasMaximum()
      */
-    MAY_OVERWRITE,
-    /**
-     * Indicates that an incoming PUBLISH packet does not have a topic alias.
-     */
-    HAS_NOT,
-    /**
-     * Indicates that an incoming PUBLISH packet has a topic alias.
-     */
-    HAS
+    IF_AVAILABLE
 
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -91,7 +91,9 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
     public Mqtt5Subscription build() {
         Preconditions.checkNotNull(topicFilter);
         Preconditions.checkNotNull(qos);
-        Preconditions.checkArgument(!(topicFilter.isShared() && noLocal));
+        Preconditions.checkArgument(
+                !(topicFilter.isShared() && noLocal),
+                "It is a Protocol Error to set no local to true on a Shared Subscription.");
         return new MqttSubscription(topicFilter, qos, noLocal, retainHandling, retainAsPublished);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -64,7 +64,7 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
 
     @NotNull
     public Mqtt5SubscriptionBuilder<P> qos(@NotNull final MqttQos qos) {
-        this.qos = Preconditions.checkNotNull(qos);
+        this.qos = Preconditions.checkNotNull(qos, "QoS must not be null.");
         return this;
     }
 
@@ -76,7 +76,7 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
 
     @NotNull
     public Mqtt5SubscriptionBuilder<P> retainHandling(@NotNull final Mqtt5RetainHandling retainHandling) {
-        this.retainHandling = Preconditions.checkNotNull(retainHandling);
+        this.retainHandling = Preconditions.checkNotNull(retainHandling, "Retain handling must not be null.");
         return this;
     }
 
@@ -89,8 +89,8 @@ public class Mqtt5SubscriptionBuilder<P> extends FluentBuilder<Mqtt5Subscription
     @NotNull
     @Override
     public Mqtt5Subscription build() {
-        Preconditions.checkNotNull(topicFilter);
-        Preconditions.checkNotNull(qos);
+        Preconditions.checkNotNull(topicFilter, "Topic filter must not be null.");
+        Preconditions.checkNotNull(qos, "QoS must not be null.");
         Preconditions.checkArgument(
                 !(topicFilter.isShared() && noLocal),
                 "It is a Protocol Error to set no local to true on a Shared Subscription.");

--- a/src/main/java/org/mqttbee/api/util/KeyStoreUtil.java
+++ b/src/main/java/org/mqttbee/api/util/KeyStoreUtil.java
@@ -42,7 +42,7 @@ public class KeyStoreUtil {
     public static TrustManagerFactory trustManagerFromKeystore(
             @NotNull final File trustStoreFile, @NotNull final String trustStorePassword) throws SSLException {
 
-        Preconditions.checkNotNull(trustStoreFile, "Truststore must not be null");
+        Preconditions.checkNotNull(trustStoreFile, "Truststore file must not be null.");
         try (final FileInputStream fileInputStream = new FileInputStream(trustStoreFile)) {
             final KeyStore keyStoreTrust = KeyStore.getInstance(KEYSTORE_TYPE);
             keyStoreTrust.load(fileInputStream, trustStorePassword.toCharArray());
@@ -65,7 +65,7 @@ public class KeyStoreUtil {
             @NotNull final File keyStoreFile, @NotNull final String keyStorePassword,
             @NotNull final String privateKeyPassword) throws SSLException {
 
-        Preconditions.checkNotNull(keyStoreFile, "Keystore must not be null");
+        Preconditions.checkNotNull(keyStoreFile, "Keystore file must not be null.");
         try (final FileInputStream fileInputStream = new FileInputStream(keyStoreFile)) {
             final KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
             keyStore.load(fileInputStream, keyStorePassword.toCharArray());

--- a/src/main/java/org/mqttbee/mqtt/MqttClientData.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientData.java
@@ -44,7 +44,7 @@ public class MqttClientData implements Mqtt5ClientData {
 
     @NotNull
     public static MqttClientData from(@NotNull final Channel channel) {
-        return Preconditions.checkNotNull(channel.attr(KEY).get());
+        return Preconditions.checkNotNull(channel.attr(KEY).get(), "Channel client data must not be null.");
     }
 
     private final MqttVersion mqttVersion;

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
@@ -100,7 +100,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
         ByteBuffer correlationData = null;
         ImmutableList.Builder<MqttUserPropertyImpl> userPropertiesBuilder = null;
         int topicAlias = DEFAULT_NO_TOPIC_ALIAS;
-        TopicAliasUsage topicAliasUsage = TopicAliasUsage.HAS_NOT;
+        TopicAliasUsage topicAliasUsage = TopicAliasUsage.NO;
         ImmutableIntArray.Builder subscriptionIdentifiersBuilder = null;
 
         final int propertiesStartIndex = in.readerIndex();
@@ -154,7 +154,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
                         throw new MqttDecoderException(
                                 Mqtt5DisconnectReasonCode.TOPIC_ALIAS_INVALID, "topic alias must not be 0");
                     }
-                    topicAliasUsage = TopicAliasUsage.HAS;
+                    topicAliasUsage = TopicAliasUsage.YES;
                     break;
 
                 case SUBSCRIPTION_IDENTIFIER:

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttBinaryData.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttBinaryData.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
  */
 public class MqttBinaryData {
 
-    private static final int MAX_LENGTH = 65_535;
+    public static final int MAX_LENGTH = 65_535;
     public static final int EMPTY_LENGTH = 2;
 
     private MqttBinaryData() {

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/MqttOutgoingQosHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/MqttOutgoingQosHandler.java
@@ -162,7 +162,7 @@ public class MqttOutgoingQosHandler extends ChannelInboundHandlerAdapter {
             if (topicAlias != DEFAULT_NO_TOPIC_ALIAS) {
                 isNewTopicAlias = false;
             } else {
-                topicAlias = topicAliasMapping.set(topic, publish.getTopicAliasUsage());
+                topicAlias = topicAliasMapping.set(topic, publish.usesTopicAlias());
                 isNewTopicAlias = topicAlias != DEFAULT_NO_TOPIC_ALIAS;
             }
         }

--- a/src/main/java/org/mqttbee/mqtt/handler/ssl/SslUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/ssl/SslUtil.java
@@ -34,8 +34,8 @@ public class SslUtil {
     static SSLEngine createSslEngine(@NotNull final Channel channel, @NotNull final MqttClientSslConfig sslConfig)
             throws SSLException {
 
-        Preconditions.checkNotNull(channel, "channel must not be null");
-        Preconditions.checkNotNull(sslConfig, "SslData must not be null");
+        Preconditions.checkNotNull(channel, "Channel must not be null.");
+        Preconditions.checkNotNull(sslConfig, "SSL config must not be null.");
 
         final SSLEngine sslEngine = createSslContext(sslConfig).newEngine(channel.alloc());
 

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuthBuilder.java
@@ -45,8 +45,8 @@ public class MqttAuthBuilder implements Mqtt5AuthBuilder {
     public MqttAuthBuilder(
             @NotNull final Mqtt5AuthReasonCode reasonCode, @NotNull final MqttUTF8StringImpl method) {
 
-        Preconditions.checkNotNull(reasonCode);
-        Preconditions.checkNotNull(method);
+        Preconditions.checkNotNull(reasonCode, "Reason code must not be null.");
+        Preconditions.checkNotNull(method, "Method must not be null.");
         this.reasonCode = reasonCode;
         this.method = method;
     }

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuthBuilder.java
@@ -35,7 +35,7 @@ public class MqttEnhancedAuthBuilder implements Mqtt5EnhancedAuthBuilder {
     private ByteBuffer data;
 
     public MqttEnhancedAuthBuilder(@NotNull final MqttUTF8StringImpl method) {
-        Preconditions.checkNotNull(method);
+        Preconditions.checkNotNull(method, "Method must not be null.");
         this.method = method;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
@@ -170,7 +170,7 @@ public class MqttPublish extends MqttMessageWithUserPropertiesImpl implements Mq
 
     @NotNull
     @Override
-    public TopicAliasUsage getTopicAliasUsage() {
+    public TopicAliasUsage usesTopicAlias() {
         return topicAliasUsage;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
@@ -47,7 +47,7 @@ public class MqttWillPublish extends MqttPublish implements Mqtt5WillPublish {
             final long delayInterval) {
 
         super(topic, payload, qos, isRetain, messageExpiryInterval, payloadFormatIndicator, contentType, responseTopic,
-                correlationData, TopicAliasUsage.MUST_NOT, userProperties);
+                correlationData, TopicAliasUsage.NO, userProperties);
         this.delayInterval = delayInterval;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -54,7 +54,7 @@ public class Mqtt3PublishView implements Mqtt3Publish {
             final boolean isRetain) {
 
         return new MqttPublish(topic, payload, qos, isRetain, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null,
-                null, null, TopicAliasUsage.MUST_NOT, MqttUserPropertiesImpl.NO_USER_PROPERTIES);
+                null, null, TopicAliasUsage.NO, MqttUserPropertiesImpl.NO_USER_PROPERTIES);
     }
 
     @NotNull

--- a/src/main/java/org/mqttbee/mqtt/mqtt5/Mqtt5ClientImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt5/Mqtt5ClientImpl.java
@@ -145,7 +145,7 @@ public class Mqtt5ClientImpl implements Mqtt5Client {
     @NotNull
     @Override
     public Flowable<Mqtt5Publish> publishes(@NotNull final MqttGlobalPublishFlowType type) {
-        Preconditions.checkNotNull(type);
+        Preconditions.checkNotNull(type, "Global publish flow type must not be null.");
 
         return new MqttGlobalIncomingPublishFlowable(type, clientData).observeOn(
                 clientData.getExecutorConfig().getApplicationScheduler());

--- a/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
@@ -137,7 +137,9 @@ public class MqttBuilderUtil {
         if (binary == null) {
             return null;
         }
-        Preconditions.checkArgument(MqttBinaryData.isInRange(binary));
+        Preconditions.checkArgument(MqttBinaryData.isInRange(binary),
+                "Cannot encode given byte array as binary data. Byte array to long. Found: %s bytes. Maximum length is %s.",
+                binary.length, MqttBinaryData.MAX_LENGTH);
         return ByteBufferUtil.wrap(binary);
     }
 
@@ -146,7 +148,10 @@ public class MqttBuilderUtil {
         if (binary == null) {
             return null;
         }
-        Preconditions.checkArgument(MqttBinaryData.isInRange(binary));
+        Preconditions.checkArgument(MqttBinaryData.isInRange(binary),
+                "Cannot encode given byte buffer as binary data. Too many remaining bytes in byte buffer. Found: %s bytes. Maximum length is %s.",
+                binary.remaining(), MqttBinaryData.MAX_LENGTH);
+
         return ByteBufferUtil.slice(binary);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/util/MqttBuilderUtil.java
@@ -35,7 +35,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttUTF8StringImpl string(@NotNull final String string) {
-        Preconditions.checkNotNull(string);
+        Preconditions.checkNotNull(string, "String must not be null.");
         final MqttUTF8StringImpl from = MqttUTF8StringImpl.from(string);
         if (from == null) {
             throw new IllegalArgumentException("The string: [" + string + "] is not a valid UTF-8 encoded String.");
@@ -45,7 +45,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttUTF8StringImpl string(@NotNull final MqttUTF8String string) {
-        Preconditions.checkNotNull(string);
+        Preconditions.checkNotNull(string, "String must not be null.");
         return MustNotBeImplementedUtil.checkNotImplemented(string, MqttUTF8StringImpl.class);
     }
 
@@ -61,7 +61,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttTopicImpl topic(@NotNull final String string) {
-        Preconditions.checkNotNull(string);
+        Preconditions.checkNotNull(string, "String must not be null.");
         final MqttTopicImpl from = MqttTopicImpl.from(string);
         if (from == null) {
             throw new IllegalArgumentException("The string: [" + string + "] is not a valid Topic Name.");
@@ -71,7 +71,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttTopicImpl topic(@NotNull final MqttTopic topic) {
-        Preconditions.checkNotNull(topic);
+        Preconditions.checkNotNull(topic, "Topic must not be null.");
         return MustNotBeImplementedUtil.checkNotImplemented(topic, MqttTopicImpl.class);
     }
 
@@ -87,7 +87,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttTopicFilterImpl topicFilter(@NotNull final String string) {
-        Preconditions.checkNotNull(string);
+        Preconditions.checkNotNull(string, "String must not be null.");
         final MqttTopicFilterImpl from = MqttTopicFilterImpl.from(string);
         if (from == null) {
             throw new IllegalArgumentException("The string: [" + string + "] is not a valid Topic Filter.");
@@ -96,17 +96,17 @@ public class MqttBuilderUtil {
     }
 
     @NotNull
-    public static MqttTopicFilterImpl topicFilter(@NotNull final MqttTopicFilter topic) {
-        Preconditions.checkNotNull(topic);
-        return MustNotBeImplementedUtil.checkNotImplemented(topic, MqttTopicFilterImpl.class);
+    public static MqttTopicFilterImpl topicFilter(@NotNull final MqttTopicFilter topicFilter) {
+        Preconditions.checkNotNull(topicFilter, "Topic filter must not be null.");
+        return MustNotBeImplementedUtil.checkNotImplemented(topicFilter, MqttTopicFilterImpl.class);
     }
 
     @NotNull
     public static MqttSharedTopicFilterImpl sharedTopicFilter(
             @NotNull final String shareName, @NotNull final String topicFilter) {
 
-        Preconditions.checkNotNull(shareName);
-        Preconditions.checkNotNull(topicFilter);
+        Preconditions.checkNotNull(shareName, "Share name must not be null.");
+        Preconditions.checkNotNull(topicFilter, "Topic filter must not be null.");
         final MqttSharedTopicFilterImpl sharedTopicFilter = MqttSharedTopicFilterImpl.from(shareName, topicFilter);
         if (sharedTopicFilter == null) {
             throw new IllegalArgumentException(
@@ -118,7 +118,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttClientIdentifierImpl clientIdentifier(@NotNull final String string) {
-        Preconditions.checkNotNull(string);
+        Preconditions.checkNotNull(string, "String must not be null.");
         final MqttClientIdentifierImpl from = MqttClientIdentifierImpl.from(string);
         if (from == null) {
             throw new IllegalArgumentException("The string: [" + string + "] is not a valid Client Identifier.");
@@ -128,7 +128,7 @@ public class MqttBuilderUtil {
 
     @NotNull
     public static MqttClientIdentifierImpl clientIdentifier(@NotNull final MqttClientIdentifier clientIdentifier) {
-        Preconditions.checkNotNull(clientIdentifier);
+        Preconditions.checkNotNull(clientIdentifier, "Client identifier must not be null.");
         return MustNotBeImplementedUtil.checkNotImplemented(clientIdentifier, MqttClientIdentifierImpl.class);
     }
 

--- a/src/main/java/org/mqttbee/rx/FlowableWithSingleSplit.java
+++ b/src/main/java/org/mqttbee/rx/FlowableWithSingleSplit.java
@@ -133,8 +133,8 @@ public class FlowableWithSingleSplit<T, S, F> extends FlowableWithSingle<S, F> {
     public <SM, FM> FlowableWithSingleSplit<T, SM, FM> mapBoth(
             @NotNull final Function<S, SM> singleMapper, @NotNull final Function<F, FM> flowableMapper) {
 
-        Preconditions.checkNotNull(singleMapper);
-        Preconditions.checkNotNull(flowableMapper);
+        Preconditions.checkNotNull(singleMapper, "Single mapper must not be null.");
+        Preconditions.checkNotNull(flowableMapper, "Flowable mapper must not be null.");
         return new FlowableWithSingleSplit<>(
                 source, mapCaster(singleCaster, singleMapper), mapCaster(flowableCaster, flowableMapper), null);
     }
@@ -142,7 +142,7 @@ public class FlowableWithSingleSplit<T, S, F> extends FlowableWithSingle<S, F> {
     @NotNull
     @Override
     public FlowableWithSingleSplit<T, S, F> mapError(@NotNull final Function<Throwable, Throwable> mapper) {
-        Preconditions.checkNotNull(mapper);
+        Preconditions.checkNotNull(mapper, "Mapper must not be null.");
         final Function<Throwable, Flowable<T>> resumeMapper = throwable -> Flowable.error(mapper.apply(throwable));
         return new FlowableWithSingleSplit<>(
                 source.onErrorResumeNext(resumeMapper), singleCaster, flowableCaster, singleConsumer);
@@ -151,7 +151,7 @@ public class FlowableWithSingleSplit<T, S, F> extends FlowableWithSingle<S, F> {
     @NotNull
     @Override
     public Flowable<F> doOnSingle(@NotNull final BiConsumer<S, Subscription> singleConsumer) {
-        Preconditions.checkNotNull(singleConsumer);
+        Preconditions.checkNotNull(singleConsumer, "Single consumer must not be null.");
         return new FlowableWithSingleSplit<>(source, singleCaster, flowableCaster, singleConsumer);
     }
 

--- a/src/main/java/org/mqttbee/util/MustNotBeImplementedUtil.java
+++ b/src/main/java/org/mqttbee/util/MustNotBeImplementedUtil.java
@@ -40,7 +40,7 @@ public class MustNotBeImplementedUtil {
     @NotNull
     @SuppressWarnings("unchecked")
     public static <S, T extends S> T checkNotImplemented(@NotNull final S object, @NotNull final Class<T> type) {
-        Preconditions.checkNotNull(object);
+        Preconditions.checkNotNull(object, "Object must not be null.");
         if (type.isInstance(object)) {
             return (T) object;
         }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -119,7 +119,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertEquals("response", publish.getResponseTopic().get().toString());
         assertTrue(publish.getCorrelationData().isPresent());
         assertEquals(ByteBuffer.wrap(new byte[]{5, 4, 3, 2, 1}), publish.getCorrelationData().get());
-        assertEquals(TopicAliasUsage.HAS, publish.getTopicAliasUsage());
+        assertEquals(TopicAliasUsage.YES, publish.getTopicAliasUsage());
 
         final ImmutableList<MqttUserPropertyImpl> userProperties = publish.getUserProperties().asList();
         assertEquals(1, userProperties.size());
@@ -166,7 +166,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertFalse(publish.getMessageExpiryInterval().isPresent());
         assertTrue(publish.getPayloadFormatIndicator().isPresent());
         assertEquals(Mqtt5PayloadFormatIndicator.UNSPECIFIED, publish.getPayloadFormatIndicator().get());
-        assertEquals(TopicAliasUsage.HAS_NOT, publish.getTopicAliasUsage());
+        assertEquals(TopicAliasUsage.NO, publish.getTopicAliasUsage());
 
         assertTrue(publish.getPayload().isPresent());
         assertEquals(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), publish.getPayload().get());

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -119,7 +119,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertEquals("response", publish.getResponseTopic().get().toString());
         assertTrue(publish.getCorrelationData().isPresent());
         assertEquals(ByteBuffer.wrap(new byte[]{5, 4, 3, 2, 1}), publish.getCorrelationData().get());
-        assertEquals(TopicAliasUsage.YES, publish.getTopicAliasUsage());
+        assertEquals(TopicAliasUsage.YES, publish.usesTopicAlias());
 
         final ImmutableList<MqttUserPropertyImpl> userProperties = publish.getUserProperties().asList();
         assertEquals(1, userProperties.size());
@@ -166,7 +166,7 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertFalse(publish.getMessageExpiryInterval().isPresent());
         assertTrue(publish.getPayloadFormatIndicator().isPresent());
         assertEquals(Mqtt5PayloadFormatIndicator.UNSPECIFIED, publish.getPayloadFormatIndicator().get());
-        assertEquals(TopicAliasUsage.NO, publish.getTopicAliasUsage());
+        assertEquals(TopicAliasUsage.NO, publish.usesTopicAlias());
 
         assertTrue(publish.getPayload().isPresent());
         assertEquals(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), publish.getPayload().get());

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.exceptions.MqttMaximumPacketSizeExceededException;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage;
 import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttPublishProperty;
@@ -36,7 +37,6 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish.DEFAULT_TOPIC_ALIAS_USAGE;
-import static org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage.*;
 import static org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 import static org.mqttbee.mqtt.message.publish.MqttStatefulPublish.DEFAULT_NO_TOPIC_ALIAS;
 
@@ -94,7 +94,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
                         MqttQos.AT_MOST_ONCE, false, 10, Mqtt5PayloadFormatIndicator.UNSPECIFIED,
                         requireNonNull(MqttUTF8StringImpl.from("myContentType")),
                         requireNonNull(MqttTopicImpl.from("responseTopic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
-                        HAS_NOT, userProperties);
+                        TopicAliasUsage.NO, userProperties);
 
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
@@ -121,7 +121,8 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
                         MqttQos.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
-                        Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, TopicAliasUsage.NO,
+                        NO_USER_PROPERTIES);
 
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
@@ -146,7 +147,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_MOST_ONCE, true,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, false, ImmutableIntArray.of());
     }
 
@@ -172,7 +173,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, true, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -198,7 +199,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -224,7 +225,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 17, true, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -250,7 +251,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null, null,
-                        null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -277,7 +278,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false, 1000,
-                        Mqtt5PayloadFormatIndicator.UTF_8, null, null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        Mqtt5PayloadFormatIndicator.UTF_8, null, null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -305,7 +306,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8,
-                        MqttUTF8StringImpl.from("myContentType"), null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        MqttUTF8StringImpl.from("myContentType"), null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -333,7 +334,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null,
-                        MqttTopicImpl.from("responseTopic"), null, HAS_NOT, NO_USER_PROPERTIES);
+                        MqttTopicImpl.from("responseTopic"), null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -363,7 +364,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null, null,
-                        correlationData, HAS_NOT, NO_USER_PROPERTIES);
+                        correlationData, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -388,7 +389,8 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
-                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, MAY, NO_USER_PROPERTIES);
+                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null,
+                        TopicAliasUsage.IF_AVAILABLE, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, 8, true, ImmutableIntArray.of());
     }
 
@@ -411,7 +413,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
-                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, MUST_NOT,
+                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, TopicAliasUsage.NO,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, ImmutableIntArray.of());
     }
@@ -461,7 +463,8 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
-                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, MAY, NO_USER_PROPERTIES);
+                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null,
+                        TopicAliasUsage.IF_AVAILABLE, NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, 8, false, ImmutableIntArray.of());
     }
 
@@ -492,7 +495,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UTF_8, null, null,
-                        null, HAS_NOT, userProperties);
+                        null, TopicAliasUsage.NO, userProperties);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -517,7 +520,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
-                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, HAS_NOT,
+                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, TopicAliasUsage.NO,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of(3));
     }
@@ -545,7 +548,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
-                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, HAS_NOT,
+                        MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null, TopicAliasUsage.NO,
                         NO_USER_PROPERTIES);
         encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of(3, 4));
     }
@@ -603,19 +606,19 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publishQos0 =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_MOST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expectedQos0, publishQos0, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
 
         final MqttPublish publishQos1 =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_LEAST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expectedQos1, publishQos1, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
 
         final MqttPublish publishQos2 =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.EXACTLY_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, null, HAS_NOT, NO_USER_PROPERTIES);
+                        null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
         encode(expectedQos2, publishQos2, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
 
@@ -626,7 +629,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), null, MqttQos.AT_MOST_ONCE, false,
                         MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null,
-                        null, correlationData, HAS_NOT, NO_USER_PROPERTIES);
+                        null, correlationData, TopicAliasUsage.NO, NO_USER_PROPERTIES);
 
 
         final MqttStatefulPublish publishInternal =
@@ -666,7 +669,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
                         MqttQos.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
-                        Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, HAS_NOT, userProperties);
+                        Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, TopicAliasUsage.NO, userProperties);
 
         encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
     }
@@ -712,7 +715,8 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish =
                 new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}),
                         MqttQos.AT_MOST_ONCE, false, MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY,
-                        Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, correlationData, HAS_NOT, userProperties);
+                        Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, correlationData, TopicAliasUsage.NO,
+                        userProperties);
 
         encode(expected.array(), publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
         expected.release();

--- a/src/test/java/org/mqttbee/mqtt/message/publish/MqttPublishTest.java
+++ b/src/test/java/org/mqttbee/mqtt/message/publish/MqttPublishTest.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage.HAS_NOT;
+import static org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage.NO;
 import static org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl.NO_USER_PROPERTIES;
 
 /**
@@ -37,8 +37,8 @@ public class MqttPublishTest {
 
     public static MqttPublish createPublishFromPayload(final ByteBuffer payload) {
         return new MqttPublish(requireNonNull(MqttTopicImpl.from("topic")), payload, MqttQos.AT_MOST_ONCE, false,
-            MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
-                HAS_NOT, NO_USER_PROPERTIES);
+            MqttPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, NO,
+                NO_USER_PROPERTIES);
     }
 
     @Test


### PR DESCRIPTION
**Motivation**
Precondition checks in builder methods must have meaningful error messages.

**Changes**
* add error messages to precondition checks
* refactor TopicAliasUsage enum to only have states YES, NO and IF_AVAILABLE
* remove redundant precondition check on toipc alias usage in publish builder