### PR TITLE
MQTT3 encoder tests

### DIFF
--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/AbstractMqttEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/AbstractMqttEncoderTest.java
@@ -24,20 +24,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mqttbee.annotations.NotNull;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.mqtt.MqttClientData;
-import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
 import org.mqttbee.mqtt.MqttServerConnectionData;
-import org.mqttbee.mqtt.MqttVersion;
-import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
-
-import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Silvio Giebl
  */
-public class AbstractMqtt5EncoderTest {
+public abstract class AbstractMqttEncoderTest {
 
     private final MqttMessageEncoders messageEncoders;
     private final boolean connected;
@@ -45,12 +40,14 @@ public class AbstractMqtt5EncoderTest {
 
     protected EmbeddedChannel channel;
 
-    protected AbstractMqtt5EncoderTest(@NotNull final MqttMessageEncoders messageEncoders, final boolean connected) {
+    protected AbstractMqttEncoderTest(
+            @NotNull final MqttMessageEncoders messageEncoders,
+            final boolean connected,
+            final MqttClientData clientData
+    ) {
         this.messageEncoders = messageEncoders;
         this.connected = connected;
-        clientData =
-                new MqttClientData(MqttVersion.MQTT_5_0, Objects.requireNonNull(MqttClientIdentifierImpl.from("test")),
-                        "localhost", 1883, null, null, false, false, MqttClientExecutorConfigImpl.DEFAULT, null);
+        this.clientData = clientData;
     }
 
     @BeforeEach

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/MqttPingReqEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/MqttPingReqEncoderTest.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.codec.encoder;
 
 import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.Test;
+import org.mqttbee.mqtt.codec.encoder.mqtt5.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.message.ping.MqttPingReq;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertArrayEquals;
  * @author David Katz
  */
 class MqttPingReqEncoderTest extends AbstractMqtt5EncoderTest {
-
+// TODO does this want to exist for both mqtt3 and mqtt5?
     MqttPingReqEncoderTest() {
         super(code -> new MqttPingReqEncoder(), true);
     }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/AbstractMqtt3EncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/AbstractMqtt3EncoderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mqttbee.mqtt.codec.encoder.mqtt3;
+
+import com.google.common.primitives.Bytes;
+import io.netty.buffer.ByteBuf;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
+import org.mqttbee.annotations.NotNull;
+import org.mqttbee.mqtt.MqttClientData;
+import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
+import org.mqttbee.mqtt.MqttVersion;
+import org.mqttbee.mqtt.codec.encoder.AbstractMqttEncoderTest;
+import org.mqttbee.mqtt.codec.encoder.MqttMessageEncoders;
+import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
+import org.mqttbee.mqtt.message.MqttMessage;
+
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * @author Alex Stockinger
+ */
+public abstract class AbstractMqtt3EncoderTest extends AbstractMqttEncoderTest {
+
+    protected static final Charset UTF8 = Charset.forName("UTF-8");
+
+    protected AbstractMqtt3EncoderTest(
+            @NotNull final MqttMessageEncoders messageEncoders,
+            final boolean connected
+    ) {
+        super(messageEncoders, connected, createClientData());
+    }
+
+    private static MqttClientData createClientData() {
+        return new MqttClientData(
+                MqttVersion.MQTT_3_1_1,
+                Objects.requireNonNull(MqttClientIdentifierImpl.from("test")),
+                "localhost",
+                1883,
+                null,
+                null,
+                false,
+                false,
+                MqttClientExecutorConfigImpl.DEFAULT,
+                null
+        );
+    }
+
+    protected void encode(final byte[] expected, final MqttMessage object) {
+        assertArrayEquals(expected, bytesOf(object));
+    }
+
+    protected byte[] bytesOf(final MqttWireMessage message) throws MqttException {
+        return Bytes.concat(message.getHeader(), message.getPayload());
+    }
+
+    protected byte[] bytesOf(final MqttMessage object) {
+        channel.writeOutbound(object);
+        final ByteBuf byteBuf = channel.readOutbound();
+        final byte[] actual = new byte[byteBuf.readableBytes()];
+        byteBuf.readBytes(actual);
+        byteBuf.release();
+        return actual;
+    }
+}

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3ConnectEncoderTest.java
@@ -17,113 +17,90 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
-import com.google.common.primitives.Bytes;
-import io.netty.buffer.ByteBuf;
 import org.eclipse.paho.client.mqttv3.MqttException;
-import org.junit.jupiter.api.Test;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvFileSource;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
+import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
+import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 import org.mqttbee.mqtt.message.connect.MqttConnect;
 import org.mqttbee.mqtt.message.connect.MqttStatefulConnect;
 import org.mqttbee.mqtt.message.connect.mqtt3.Mqtt3ConnectView;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
+import static org.eclipse.paho.client.mqttv3.MqttConnectOptions.MQTT_VERSION_3_1_1;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.platform.commons.util.StringUtils.isNotBlank;
 
-class Mqtt3ConnectEncoderTest extends AbstractMqtt5EncoderTest {
-
-    private static final byte[] EXAMPLE_CONNECT = {
-            // FIXED HEADER
-            // packet type and flags
-            0x10,
-            // remaining length (16 Bytes)
-            0x10,
-            // VARIABLE HEADER
-            // protocol name
-            0x00, //msb
-            0x04, //lsb
-            'M', 'Q', 'T', 'T',
-            //protocol level
-            0x04,
-            //connect flags (only clean session is set)
-            0b0000_0010,
-            //keep alive (60)
-            0x00, 0x3c,
-            //clientId
-            0x00, 0x04, 'T', 'E', 'S', 'T'
-    };
+class Mqtt3ConnectEncoderTest extends AbstractMqtt3EncoderTest {
 
     Mqtt3ConnectEncoderTest() {
         super(code -> new Mqtt3ConnectEncoder(), false);
     }
 
-    @Test
-    void encode_SUCCESS() {
-        final MqttClientIdentifierImpl identifier = Objects.requireNonNull(MqttClientIdentifierImpl.from("TEST"));
-        final MqttConnect connect = Mqtt3ConnectView.delegate(60, true, null, null);
-        final MqttStatefulConnect connectWrapper = connect.createStateful(identifier, null);
-        encode(EXAMPLE_CONNECT, connectWrapper);
+    @CsvFileSource(resources = "/testParams/mqtt3/Connect.csv")
+    @ParameterizedTest(name = "Connect(\"{0}\", {1}, {2}, \"{3}\", \"{4}\", \"{5}\", \"{6}\")")
+    public void matchesPaho(
+            final String clientId,
+            final boolean cleanSession,
+            final int keepAliveInterval,
+            final String userName,
+            final String password,
+            final String willMessage,
+            final String willTopic,
+            final Integer willQos,
+            final Boolean willRetained
+    ) throws MqttException {
+        final boolean hasAuth = isNotBlank(userName) && isNotBlank(password);
+        final boolean hasWill = isNotBlank(willMessage)
+                && isNotBlank(willTopic)
+                && willQos != null
+                && willRetained != null;
+
+        final MqttSimpleAuth auth = !hasAuth ? null : new MqttSimpleAuth(
+                MqttUTF8StringImpl.from(userName),
+                ByteBuffer.wrap(password.getBytes(UTF8))
+        );
+        final MqttClientIdentifierImpl identifier = MqttClientIdentifierImpl.from(clientId);
+        final MqttWillPublish beeWill = !hasWill ? null : new MqttWillPublish(
+                MqttTopicImpl.from(willTopic),
+                ByteBuffer.wrap(willMessage.getBytes()),
+                MqttQos.fromCode(willQos),
+                willRetained,
+                MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, // Not in MQTT 3.1.1
+                null, // Not in MQTT 3.1.1
+                null, // Not in MQTT 3.1.1
+                null, // Not in MQTT 3.1.1
+                null, // Not in MQTT 3.1.1
+                MqttUserPropertiesImpl.NO_USER_PROPERTIES, // Not in MQTT 3.1.1
+                0 // Not in MQTT 3.1.1
+        );
+        final MqttConnect beeConnect = Mqtt3ConnectView.delegate(keepAliveInterval, cleanSession, auth, beeWill);
+        final MqttStatefulConnect connectWrapper = beeConnect.createStateful(identifier, null);
+
+        org.eclipse.paho.client.mqttv3.internal.wire.MqttConnect pahoConnect =
+                new org.eclipse.paho.client.mqttv3.internal.wire.MqttConnect(
+                        clientId,
+                        MQTT_VERSION_3_1_1, // MQTT bee only supports 3.1.1, so constant for PAHO
+                        cleanSession,
+                        keepAliveInterval,
+                        !hasAuth ? null : userName,
+                        !hasAuth ? null : password.toCharArray(),
+                        !hasWill ? null : new MqttMessage(willMessage.getBytes(UTF8)) {
+                            {
+                                setQos(willQos);
+                                setRetained(willRetained);
+                            }
+                        },
+                        !hasWill ? null : willTopic
+                );
+
+        assertArrayEquals(bytesOf(pahoConnect), bytesOf(connectWrapper));
     }
-
-    @Test
-    void test_SUCCESS_WITH_WILL_WITH_PAHO() throws MqttException {
-        final String clientId = "Test123";
-        final boolean cleanSession = true;
-        final int keepAlive = 120;
-        final String username = null;
-        final String password = null;
-        final String willTopic = "my/last/will";
-        final String myLastWill = "mylastwillpayload";
-        final boolean isRetained = false;
-        final int qosWill = 1;
-
-        //PAHO
-        final org.eclipse.paho.client.mqttv3.MqttMessage will =
-                new org.eclipse.paho.client.mqttv3.MqttMessage(myLastWill.getBytes());
-        will.setQos(qosWill);
-        final org.eclipse.paho.client.mqttv3.internal.wire.MqttConnect pahoConnect =
-                new org.eclipse.paho.client.mqttv3.internal.wire.MqttConnect(clientId, 4, cleanSession, keepAlive,
-                        username, password == null ? "".toCharArray() : password.toCharArray(), will, willTopic);
-
-        final byte[] expected = Bytes.concat(pahoConnect.getHeader(), pahoConnect.getPayload());
-
-        final MqttWillPublish willMessage = new MqttWillPublish(Objects.requireNonNull(MqttTopicImpl.from(willTopic)),
-                ByteBuffer.wrap(myLastWill.getBytes()), Objects.requireNonNull(MqttQos.fromCode(qosWill)), isRetained,
-                MqttWillPublish.MESSAGE_EXPIRY_INTERVAL_INFINITY, null, null, null, null,
-                MqttUserPropertiesImpl.NO_USER_PROPERTIES, 0);
-
-        final MqttConnect connect = Mqtt3ConnectView.delegate(keepAlive, cleanSession, null, willMessage);
-        final MqttStatefulConnect connectWrapper =
-                connect.createStateful(Objects.requireNonNull(MqttClientIdentifierImpl.from(clientId)), null);
-
-        encode(expected, connectWrapper);
-    }
-
-    /**
-     * Pseudo test to assure we get the right bytes from paho methods
-     */
-    @Test
-    void test_PAHO_GETPAYLOAD_METHOD() throws MqttException {
-        final org.eclipse.paho.client.mqttv3.internal.wire.MqttConnect pahoConnect =
-                new org.eclipse.paho.client.mqttv3.internal.wire.MqttConnect("TEST", 4, true, 60, null, null, null,
-                        null);
-        final byte[] actual = Bytes.concat(pahoConnect.getHeader(), pahoConnect.getPayload());
-        assertArrayEquals(EXAMPLE_CONNECT, actual);
-    }
-
-    private void encode(final byte[] expected, final MqttStatefulConnect connect) {
-        channel.writeOutbound(connect);
-        final ByteBuf byteBuf = channel.readOutbound();
-        final byte[] actual = new byte[byteBuf.readableBytes()];
-        byteBuf.readBytes(actual);
-        byteBuf.release();
-        assertArrayEquals(expected, actual);
-    }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PingReqEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PingReqEncoderTest.java
@@ -19,23 +19,23 @@ package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.Test;
-import org.mqttbee.mqtt.message.publish.pubcomp.MqttPubComp;
-import org.mqttbee.mqtt.message.publish.pubcomp.mqtt3.Mqtt3PubCompView;
+import org.mqttbee.mqtt.codec.encoder.MqttPingReqEncoder;
+import org.mqttbee.mqtt.message.ping.MqttPingReq;
 
 import static org.junit.Assert.assertArrayEquals;
 
-class Mqtt3PubCompEncoderTest extends AbstractMqtt3EncoderTest {
+class Mqtt3PingReqEncoderTest extends AbstractMqtt3EncoderTest {
 
-    Mqtt3PubCompEncoderTest() {
-        super(code -> new Mqtt3PubCompEncoder(), true);
+    Mqtt3PingReqEncoderTest() {
+        super(code -> MqttPingReqEncoder.INSTANCE, true);
     }
 
     @Test
-    void matchesPaho() throws MqttException {
-        final int id = 42;
-        final org.eclipse.paho.client.mqttv3.internal.wire.MqttPubComp pahoMessage =
-                new org.eclipse.paho.client.mqttv3.internal.wire.MqttPubComp(id);
-        final MqttPubComp beeMessage = Mqtt3PubCompView.delegate(id);
-        assertArrayEquals(bytesOf(pahoMessage), bytesOf(beeMessage));
+    void encode() throws MqttException {
+        final MqttPingReq beePing = MqttPingReq.INSTANCE;
+        final org.eclipse.paho.client.mqttv3.internal.wire.MqttPingReq pahoPing =
+                new org.eclipse.paho.client.mqttv3.internal.wire.MqttPingReq();
+
+        assertArrayEquals(bytesOf(pahoPing), bytesOf(beePing));
     }
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubAckEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubAckEncoderTest.java
@@ -17,41 +17,25 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
-import io.netty.buffer.ByteBuf;
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.Test;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.message.publish.puback.MqttPubAck;
 import org.mqttbee.mqtt.message.publish.puback.mqtt3.Mqtt3PubAckView;
 
 import static org.junit.Assert.assertArrayEquals;
 
-class Mqtt3PubAckEncoderTest extends AbstractMqtt5EncoderTest {
+class Mqtt3PubAckEncoderTest extends AbstractMqtt3EncoderTest {
 
     Mqtt3PubAckEncoderTest() {
         super(code -> new Mqtt3PubAckEncoder(), true);
     }
 
     @Test
-    void encode() {
-        final int id = 1;
-        final byte msb = (byte) (id >>> 8);
-        final byte lsb = (byte) id;
-        final byte[] expected = {0x40, 0x02, msb, lsb};
-        final MqttPubAck pubAck = Mqtt3PubAckView.delegate(id);
-        encode(expected, pubAck);
+    public void matchesPaho() throws MqttException {
+        final int id = 42;
+        org.eclipse.paho.client.mqttv3.internal.wire.MqttPubAck pahoMessage
+                = new org.eclipse.paho.client.mqttv3.internal.wire.MqttPubAck(id);
+        final MqttPubAck beeMessage = Mqtt3PubAckView.delegate(id);
+        assertArrayEquals(bytesOf(pahoMessage), bytesOf(beeMessage));
     }
-
-    @Test
-    void encodedRemainingLength() {
-    }
-
-    private void encode(final byte[] expected, final MqttPubAck pubAck) {
-        channel.writeOutbound(pubAck);
-        final ByteBuf byteBuf = channel.readOutbound();
-        final byte[] actual = new byte[byteBuf.readableBytes()];
-        byteBuf.readBytes(actual);
-        byteBuf.release();
-        assertArrayEquals(expected, actual);
-    }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRelEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3PubRelEncoderTest.java
@@ -17,41 +17,37 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
-import io.netty.buffer.ByteBuf;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttPubRec;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttPublish;
 import org.junit.jupiter.api.Test;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
 import org.mqttbee.mqtt.message.publish.pubrel.mqtt3.Mqtt3PubRelView;
 
 import static org.junit.Assert.assertArrayEquals;
 
-class Mqtt3PubRelEncoderTest extends AbstractMqtt5EncoderTest {
+class Mqtt3PubRelEncoderTest extends AbstractMqtt3EncoderTest {
 
     Mqtt3PubRelEncoderTest() {
         super(code -> new Mqtt3PubRelEncoder(), true);
     }
 
     @Test
-    void encode() {
-        final int id = 1;
-        final byte msb = (byte) (id >>> 8);
-        final byte lsb = (byte) id;
-        final byte[] expected = {0x62, 0x02, msb, lsb};
-        final MqttPubRel pubRel = Mqtt3PubRelView.delegate(id);
-        encode(expected, pubRel);
-    }
+    void matchesPaho() throws MqttException {
+        final int id = 42;
 
-    @Test
-    void encodedRemainingLength() {
-    }
+        final byte[] payload = new byte[]{42};
+        final MqttPublish pahoPublish = new MqttPublish(
+                "some/topic/string",
+                new MqttMessage(payload)
+        );
+        pahoPublish.setMessageId(id);
+        final org.eclipse.paho.client.mqttv3.internal.wire.MqttPubRel pahoPubRel =
+                new org.eclipse.paho.client.mqttv3.internal.wire.MqttPubRel(new MqttPubRec(pahoPublish));
 
-    private void encode(final byte[] expected, final MqttPubRel pubRel) {
-        channel.writeOutbound(pubRel);
-        final ByteBuf byteBuf = channel.readOutbound();
-        final byte[] actual = new byte[byteBuf.readableBytes()];
-        byteBuf.readBytes(actual);
-        byteBuf.release();
-        assertArrayEquals(expected, actual);
-    }
+        final MqttPubRel beePubRel = Mqtt3PubRelView.delegate(id);
 
+        assertArrayEquals(bytesOf(pahoPubRel), bytesOf(beePubRel));
+    }
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mqttbee.mqtt.codec.encoder.mqtt5;
+
+import org.mqttbee.annotations.NotNull;
+import org.mqttbee.mqtt.MqttClientData;
+import org.mqttbee.mqtt.MqttClientExecutorConfigImpl;
+import org.mqttbee.mqtt.MqttVersion;
+import org.mqttbee.mqtt.codec.encoder.AbstractMqttEncoderTest;
+import org.mqttbee.mqtt.codec.encoder.MqttMessageEncoders;
+import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
+
+import java.util.Objects;
+
+public class AbstractMqtt5EncoderTest extends AbstractMqttEncoderTest {
+    protected AbstractMqtt5EncoderTest(
+            @NotNull final MqttMessageEncoders messageEncoders,
+            final boolean connected
+    ) {
+        super(messageEncoders, connected, createClientData());
+    }
+
+    private static MqttClientData createClientData() {
+        return new MqttClientData(
+                MqttVersion.MQTT_5_0,
+                Objects.requireNonNull(MqttClientIdentifierImpl.from("test")),
+                "localhost",
+                1883,
+                null,
+                null,
+                false,
+                false,
+                MqttClientExecutorConfigImpl.DEFAULT,
+                null
+        );
+    }
+}

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderWithUserPropertiesTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderWithUserPropertiesTest.java
@@ -19,7 +19,6 @@ package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
 import com.google.common.collect.ImmutableList;
 import org.mqttbee.annotations.NotNull;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.codec.encoder.MqttMessageEncoders;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
@@ -48,7 +47,9 @@ abstract class AbstractMqtt5EncoderWithUserPropertiesTest extends AbstractMqtt5E
     final private MqttUserPropertyImpl userProperty = new MqttUserPropertyImpl(user, property);
 
     AbstractMqtt5EncoderWithUserPropertiesTest(
-            @NotNull final MqttMessageEncoders messageEncoders, final boolean connected) {
+            @NotNull final MqttMessageEncoders messageEncoders,
+            final boolean connected
+    ) {
 
         super(messageEncoders, connected);
     }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoderTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5AuthReasonCode;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.datatypes.MqttUTF8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
@@ -35,7 +35,6 @@ import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.auth.MqttEnhancedAuth;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoderTest.java
@@ -20,7 +20,6 @@ package org.mqttbee.mqtt.codec.encoder.mqtt5;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.mqttbee.api.mqtt.exceptions.MqttMaximumPacketSizeExceededException;
-import org.mqttbee.mqtt.codec.encoder.AbstractMqtt5EncoderTest;
 import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.unsubscribe.MqttStatefulUnsubscribe;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;

--- a/src/test/resources/testParams/mqtt3/Connect.csv
+++ b/src/test/resources/testParams/mqtt3/Connect.csv
@@ -1,0 +1,4 @@
+client42, true, 10, , , , , ,
+client42, true, 10, userName, password, , , ,
+client42, true, 10, userName, password, willMessage, my/will/topic, 1, true
+


### PR DESCRIPTION
The existing MQTT3 encoder tests were replaced with tests comparing the encoded output with eclipse paho's output.