### PR TITLE
Added javadoc check to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ stages:
   - name: release
     if: branch = master && type != pull_request
 
+script: ./gradlew check javadoc
+
 jobs:
   include:
     - stage: snapshot

--- a/src/main/java/org/mqttbee/rx/FlowableMapFilter.java
+++ b/src/main/java/org/mqttbee/rx/FlowableMapFilter.java
@@ -37,7 +37,7 @@ import org.reactivestreams.Subscriber;
  * <dd>The operator doesn't interfere with backpressure which is determined by the source {@code Publisher}'s
  * backpressure behavior.</dd>
  * <dt><b>Scheduler:</b></dt>
- * <dd>The operator does not operate by default on a particular {@link io.reactivex.Scheduler, Scheduler}.</dd>
+ * <dd>The operator does not operate by default on a particular {@link io.reactivex.Scheduler Scheduler}.</dd>
  * </dl>
  *
  * @author Silvio Giebl


### PR DESCRIPTION
**Motivation**
Javadoc is not tested on branch and PR builds, but is necessary to build the development snapshot

**Changes**
- Added javadoc check to travis build
- Fixed javadoc error