### PR TITLE
Feature/websocket subprotocol

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/MqttWebSocketConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttWebSocketConfig.java
@@ -31,4 +31,6 @@ public interface MqttWebSocketConfig {
     @NotNull
     String getServerPath();
 
+    @NotNull
+    String getSubprotocol();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/MqttWebSocketConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttWebSocketConfigBuilder.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
  */
 public class MqttWebSocketConfigBuilder<P> extends FluentBuilder<MqttWebSocketConfig, P> {
 
-    private String serverPath = "";
+    private String serverPath = MqttWebSocketConfigImpl.DEFAULT_SERVER_PATH;
 
     public MqttWebSocketConfigBuilder(@Nullable final Function<? super MqttWebSocketConfig, P> parentConsumer) {
         super(parentConsumer);

--- a/src/main/java/org/mqttbee/api/mqtt/MqttWebSocketConfigBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttWebSocketConfigBuilder.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 public class MqttWebSocketConfigBuilder<P> extends FluentBuilder<MqttWebSocketConfig, P> {
 
     private String serverPath = MqttWebSocketConfigImpl.DEFAULT_SERVER_PATH;
+    private String subprotocol = MqttWebSocketConfigImpl.DEFAULT_MQTT_SUBPROTOCOL;
 
     public MqttWebSocketConfigBuilder(@Nullable final Function<? super MqttWebSocketConfig, P> parentConsumer) {
         super(parentConsumer);
@@ -42,9 +43,15 @@ public class MqttWebSocketConfigBuilder<P> extends FluentBuilder<MqttWebSocketCo
     }
 
     @NotNull
+    public MqttWebSocketConfigBuilder<P> subprotocol(@NotNull final String subprotocol) {
+        this.subprotocol = subprotocol;
+        return this;
+    }
+
+    @NotNull
     @Override
     public MqttWebSocketConfig build() {
-        return new MqttWebSocketConfigImpl(serverPath);
+        return new MqttWebSocketConfigImpl(serverPath, subprotocol);
     }
 
 }

--- a/src/main/java/org/mqttbee/mqtt/MqttWebSocketConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttWebSocketConfigImpl.java
@@ -23,8 +23,9 @@ import org.mqttbee.api.mqtt.MqttWebSocketConfig;
  * @author David Katz
  */
 public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
+    public static final String DEFAULT_SERVER_PATH = "";
 
-    public static final MqttWebSocketConfigImpl DEFAULT = new MqttWebSocketConfigImpl("");
+    public static final MqttWebSocketConfigImpl DEFAULT = new MqttWebSocketConfigImpl(DEFAULT_SERVER_PATH);
 
     private final String serverPath;
 

--- a/src/main/java/org/mqttbee/mqtt/MqttWebSocketConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttWebSocketConfigImpl.java
@@ -21,23 +21,35 @@ import org.mqttbee.api.mqtt.MqttWebSocketConfig;
 
 /**
  * @author David Katz
+ * @author Christian Hoff
  */
 public class MqttWebSocketConfigImpl implements MqttWebSocketConfig {
     public static final String DEFAULT_SERVER_PATH = "";
+    // https://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name
+    public static final String DEFAULT_MQTT_SUBPROTOCOL = "mqtt";
 
-    public static final MqttWebSocketConfigImpl DEFAULT = new MqttWebSocketConfigImpl(DEFAULT_SERVER_PATH);
+    public static final MqttWebSocketConfigImpl DEFAULT =
+            new MqttWebSocketConfigImpl(DEFAULT_SERVER_PATH, DEFAULT_MQTT_SUBPROTOCOL);
 
     private final String serverPath;
+    private final String subprotocol;
 
-    public MqttWebSocketConfigImpl(@NotNull final String serverPath) {
+    public MqttWebSocketConfigImpl(@NotNull final String serverPath, @NotNull final String subprotocol) {
         // remove any leading slashes
         this.serverPath = serverPath.replaceAll("^/+", "");
+        this.subprotocol = subprotocol;
     }
 
     @Override
     @NotNull
     public String getServerPath() {
         return serverPath;
+    }
+
+    @Override
+    @NotNull
+    public String getSubprotocol() {
+        return subprotocol;
     }
 
 }

--- a/src/main/java/org/mqttbee/mqtt/handler/websocket/MqttWebSocketClientProtocolHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/websocket/MqttWebSocketClientProtocolHandler.java
@@ -39,8 +39,6 @@ public class MqttWebSocketClientProtocolHandler extends WebSocketClientProtocolH
     public static final String NAME = "ws.mqtt";
     private static final String WEBSOCKET_URI_SCHEME = "ws";
     private static final String WEBSOCKET_TLS_URI_SCHEME = "wss";
-    // https://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name
-    private static final String MQTT_SUBPROTOCOL = "mqtt";
 
     private static URI createURI(
             @NotNull final MqttClientData clientData, @NotNull final MqttWebSocketConfig webSocketConfig)
@@ -57,8 +55,8 @@ public class MqttWebSocketClientProtocolHandler extends WebSocketClientProtocolH
             @NotNull final MqttClientData clientData, @NotNull final MqttWebSocketConfig webSocketConfig,
             @NotNull final MqttChannelInitializer channelInitializer) throws URISyntaxException {
 
-        super(createURI(clientData, webSocketConfig), WebSocketVersion.V13, MQTT_SUBPROTOCOL, true, null,
-                MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT);
+        super(createURI(clientData, webSocketConfig), WebSocketVersion.V13, webSocketConfig.getSubprotocol(), true,
+                null, MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT);
         this.channelInitializer = channelInitializer;
     }
 


### PR DESCRIPTION
**Motivation**
The WebSocket subprotocol as defined by [IANA](https://www.iana.org/assignments/websocket/websocket.xml#subprotocol-name) must be configurable by users.

**Changes**

introduce constant for default server path to remove magic string
make WebSocket subprotocol configurable #125 