### PR TITLE
Improvement/replace immutablelist

### DIFF
--- a/src/main/java/org/mqttbee/annotations/CallByThread.java
+++ b/src/main/java/org/mqttbee/annotations/CallByThread.java
@@ -17,12 +17,9 @@
 
 package org.mqttbee.annotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import java.lang.annotation.*;
 
 /**
  * Documents that a method should only be called by the specified thread.
@@ -30,10 +27,9 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  * @author Silvio Giebl
  */
 @Documented
-@Retention(CLASS)
-@Target(METHOD)
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
 public @interface CallByThread {
 
-    String value();
-
+    @NotNull String value();
 }

--- a/src/main/java/org/mqttbee/annotations/Immutable.java
+++ b/src/main/java/org/mqttbee/annotations/Immutable.java
@@ -20,16 +20,12 @@ package org.mqttbee.annotations;
 import java.lang.annotation.*;
 
 /**
- * Documents that an interface MUST NOT be implemented by the user.
- * <p>
- * The implementation is provided by the library.
- * <p>
- * This allows the library to later add methods to the interface without breaking backwards compatibility with
- * implementing classes.
+ * Documents that the annotated type is immutable. This means that its state can not be seen to change and can not be
+ * changed by callers.
  *
  * @author Silvio Giebl
  */
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target(ElementType.TYPE)
-public @interface DoNotImplement {}
+@Target({ElementType.TYPE, ElementType.TYPE_USE})
+public @interface Immutable {}

--- a/src/main/java/org/mqttbee/api/mqtt/MqttClientSslConfig.java
+++ b/src/main/java/org/mqttbee/api/mqtt/MqttClientSslConfig.java
@@ -16,13 +16,14 @@
 
 package org.mqttbee.api.mqtt;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.MqttClientSslConfigImplBuilder;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -42,9 +43,9 @@ public interface MqttClientSslConfig {
 
     @NotNull Optional<TrustManagerFactory> getTrustManagerFactory();
 
-    @NotNull Optional<ImmutableList<String>> getCipherSuites();
+    @NotNull Optional<@Immutable List<@NotNull String>> getCipherSuites();
 
-    @NotNull Optional<ImmutableList<String>> getProtocols();
+    @NotNull Optional<@Immutable List<@NotNull String>> getProtocols();
 
     long getHandshakeTimeoutMs();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttSharedTopicFilter.java
@@ -64,12 +64,6 @@ public interface MqttSharedTopicFilter extends MqttTopicFilter {
         return new MqttTopicFilterImplBuilder.SharedDefault(shareName);
     }
 
-    static @NotNull MqttSharedTopicFilterBuilder.Complete extend(
-            final @NotNull MqttSharedTopicFilter sharedTopicFilter) {
-
-        return new MqttTopicFilterImplBuilder.SharedDefault(sharedTopicFilter);
-    }
-
     /**
      * @return the Share Name of this Shared Topic Filter as a string.
      */
@@ -79,4 +73,6 @@ public interface MqttSharedTopicFilter extends MqttTopicFilter {
      * @return the Topic Filter of this Shared Topic Filter.
      */
     @NotNull MqttTopicFilter getTopicFilter();
+
+    @NotNull MqttSharedTopicFilterBuilder.Complete extendShared();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
@@ -60,10 +60,6 @@ public interface MqttTopic extends MqttUtf8String {
         return new MqttTopicImplBuilder.Default();
     }
 
-    static @NotNull MqttTopicBuilder.Complete extend(final @NotNull MqttTopic topic) {
-        return new MqttTopicImplBuilder.Default(topic);
-    }
-
     /**
      * @return the levels of this Topic Name.
      */
@@ -73,4 +69,6 @@ public interface MqttTopic extends MqttUtf8String {
      * @return a Topic Filter matching only this Topic Name.
      */
     @NotNull MqttTopicFilter filter();
+
+    @NotNull MqttTopicBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopic.java
@@ -17,11 +17,13 @@
 
 package org.mqttbee.api.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
 import org.mqttbee.mqtt.datatypes.MqttTopicImplBuilder;
+
+import java.util.List;
 
 /**
  * MQTT Topic Name according to the MQTT specification.
@@ -65,7 +67,7 @@ public interface MqttTopic extends MqttUtf8String {
     /**
      * @return the levels of this Topic Name.
      */
-    @NotNull ImmutableList<String> getLevels();
+    @Immutable @NotNull List<@NotNull String> getLevels();
 
     /**
      * @return a Topic Filter matching only this Topic Name.

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
@@ -64,10 +64,6 @@ public interface MqttTopicFilter extends MqttUtf8String {
         return new MqttTopicFilterImplBuilder.Default();
     }
 
-    static @NotNull MqttTopicFilterBuilder.Complete extend(final @NotNull MqttTopicFilter topicFilter) {
-        return new MqttTopicFilterImplBuilder.Default(topicFilter);
-    }
-
     /**
      * @return the levels of this Topic Filter.
      */
@@ -114,4 +110,6 @@ public interface MqttTopicFilter extends MqttUtf8String {
      * @return true if this Topic Filter matches the given Topic Filter, otherwise false.
      */
     boolean matches(@NotNull MqttTopicFilter topicFilter);
+
+    @NotNull MqttTopicFilterBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
+++ b/src/main/java/org/mqttbee/api/mqtt/datatypes/MqttTopicFilter.java
@@ -17,11 +17,13 @@
 
 package org.mqttbee.api.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImplBuilder;
+
+import java.util.List;
 
 /**
  * MQTT Topic Filter according to the MQTT specification.
@@ -69,7 +71,7 @@ public interface MqttTopicFilter extends MqttUtf8String {
     /**
      * @return the levels of this Topic Filter.
      */
-    @NotNull ImmutableList<String> getLevels();
+    @Immutable @NotNull List<@NotNull String> getLevels();
 
     /**
      * @return whether this Topic Filter contains wildcards.

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/connect/Mqtt3Connect.java
@@ -41,10 +41,6 @@ public interface Mqtt3Connect extends Mqtt3Message {
         return new Mqtt3ConnectViewBuilder.Default();
     }
 
-    static @NotNull Mqtt3ConnectBuilder extend(final @NotNull Mqtt3Connect connect) {
-        return new Mqtt3ConnectViewBuilder.Default(connect);
-    }
-
     /**
      * @return the keep alive in seconds the client wants to use.
      */
@@ -71,4 +67,5 @@ public interface Mqtt3Connect extends Mqtt3Message {
         return Mqtt3MessageType.CONNECT;
     }
 
+    @NotNull Mqtt3ConnectBuilder extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3Publish.java
@@ -41,10 +41,6 @@ public interface Mqtt3Publish extends Mqtt3Message, Mqtt3SubscribeResult {
         return new Mqtt3PublishViewBuilder.Default();
     }
 
-    static @NotNull Mqtt3PublishBuilder.Complete extend(@NotNull final Mqtt3Publish publish) {
-        return new Mqtt3PublishViewBuilder.Default(publish);
-    }
-
     /**
      * @return the topic of this PUBLISH packet.
      */
@@ -75,4 +71,5 @@ public interface Mqtt3Publish extends Mqtt3Message, Mqtt3SubscribeResult {
         return Mqtt3MessageType.PUBLISH;
     }
 
+    @NotNull Mqtt3PublishBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
@@ -36,10 +36,6 @@ public interface Mqtt3Subscribe extends Mqtt3Message {
         return new Mqtt3SubscribeViewBuilder.Default();
     }
 
-    static @NotNull Mqtt3SubscribeBuilder.Complete extend(final @NotNull Mqtt3Subscribe subscribe) {
-        return new Mqtt3SubscribeViewBuilder.Default(subscribe);
-    }
-
     /**
      * @return the {@link Mqtt3Subscription}s of this SUBSCRIBE packet. The list contains at least one subscription.
      */
@@ -49,4 +45,6 @@ public interface Mqtt3Subscribe extends Mqtt3Message {
     default @NotNull Mqtt3MessageType getType() {
         return Mqtt3MessageType.SUBSCRIBE;
     }
+
+    @NotNull Mqtt3SubscribeBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/Mqtt3Subscribe.java
@@ -17,12 +17,14 @@
 
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 import org.mqttbee.mqtt.message.subscribe.mqtt3.Mqtt3SubscribeViewBuilder;
+
+import java.util.List;
 
 /**
  * MQTT 3 SUBSCRIBE packet.
@@ -41,11 +43,10 @@ public interface Mqtt3Subscribe extends Mqtt3Message {
     /**
      * @return the {@link Mqtt3Subscription}s of this SUBSCRIBE packet. The list contains at least one subscription.
      */
-    @NotNull ImmutableList<? extends Mqtt3Subscription> getSubscriptions();
+    @Immutable @NotNull List<@NotNull ? extends Mqtt3Subscription> getSubscriptions();
 
     @Override
     default @NotNull Mqtt3MessageType getType() {
         return Mqtt3MessageType.SUBSCRIBE;
     }
-
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/suback/Mqtt3SubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/subscribe/suback/Mqtt3SubAck.java
@@ -17,12 +17,14 @@
 
 package org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback;
 
-import com.google.common.collect.ImmutableList;
-import org.mqttbee.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3SubscribeResult;
+
+import java.util.List;
 
 /**
  * MQTT 3 SUBACK packet.
@@ -32,16 +34,12 @@ public interface Mqtt3SubAck extends Mqtt3Message, Mqtt3SubscribeResult {
 
     /**
      * @return the Return Codes of this SUBACK packet, each belonging to a subscription in the corresponding SUBSCRIBE
-     * packet in the same order.
+     *         packet in the same order.
      */
-    @NotNull
-    ImmutableList<Mqtt3SubAckReturnCode> getReturnCodes();
+    @Immutable @NotNull List<@NotNull Mqtt3SubAckReturnCode> getReturnCodes();
 
-    @NotNull
     @Override
-    default Mqtt3MessageType getType() {
+    default @NotNull Mqtt3MessageType getType() {
         return Mqtt3MessageType.SUBACK;
     }
-
-
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
@@ -37,10 +37,6 @@ public interface Mqtt3Unsubscribe extends Mqtt3Message {
         return new Mqtt3UnsubscribeViewBuilder.Default();
     }
 
-    static @NotNull Mqtt3UnsubscribeBuilder.Complete extend(final @NotNull Mqtt3Unsubscribe unsubscribe) {
-        return new Mqtt3UnsubscribeViewBuilder.Default(unsubscribe);
-    }
-
     /**
      * @return the Topic Filters of this UNSUBSCRIBE packet. The list contains at least one Topic Filter.
      */
@@ -50,4 +46,6 @@ public interface Mqtt3Unsubscribe extends Mqtt3Message {
     default @NotNull Mqtt3MessageType getType() {
         return Mqtt3MessageType.UNSUBSCRIBE;
     }
+
+    @NotNull Mqtt3UnsubscribeBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3Unsubscribe.java
@@ -17,13 +17,15 @@
 
 package org.mqttbee.api.mqtt.mqtt3.message.unsubscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3Message;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 import org.mqttbee.mqtt.message.unsubscribe.mqtt3.Mqtt3UnsubscribeViewBuilder;
+
+import java.util.List;
 
 /**
  * MQTT 3 UNSUBSCRIBE packet.
@@ -42,11 +44,10 @@ public interface Mqtt3Unsubscribe extends Mqtt3Message {
     /**
      * @return the Topic Filters of this UNSUBSCRIBE packet. The list contains at least one Topic Filter.
      */
-    @NotNull ImmutableList<? extends MqttTopicFilter> getTopicFilters();
+    @Immutable @NotNull List<@NotNull ? extends MqttTopicFilter> getTopicFilters();
 
     @Override
     default @NotNull Mqtt3MessageType getType() {
         return Mqtt3MessageType.UNSUBSCRIBE;
     }
-
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
@@ -59,12 +59,10 @@ public interface Mqtt5UserProperties {
         return new MqttUserPropertiesImplBuilder.Default();
     }
 
-    static @NotNull Mqtt5UserPropertiesBuilder extend(final @NotNull Mqtt5UserProperties userProperties) {
-        return new MqttUserPropertiesImplBuilder.Default(userProperties);
-    }
-
     /**
      * @return the User Properties as an immutable list.
      */
     @Immutable @NotNull List<@NotNull ? extends Mqtt5UserProperty> asList();
+
+    @NotNull Mqtt5UserPropertiesBuilder extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
@@ -47,7 +47,7 @@ public interface Mqtt5UserProperties {
      * @param userProperties the User Properties.
      * @return the created collection of User Properties.
      */
-    static @NotNull Mqtt5UserProperties of(final @NotNull Mqtt5UserProperty... userProperties) {
+    static @NotNull Mqtt5UserProperties of(final @NotNull Mqtt5UserProperty @NotNull ... userProperties) {
         return MqttChecks.userProperties(userProperties);
     }
 

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/datatypes/Mqtt5UserProperties.java
@@ -17,9 +17,9 @@
 
 package org.mqttbee.api.mqtt.mqtt5.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImplBuilder;
 import org.mqttbee.mqtt.util.MqttChecks;
@@ -66,5 +66,5 @@ public interface Mqtt5UserProperties {
     /**
      * @return the User Properties as an immutable list.
      */
-    @NotNull ImmutableList<@NotNull ? extends Mqtt5UserProperty> asList();
+    @Immutable @NotNull List<@NotNull ? extends Mqtt5UserProperty> asList();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/connect/Mqtt5Connect.java
@@ -50,10 +50,6 @@ public interface Mqtt5Connect extends Mqtt5Message {
         return new MqttConnectBuilder.Default();
     }
 
-    static @NotNull Mqtt5ConnectBuilder extend(final @NotNull Mqtt5Connect connect) {
-        return new MqttConnectBuilder.Default(connect);
-    }
-
     /**
      * @return the keep alive in seconds the client wants to use.
      */
@@ -112,4 +108,5 @@ public interface Mqtt5Connect extends Mqtt5Message {
         return Mqtt5MessageType.CONNECT;
     }
 
+    @NotNull Mqtt5ConnectBuilder extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5Disconnect.java
@@ -42,10 +42,6 @@ public interface Mqtt5Disconnect extends Mqtt5Message {
         return new MqttDisconnectBuilder.Default();
     }
 
-    static @NotNull Mqtt5DisconnectBuilder extend(final @NotNull Mqtt5Disconnect disconnect) {
-        return new MqttDisconnectBuilder.Default(disconnect);
-    }
-
     /**
      * @return the reason code of this DISCONNECT packet.
      */
@@ -76,4 +72,6 @@ public interface Mqtt5Disconnect extends Mqtt5Message {
     default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.DISCONNECT;
     }
+
+    @NotNull Mqtt5DisconnectBuilder extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5Publish.java
@@ -51,10 +51,6 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
         return new MqttPublishBuilder.Default();
     }
 
-    static @NotNull Mqtt5PublishBuilder.Complete extend(final @NotNull Mqtt5Publish publish) {
-        return new MqttPublishBuilder.Default(publish);
-    }
-
     /**
      * @return the topic of this PUBLISH packet.
      */
@@ -120,4 +116,5 @@ public interface Mqtt5Publish extends Mqtt5Message, Mqtt5SubscribeResult {
         return Mqtt5MessageType.PUBLISH;
     }
 
+    @NotNull Mqtt5PublishBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5PublishBuilder.java
@@ -31,6 +31,8 @@ public interface Mqtt5PublishBuilder extends
             Mqtt5PublishBuilder.Complete> {
 // @formatter:off
 
+    @NotNull Mqtt5WillPublishBuilder asWill();
+
     // @formatter:off
     @DoNotImplement
     interface Complete extends
@@ -39,6 +41,9 @@ public interface Mqtt5PublishBuilder extends
                 Mqtt5PublishBuilder,
                 Mqtt5PublishBuilder.Complete> {
     // @formatter:off
+
+        @Override
+        @NotNull Mqtt5WillPublishBuilder.Complete asWill();
 
         @NotNull Mqtt5Publish build();
     }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/publish/Mqtt5WillPublish.java
@@ -38,13 +38,10 @@ public interface Mqtt5WillPublish extends Mqtt5Publish {
         return new MqttPublishBuilder.WillDefault();
     }
 
-    static @NotNull Mqtt5WillPublishBuilder.Complete extend(@NotNull final Mqtt5Publish publish) {
-        return new MqttPublishBuilder.WillDefault(publish);
-    }
-
     /**
      * @return the delay of this Will Publish. The default is {@link #DEFAULT_DELAY_INTERVAL}.
      */
     long getDelayInterval();
 
+    @NotNull Mqtt5WillPublishBuilder.Complete extendAsWill();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
@@ -39,10 +39,6 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
         return new MqttSubscribeBuilder.Default();
     }
 
-    static @NotNull Mqtt5SubscribeBuilder.Complete extend(final @NotNull Mqtt5Subscribe subscribe) {
-        return new MqttSubscribeBuilder.Default(subscribe);
-    }
-
     /**
      * @return the {@link Mqtt5Subscription}s of this SUBSCRIBE packet. The list contains at least one subscription.
      */
@@ -57,4 +53,6 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
     default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.SUBSCRIBE;
     }
+
+    @NotNull Mqtt5SubscribeBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/Mqtt5Subscribe.java
@@ -17,13 +17,15 @@
 
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribeBuilder;
+
+import java.util.List;
 
 /**
  * MQTT 5 SUBSCRIBE packet.
@@ -44,7 +46,7 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
     /**
      * @return the {@link Mqtt5Subscription}s of this SUBSCRIBE packet. The list contains at least one subscription.
      */
-    @NotNull ImmutableList<? extends Mqtt5Subscription> getSubscriptions();
+    @Immutable @NotNull List<@NotNull ? extends Mqtt5Subscription> getSubscriptions();
 
     /**
      * @return the optional user properties of this SUBSCRIBE packet.
@@ -55,5 +57,4 @@ public interface Mqtt5Subscribe extends Mqtt5Message {
     default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.SUBSCRIBE;
     }
-
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/suback/Mqtt5SubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/subscribe/suback/Mqtt5SubAck.java
@@ -17,15 +17,16 @@
 
 package org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback;
 
-import com.google.common.collect.ImmutableList;
-import org.mqttbee.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5SubscribeResult;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -38,27 +39,22 @@ public interface Mqtt5SubAck extends Mqtt5Message, Mqtt5SubscribeResult {
 
     /**
      * @return the reason codes of this SUBACK packet, each belonging to a subscription in the corresponding SUBSCRIBE
-     * packet in the same order.
+     *         packet in the same order.
      */
-    @NotNull
-    ImmutableList<Mqtt5SubAckReasonCode> getReasonCodes();
+    @Immutable @NotNull List<@NotNull Mqtt5SubAckReasonCode> getReasonCodes();
 
     /**
      * @return the optional reason string of this SUBACK packet.
      */
-    @NotNull
-    Optional<MqttUtf8String> getReasonString();
+    @NotNull Optional<MqttUtf8String> getReasonString();
 
     /**
      * @return the optional user properties of this SUBACK packet.
      */
-    @NotNull
-    Mqtt5UserProperties getUserProperties();
+    @NotNull Mqtt5UserProperties getUserProperties();
 
-    @NotNull
     @Override
-    default Mqtt5MessageType getType() {
+    default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.SUBACK;
     }
-
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
@@ -17,14 +17,16 @@
 
 package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribeBuilder;
+
+import java.util.List;
 
 /**
  * MQTT 5 UNSUBSCRIBE packet.
@@ -45,7 +47,7 @@ public interface Mqtt5Unsubscribe extends Mqtt5Message {
     /**
      * @return the Topic Filters of this UNSUBSCRIBE packet. The list contains at least one Topic Filter.
      */
-    @NotNull ImmutableList<? extends MqttTopicFilter> getTopicFilters();
+    @Immutable @NotNull List<@NotNull ? extends MqttTopicFilter> getTopicFilters();
 
     /**
      * @return the optional user properties of this UNSUBSCRIBE packet.
@@ -56,5 +58,4 @@ public interface Mqtt5Unsubscribe extends Mqtt5Message {
     default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.UNSUBSCRIBE;
     }
-
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/Mqtt5Unsubscribe.java
@@ -40,10 +40,6 @@ public interface Mqtt5Unsubscribe extends Mqtt5Message {
         return new MqttUnsubscribeBuilder.Default();
     }
 
-    static @NotNull Mqtt5UnsubscribeBuilder.Complete extend(final @NotNull Mqtt5Unsubscribe unsubscribe) {
-        return new MqttUnsubscribeBuilder.Default(unsubscribe);
-    }
-
     /**
      * @return the Topic Filters of this UNSUBSCRIBE packet. The list contains at least one Topic Filter.
      */
@@ -58,4 +54,6 @@ public interface Mqtt5Unsubscribe extends Mqtt5Message {
     default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.UNSUBSCRIBE;
     }
+
+    @NotNull Mqtt5UnsubscribeBuilder.Complete extend();
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/unsuback/Mqtt5UnsubAck.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/unsubscribe/unsuback/Mqtt5UnsubAck.java
@@ -17,14 +17,15 @@
 
 package org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback;
 
-import com.google.common.collect.ImmutableList;
-import org.mqttbee.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.DoNotImplement;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5Message;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -37,27 +38,22 @@ public interface Mqtt5UnsubAck extends Mqtt5Message {
 
     /**
      * @return the reason codes of this UNSUBACK packet, each belonging to a topic filter in the corresponding
-     * UNSUBSCRIBE packet in the same order.
+     *         UNSUBSCRIBE packet in the same order.
      */
-    @NotNull
-    ImmutableList<Mqtt5UnsubAckReasonCode> getReasonCodes();
+    @Immutable @NotNull List<@NotNull Mqtt5UnsubAckReasonCode> getReasonCodes();
 
     /**
      * @return the optional reason string of this UNSUBACK packet.
      */
-    @NotNull
-    Optional<MqttUtf8String> getReasonString();
+    @NotNull Optional<MqttUtf8String> getReasonString();
 
     /**
      * @return the optional user properties of this UNSUBACK packet.
      */
-    @NotNull
-    Mqtt5UserProperties getUserProperties();
+    @NotNull Mqtt5UserProperties getUserProperties();
 
-    @NotNull
     @Override
-    default Mqtt5MessageType getType() {
+    default @NotNull Mqtt5MessageType getType() {
         return Mqtt5MessageType.UNSUBACK;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/MqttClientSslConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientSslConfigImpl.java
@@ -23,6 +23,7 @@ import org.mqttbee.api.mqtt.MqttClientSslConfig;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -42,8 +43,9 @@ public class MqttClientSslConfigImpl implements MqttClientSslConfig {
 
     MqttClientSslConfigImpl(
             final @Nullable KeyManagerFactory keyManagerFactory,
-            final @Nullable TrustManagerFactory trustManagerFactory, final @Nullable ImmutableList<String> cipherSuites,
-            final @Nullable ImmutableList<String> protocols, final long handshakeTimeoutMs) {
+            final @Nullable TrustManagerFactory trustManagerFactory,
+            final @Nullable ImmutableList<@NotNull String> cipherSuites,
+            final @Nullable ImmutableList<@NotNull String> protocols, final long handshakeTimeoutMs) {
 
         this.keyManagerFactory = keyManagerFactory;
         this.trustManagerFactory = trustManagerFactory;
@@ -71,20 +73,20 @@ public class MqttClientSslConfigImpl implements MqttClientSslConfig {
     }
 
     @Override
-    public @NotNull Optional<ImmutableList<String>> getCipherSuites() {
+    public @NotNull Optional<List<@NotNull String>> getCipherSuites() {
         return Optional.ofNullable(cipherSuites);
     }
 
-    public @Nullable ImmutableList<String> getRawCipherSuites() {
+    public @Nullable ImmutableList<@NotNull String> getRawCipherSuites() {
         return cipherSuites;
     }
 
     @Override
-    public @NotNull Optional<ImmutableList<String>> getProtocols() {
+    public @NotNull Optional<List<@NotNull String>> getProtocols() {
         return Optional.ofNullable(protocols);
     }
 
-    public @Nullable ImmutableList<String> getRawProtocols() {
+    public @Nullable ImmutableList<@NotNull String> getRawProtocols() {
         return protocols;
     }
 
@@ -92,5 +94,4 @@ public class MqttClientSslConfigImpl implements MqttClientSslConfig {
     public long getHandshakeTimeoutMs() {
         return handshakeTimeoutMs;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/MqttClientSslConfigImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientSslConfigImpl.java
@@ -16,10 +16,10 @@
 
 package org.mqttbee.mqtt;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -43,9 +43,8 @@ public class MqttClientSslConfigImpl implements MqttClientSslConfig {
 
     MqttClientSslConfigImpl(
             final @Nullable KeyManagerFactory keyManagerFactory,
-            final @Nullable TrustManagerFactory trustManagerFactory,
-            final @Nullable ImmutableList<@NotNull String> cipherSuites,
-            final @Nullable ImmutableList<@NotNull String> protocols, final long handshakeTimeoutMs) {
+            final @Nullable TrustManagerFactory trustManagerFactory, final @Nullable ImmutableList<String> cipherSuites,
+            final @Nullable ImmutableList<String> protocols, final long handshakeTimeoutMs) {
 
         this.keyManagerFactory = keyManagerFactory;
         this.trustManagerFactory = trustManagerFactory;
@@ -73,20 +72,20 @@ public class MqttClientSslConfigImpl implements MqttClientSslConfig {
     }
 
     @Override
-    public @NotNull Optional<List<@NotNull String>> getCipherSuites() {
+    public @NotNull Optional<List<String>> getCipherSuites() {
         return Optional.ofNullable(cipherSuites);
     }
 
-    public @Nullable ImmutableList<@NotNull String> getRawCipherSuites() {
+    public @Nullable ImmutableList<String> getRawCipherSuites() {
         return cipherSuites;
     }
 
     @Override
-    public @NotNull Optional<List<@NotNull String>> getProtocols() {
+    public @NotNull Optional<List<String>> getProtocols() {
         return Optional.ofNullable(protocols);
     }
 
-    public @Nullable ImmutableList<@NotNull String> getRawProtocols() {
+    public @Nullable ImmutableList<String> getRawProtocols() {
         return protocols;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/MqttClientSslConfigImplBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/MqttClientSslConfigImplBuilder.java
@@ -17,12 +17,12 @@
 
 package org.mqttbee.mqtt;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.MqttClientSslConfig;
 import org.mqttbee.api.mqtt.MqttClientSslConfigBuilder;
 import org.mqttbee.util.Checks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -37,8 +37,8 @@ public abstract class MqttClientSslConfigImplBuilder<B extends MqttClientSslConf
 
     private @Nullable KeyManagerFactory keyManagerFactory;
     private @Nullable TrustManagerFactory trustManagerFactory;
-    private @Nullable ImmutableList<@NotNull String> cipherSuites;
-    private @Nullable ImmutableList<@NotNull String> protocols;
+    private @Nullable ImmutableList<String> cipherSuites;
+    private @Nullable ImmutableList<String> protocols;
     private long handshakeTimeoutMs = MqttClientSslConfig.DEFAULT_HANDSHAKE_TIMEOUT_MS;
 
     abstract @NotNull B self();
@@ -53,15 +53,13 @@ public abstract class MqttClientSslConfigImplBuilder<B extends MqttClientSslConf
         return self();
     }
 
-    public @NotNull B cipherSuites(final @Nullable List<String> cipherSuites) {
-        Checks.elementsNotNull(cipherSuites, "Cipher suites");
-        this.cipherSuites = (cipherSuites == null) ? null : ImmutableList.copyOf(cipherSuites);
+    public @NotNull B cipherSuites(final @Nullable List<@NotNull String> cipherSuites) {
+        this.cipherSuites = (cipherSuites == null) ? null : ImmutableList.copyOf(cipherSuites, "Cipher suites");
         return self();
     }
 
-    public @NotNull B protocols(final @Nullable List<String> protocols) {
-        Checks.elementsNotNull(protocols, "Protocols");
-        this.protocols = (protocols == null) ? null : ImmutableList.copyOf(protocols);
+    public @NotNull B protocols(final @Nullable List<@NotNull String> protocols) {
+        this.protocols = (protocols == null) ? null : ImmutableList.copyOf(protocols, "Protocols");
         return self();
     }
 

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3SubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt3/Mqtt3SubAckDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAckReturnCode;
@@ -26,6 +25,7 @@ import org.mqttbee.mqtt.codec.decoder.MqttDecoderException;
 import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoder;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
 import org.mqttbee.mqtt.message.subscribe.suback.mqtt3.Mqtt3SubAckView;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -45,8 +45,7 @@ public class Mqtt3SubAckDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 3; // 2 for the packetId + 1 for at least one Subscription
 
     @Inject
-    Mqtt3SubAckDecoder() {
-    }
+    Mqtt3SubAckDecoder() {}
 
     @Override
     public @NotNull MqttSubAck decode(
@@ -73,5 +72,4 @@ public class Mqtt3SubAckDecoder implements MqttMessageDecoder {
 
         return Mqtt3SubAckView.delegate(packetIdentifier, returnCodesBuilder.build());
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5AuthReasonCode;
@@ -29,6 +28,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.auth.MqttAuth;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,8 +49,7 @@ public class Mqtt5AuthDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 2; // reason code (1) + property length (min 1)
 
     @Inject
-    Mqtt5AuthDecoder() {
-    }
+    Mqtt5AuthDecoder() {}
 
     @Override
     public @NotNull MqttAuth decode(
@@ -109,5 +108,4 @@ public class Mqtt5AuthDecoder implements MqttMessageDecoder {
 
         return new MqttAuth(reasonCode, method, data, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
@@ -30,6 +29,7 @@ import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.auth.MqttEnhancedAuth;
 import org.mqttbee.mqtt.message.connect.connack.MqttConnAck;
 import org.mqttbee.mqtt.message.connect.connack.MqttConnAckRestrictions;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -52,8 +52,7 @@ public class Mqtt5ConnAckDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 3;
 
     @Inject
-    Mqtt5ConnAckDecoder() {
-    }
+    Mqtt5ConnAckDecoder() {}
 
     @Override
     public @NotNull MqttConnAck decode(

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.disconnect.MqttDisconnect;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -47,8 +47,7 @@ public class Mqtt5DisconnectDecoder implements MqttMessageDecoder {
     private static final int FLAGS = 0b0000;
 
     @Inject
-    Mqtt5DisconnectDecoder() {
-    }
+    Mqtt5DisconnectDecoder() {}
 
     @Override
     public @NotNull MqttDisconnect decode(
@@ -103,5 +102,4 @@ public class Mqtt5DisconnectDecoder implements MqttMessageDecoder {
 
         return new MqttDisconnect(reasonCode, sessionExpiryInterval, serverReference, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5MessageDecoderUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5MessageDecoderUtil.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttBinaryData;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.publish.puback.MqttPubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,8 +49,7 @@ public class Mqtt5PubAckDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 2;
 
     @Inject
-    Mqtt5PubAckDecoder() {
-    }
+    Mqtt5PubAckDecoder() {}
 
     @Override
     public @NotNull MqttPubAck decode(
@@ -101,5 +100,4 @@ public class Mqtt5PubAckDecoder implements MqttMessageDecoder {
 
         return new MqttPubAck(packetIdentifier, reasonCode, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp.Mqtt5PubCompReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.publish.pubcomp.MqttPubComp;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,8 +49,7 @@ public class Mqtt5PubCompDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 2;
 
     @Inject
-    Mqtt5PubCompDecoder() {
-    }
+    Mqtt5PubCompDecoder() {}
 
     @Override
     public @NotNull MqttPubComp decode(
@@ -101,5 +100,4 @@ public class Mqtt5PubCompDecoder implements MqttMessageDecoder {
 
         return new MqttPubComp(packetIdentifier, reasonCode, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRecReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,8 +49,7 @@ public class Mqtt5PubRecDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 2;
 
     @Inject
-    Mqtt5PubRecDecoder() {
-    }
+    Mqtt5PubRecDecoder() {}
 
     @Override
     public @NotNull MqttPubRec decode(
@@ -101,5 +100,4 @@ public class Mqtt5PubRecDecoder implements MqttMessageDecoder {
 
         return new MqttPubRec(packetIdentifier, reasonCode, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRelReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -49,8 +49,7 @@ public class Mqtt5PubRelDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 2;
 
     @Inject
-    Mqtt5PubRelDecoder() {
-    }
+    Mqtt5PubRelDecoder() {}
 
     @Override
     public @NotNull MqttPubRel decode(
@@ -101,5 +100,4 @@ public class Mqtt5PubRelDecoder implements MqttMessageDecoder {
 
         return new MqttPubRel(packetIdentifier, reasonCode, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
@@ -18,7 +18,6 @@
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.base.Utf8;
-import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.collections.ImmutableIntList;
 import org.mqttbee.util.collections.ImmutableList;
 import org.mqttbee.util.collections.IntMap;
 
@@ -94,7 +94,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
         ImmutableList.Builder<MqttUserPropertyImpl> userPropertiesBuilder = null;
         int topicAlias = DEFAULT_NO_TOPIC_ALIAS;
         TopicAliasUsage topicAliasUsage = TopicAliasUsage.NO;
-        ImmutableIntArray.Builder subscriptionIdentifiersBuilder = null;
+        ImmutableIntList.Builder subscriptionIdentifiersBuilder = null;
 
         final int propertiesStartIndex = in.readerIndex();
         int readPropertyLength;
@@ -104,8 +104,9 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
 
             switch (propertyIdentifier) {
                 case MESSAGE_EXPIRY_INTERVAL:
-                    messageExpiryInterval = unsignedIntOnlyOnce(messageExpiryInterval, NO_MESSAGE_EXPIRY,
-                            "message expiry interval", in);
+                    messageExpiryInterval =
+                            unsignedIntOnlyOnce(messageExpiryInterval, NO_MESSAGE_EXPIRY, "message expiry interval",
+                                    in);
                     break;
 
                 case PAYLOAD_FORMAT_INDICATOR:
@@ -152,7 +153,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
 
                 case SUBSCRIPTION_IDENTIFIER:
                     if (subscriptionIdentifiersBuilder == null) {
-                        subscriptionIdentifiersBuilder = ImmutableIntArray.builder();
+                        subscriptionIdentifiersBuilder = ImmutableIntList.builder();
                     }
                     final int subscriptionIdentifier = MqttVariableByteInteger.decode(in);
                     if (subscriptionIdentifier < 0) {
@@ -219,7 +220,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
                 new MqttPublish(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator, contentType,
                         responseTopic, correlationData, topicAliasUsage, userProperties);
 
-        final ImmutableIntArray subscriptionIdentifiers =
+        final ImmutableIntList subscriptionIdentifiers =
                 (subscriptionIdentifiersBuilder == null) ? DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS :
                         subscriptionIdentifiersBuilder.build();
 

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoder.java
@@ -18,7 +18,6 @@
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
 import com.google.common.base.Utf8;
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +32,7 @@ import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.collections.ImmutableList;
 import org.mqttbee.util.collections.IntMap;
 
 import javax.inject.Inject;
@@ -55,8 +55,7 @@ public class Mqtt5PublishDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 3; // topic name (min 2) + property length (min 1)
 
     @Inject
-    Mqtt5PublishDecoder() {
-    }
+    Mqtt5PublishDecoder() {}
 
     @Override
     public @NotNull MqttStatefulPublish decode(

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -48,8 +48,7 @@ public class Mqtt5SubAckDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 3;
 
     @Inject
-    Mqtt5SubAckDecoder() {
-    }
+    Mqtt5SubAckDecoder() {}
 
     @Override
     public @NotNull MqttSubAck decode(
@@ -98,8 +97,7 @@ public class Mqtt5SubAckDecoder implements MqttMessageDecoder {
             throw noReasonCodes();
         }
 
-        final ImmutableList.Builder<Mqtt5SubAckReasonCode> reasonCodesBuilder =
-                ImmutableList.builderWithExpectedSize(reasonCodeCount);
+        final ImmutableList.Builder<Mqtt5SubAckReasonCode> reasonCodesBuilder = ImmutableList.builder(reasonCodeCount);
         for (int i = 0; i < reasonCodeCount; i++) {
             final Mqtt5SubAckReasonCode reasonCode = Mqtt5SubAckReasonCode.fromCode(in.readUnsignedByte());
             if (reasonCode == null) {
@@ -113,5 +111,4 @@ public class Mqtt5SubAckDecoder implements MqttMessageDecoder {
 
         return new MqttSubAck(packetIdentifier, reasonCodes, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReasonCode;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.unsubscribe.unsuback.MqttUnsubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -48,8 +48,7 @@ public class Mqtt5UnsubAckDecoder implements MqttMessageDecoder {
     private static final int MIN_REMAINING_LENGTH = 3;
 
     @Inject
-    Mqtt5UnsubAckDecoder() {
-    }
+    Mqtt5UnsubAckDecoder() {}
 
     @Override
     public @NotNull MqttUnsubAck decode(
@@ -99,7 +98,7 @@ public class Mqtt5UnsubAckDecoder implements MqttMessageDecoder {
         }
 
         final ImmutableList.Builder<Mqtt5UnsubAckReasonCode> reasonCodesBuilder =
-                ImmutableList.builderWithExpectedSize(reasonCodeCount);
+                ImmutableList.builder(reasonCodeCount);
         for (int i = 0; i < reasonCodeCount; i++) {
             final Mqtt5UnsubAckReasonCode reasonCode = Mqtt5UnsubAckReasonCode.fromCode(in.readUnsignedByte());
             if (reasonCode == null) {
@@ -113,5 +112,4 @@ public class Mqtt5UnsubAckDecoder implements MqttMessageDecoder {
 
         return new MqttUnsubAck(packetIdentifier, reasonCodes, reasonString, userProperties);
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3SubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3SubscribeEncoder.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.subscribe.MqttStatefulSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -38,42 +38,40 @@ public class Mqtt3SubscribeEncoder extends Mqtt3MessageEncoder<MqttStatefulSubsc
     private static final int VARIABLE_HEADER_FIXED_LENGTH = 2; // packet identifier
 
     @Inject
-    Mqtt3SubscribeEncoder() {
-    }
+    Mqtt3SubscribeEncoder() {}
 
     @Override
-    int remainingLength(@NotNull final MqttStatefulSubscribe message) {
+    int remainingLength(final @NotNull MqttStatefulSubscribe message) {
         int remainingLength = VARIABLE_HEADER_FIXED_LENGTH;
 
         final ImmutableList<MqttSubscription> subscriptions = message.stateless().getSubscriptions();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
-            final MqttSubscription subscription = subscriptions.get(i);
-            remainingLength += subscription.getTopicFilter().encodedLength() + 1; // QoS
+            remainingLength += subscriptions.get(i).getTopicFilter().encodedLength() + 1; // QoS
         }
 
         return remainingLength;
     }
 
     @Override
-    void encode(
-            @NotNull final MqttStatefulSubscribe message, @NotNull final ByteBuf out, final int remainingLength) {
-
+    void encode(final @NotNull MqttStatefulSubscribe message, final @NotNull ByteBuf out, final int remainingLength) {
         encodeFixedHeader(out, remainingLength);
         encodeVariableHeader(message, out);
         encodePayload(message, out);
     }
 
-    private void encodeFixedHeader(@NotNull final ByteBuf out, final int remainingLength) {
+    private void encodeFixedHeader(final @NotNull ByteBuf out, final int remainingLength) {
         out.writeByte(FIXED_HEADER);
         MqttVariableByteInteger.encode(remainingLength, out);
     }
 
-    private void encodeVariableHeader(@NotNull final MqttStatefulSubscribe message, @NotNull final ByteBuf out) {
+    private void encodeVariableHeader(final @NotNull MqttStatefulSubscribe message, final @NotNull ByteBuf out) {
         out.writeShort(message.getPacketIdentifier());
     }
 
-    private void encodePayload(@NotNull final MqttStatefulSubscribe message, @NotNull final ByteBuf out) {
+    private void encodePayload(final @NotNull MqttStatefulSubscribe message, final @NotNull ByteBuf out) {
         final ImmutableList<MqttSubscription> subscriptions = message.stateless().getSubscriptions();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
             final MqttSubscription subscription = subscriptions.get(i);
             subscription.getTopicFilter().encode(out);

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3UnsubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt3/Mqtt3UnsubscribeEncoder.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt3.message.Mqtt3MessageType;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.unsubscribe.MqttStatefulUnsubscribe;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -38,14 +38,14 @@ public class Mqtt3UnsubscribeEncoder extends Mqtt3MessageEncoder<MqttStatefulUns
     private static final int VARIABLE_HEADER_FIXED_LENGTH = 2; // packet identifier
 
     @Inject
-    Mqtt3UnsubscribeEncoder() {
-    }
+    Mqtt3UnsubscribeEncoder() {}
 
     @Override
-    int remainingLength(@NotNull final MqttStatefulUnsubscribe message) {
+    int remainingLength(final @NotNull MqttStatefulUnsubscribe message) {
         int remainingLength = VARIABLE_HEADER_FIXED_LENGTH;
 
         final ImmutableList<MqttTopicFilterImpl> subscriptions = message.stateless().getTopicFilters();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
             remainingLength += subscriptions.get(i).encodedLength();
         }
@@ -54,25 +54,24 @@ public class Mqtt3UnsubscribeEncoder extends Mqtt3MessageEncoder<MqttStatefulUns
     }
 
     @Override
-    void encode(
-            @NotNull final MqttStatefulUnsubscribe message, @NotNull final ByteBuf out, final int remainingLength) {
-
+    void encode(final @NotNull MqttStatefulUnsubscribe message, final @NotNull ByteBuf out, final int remainingLength) {
         encodeFixedHeader(out, remainingLength);
         encodeVariableHeader(message, out);
         encodePayload(message, out);
     }
 
-    private void encodeFixedHeader(@NotNull final ByteBuf out, final int remainingLength) {
+    private void encodeFixedHeader(final @NotNull ByteBuf out, final int remainingLength) {
         out.writeByte(FIXED_HEADER);
         MqttVariableByteInteger.encode(remainingLength, out);
     }
 
-    private void encodeVariableHeader(@NotNull final MqttStatefulUnsubscribe message, @NotNull final ByteBuf out) {
+    private void encodeVariableHeader(final @NotNull MqttStatefulUnsubscribe message, final @NotNull ByteBuf out) {
         out.writeShort(message.getPacketIdentifier());
     }
 
-    private void encodePayload(@NotNull final MqttStatefulUnsubscribe message, @NotNull final ByteBuf out) {
+    private void encodePayload(final @NotNull MqttStatefulUnsubscribe message, final @NotNull ByteBuf out) {
         final ImmutableList<MqttTopicFilterImpl> subscriptions = message.stateless().getTopicFilters();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
             subscriptions.get(i).encode(out);
         }

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -28,6 +27,7 @@ import org.mqttbee.mqtt.datatypes.MqttBinaryData;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
+import org.mqttbee.util.collections.ImmutableIntList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -82,8 +82,8 @@ public class Mqtt5PublishEncoder extends Mqtt5MessageWithUserPropertiesEncoder<M
 
         propertyLength += shortPropertyEncodedLength(message.getTopicAlias(), DEFAULT_NO_TOPIC_ALIAS);
 
-        final ImmutableIntArray subscriptionIdentifiers = message.getSubscriptionIdentifiers();
-        for (int i = 0; i < subscriptionIdentifiers.length(); i++) {
+        final ImmutableIntList subscriptionIdentifiers = message.getSubscriptionIdentifiers();
+        for (int i = 0; i < subscriptionIdentifiers.size(); i++) {
             propertyLength += variableByteIntegerPropertyEncodedLength(subscriptionIdentifiers.get(i));
         }
 
@@ -178,8 +178,8 @@ public class Mqtt5PublishEncoder extends Mqtt5MessageWithUserPropertiesEncoder<M
 
         encodeShortProperty(TOPIC_ALIAS, message.getTopicAlias(), DEFAULT_NO_TOPIC_ALIAS, out);
 
-        final ImmutableIntArray subscriptionIdentifiers = message.getSubscriptionIdentifiers();
-        for (int i = 0; i < subscriptionIdentifiers.length(); i++) {
+        final ImmutableIntList subscriptionIdentifiers = message.getSubscriptionIdentifiers();
+        for (int i = 0; i < subscriptionIdentifiers.size(); i++) {
             encodeVariableByteIntegerProperty(SUBSCRIPTION_IDENTIFIER, subscriptionIdentifiers.get(i), out);
         }
     }

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoder.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.subscribe.MqttStatefulSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -50,6 +50,7 @@ public class Mqtt5SubscribeEncoder extends Mqtt5MessageWithUserPropertiesEncoder
         int remainingLength = VARIABLE_HEADER_FIXED_LENGTH;
 
         final ImmutableList<MqttSubscription> subscriptions = message.stateless().getSubscriptions();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
             remainingLength += subscriptions.get(i).getTopicFilter().encodedLength() + 1;
         }
@@ -103,6 +104,7 @@ public class Mqtt5SubscribeEncoder extends Mqtt5MessageWithUserPropertiesEncoder
 
     private void encodePayload(final @NotNull MqttStatefulSubscribe message, final @NotNull ByteBuf out) {
         final ImmutableList<MqttSubscription> subscriptions = message.stateless().getSubscriptions();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
             final MqttSubscription subscription = subscriptions.get(i);
 

--- a/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoder.java
+++ b/src/main/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoder.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5MessageType;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.unsubscribe.MqttStatefulUnsubscribe;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -45,6 +45,7 @@ public class Mqtt5UnsubscribeEncoder extends Mqtt5MessageWithUserPropertiesEncod
         int remainingLength = VARIABLE_HEADER_FIXED_LENGTH;
 
         final ImmutableList<MqttTopicFilterImpl> topicFilters = message.stateless().getTopicFilters();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < topicFilters.size(); i++) {
             remainingLength += topicFilters.get(i).encodedLength();
         }
@@ -90,6 +91,7 @@ public class Mqtt5UnsubscribeEncoder extends Mqtt5MessageWithUserPropertiesEncod
 
     private void encodePayload(final @NotNull MqttStatefulUnsubscribe message, final @NotNull ByteBuf out) {
         final ImmutableList<MqttTopicFilterImpl> topicFilters = message.stateless().getTopicFilters();
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < topicFilters.size(); i++) {
             topicFilters.get(i).encode(out);
         }

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttClientIdentifierImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttClientIdentifierImpl.java
@@ -21,10 +21,9 @@ import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.util.Checks;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
@@ -20,11 +20,10 @@ package org.mqttbee.mqtt.datatypes;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttSharedTopicFilter;
 import org.mqttbee.util.ByteArrayUtil;
 import org.mqttbee.util.Checks;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
@@ -275,4 +275,9 @@ public class MqttSharedTopicFilterImpl extends MqttTopicFilterImpl implements Mq
         }
         return filterCharStart;
     }
+
+    @Override
+    public @NotNull MqttTopicFilterImplBuilder.SharedDefault extendShared() {
+        return new MqttTopicFilterImplBuilder.SharedDefault(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImpl.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -240,11 +239,6 @@ public class MqttSharedTopicFilterImpl extends MqttTopicFilterImpl implements Mq
         super(string, wildcardFlags);
         filterByteStart = -1;
         this.filterCharStart = shareNameCharEnd + 1;
-    }
-
-    @Override
-    public @NotNull ImmutableList<String> getLevels() {
-        return MqttTopicImpl.splitLevels(getTopicFilterString());
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.annotations.Immutable;
-import org.mqttbee.api.mqtt.datatypes.MqttSharedTopicFilter;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.mqtt.util.MqttChecks;
@@ -275,7 +274,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
     }
 
     @Override
-    public @NotNull MqttSharedTopicFilter share(final @Nullable String shareName) {
+    public @NotNull MqttSharedTopicFilterImpl share(final @Nullable String shareName) {
         return MqttSharedTopicFilterImpl.of(shareName, this);
     }
 
@@ -305,7 +304,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
                 return true;
             } else if (fb == SINGLE_LEVEL_WILDCARD) {
                 while (ti < topic.length) { // loop until next topic level separator or end
-                    if (topic[ti] == MqttTopic.TOPIC_LEVEL_SEPARATOR) {
+                    if (topic[ti] == MqttTopicImpl.TOPIC_LEVEL_SEPARATOR) {
                         break;
                     }
                     ti++; // only increment when not topic level separator
@@ -313,7 +312,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
             } else {
                 if (ti == topic.length) {
                     // lookahead for "/#" as it includes the parent level
-                    return (fb == MqttTopic.TOPIC_LEVEL_SEPARATOR) && (fi + 1 == filter.length) &&
+                    return (fb == MqttTopicImpl.TOPIC_LEVEL_SEPARATOR) && (fi + 1 == filter.length) &&
                             (filter[fi] == MULTI_LEVEL_WILDCARD);
                 }
                 if (topic[ti++] != fb) {
@@ -347,7 +346,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
                     return false;
                 }
                 while (i2 < filter2.length) { // loop until next topic level separator or end
-                    if (filter2[i2] == MqttTopic.TOPIC_LEVEL_SEPARATOR) {
+                    if (filter2[i2] == MqttTopicImpl.TOPIC_LEVEL_SEPARATOR) {
                         break;
                     }
                     i2++; // only increment when not topic level separator
@@ -355,7 +354,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
             } else {
                 if (i2 == filter2.length) {
                     // lookahead for "/#" as it includes the parent level
-                    return (b1 == MqttTopic.TOPIC_LEVEL_SEPARATOR) && (i1 + 1 == filter1.length) &&
+                    return (b1 == MqttTopicImpl.TOPIC_LEVEL_SEPARATOR) && (i1 + 1 == filter1.length) &&
                             (filter1[i1] == MULTI_LEVEL_WILDCARD);
                 }
                 if (filter2[i2++] != b1) {
@@ -364,5 +363,10 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
             }
         }
         return (i1 == filter1.length) && (i2 == filter2.length);
+    }
+
+    @Override
+    public @NotNull MqttTopicFilterImplBuilder.Default extend() {
+        return new MqttTopicFilterImplBuilder.Default(this);
     }
 }

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
@@ -22,13 +22,12 @@ import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttSharedTopicFilter;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
@@ -251,8 +251,8 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
     }
 
     @Override
-    public @NotNull ImmutableList<String> getLevels() {
-        return MqttTopicImpl.splitLevels(toString());
+    public @NotNull ImmutableList<@NotNull String> getLevels() {
+        return MqttTopicImpl.splitLevels(getTopicFilterString());
     }
 
     @Override

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImpl.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +27,7 @@ import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -250,7 +250,7 @@ public class MqttTopicFilterImpl extends MqttUtf8StringImpl implements MqttTopic
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull String> getLevels() {
+    public @NotNull ImmutableList<String> getLevels() {
         return MqttTopicImpl.splitLevels(getTopicFilterString());
     }
 

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImplBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImplBuilder.java
@@ -19,8 +19,8 @@ package org.mqttbee.mqtt.datatypes;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.*;
-import org.mqttbee.mqtt.util.MqttChecks;
+import org.mqttbee.api.mqtt.datatypes.MqttSharedTopicFilterBuilder;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicFilterBuilder;
 import org.mqttbee.util.Checks;
 
 import java.util.function.Function;
@@ -49,7 +49,7 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
         if (stringBuilder == null) {
             stringBuilder = new StringBuilder(topicLevel);
         } else {
-            stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(topicLevel);
+            stringBuilder.append(MqttTopicImpl.TOPIC_LEVEL_SEPARATOR).append(topicLevel);
         }
         return self();
     }
@@ -58,9 +58,9 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
         if (stringBuilder == null) {
             stringBuilder = new StringBuilder();
         } else {
-            stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR);
+            stringBuilder.append(MqttTopicImpl.TOPIC_LEVEL_SEPARATOR);
         }
-        stringBuilder.append(MqttTopicFilter.SINGLE_LEVEL_WILDCARD);
+        stringBuilder.append(MqttTopicFilterImpl.SINGLE_LEVEL_WILDCARD);
         return self();
     }
 
@@ -68,9 +68,9 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
         if (stringBuilder == null) {
             stringBuilder = new StringBuilder(1);
         } else {
-            stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR);
+            stringBuilder.append(MqttTopicImpl.TOPIC_LEVEL_SEPARATOR);
         }
-        stringBuilder.append(MqttTopicFilter.MULTI_LEVEL_WILDCARD);
+        stringBuilder.append(MqttTopicFilterImpl.MULTI_LEVEL_WILDCARD);
         return self();
     }
 
@@ -102,8 +102,8 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
             super(baseTopicFilter);
         }
 
-        public Default(final @Nullable MqttTopicFilter topicFilter) {
-            super(MqttChecks.topicFilter(topicFilter));
+        Default(final @NotNull MqttTopicFilterImpl topicFilter) {
+            super(topicFilter);
         }
 
         @Override
@@ -113,11 +113,11 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
 
         @NotNull
         @Override
-        public MqttTopicFilterImplBuilder.SharedDefault share(final @Nullable String shareName) {
+        public SharedDefault share(final @Nullable String shareName) {
             if (stringBuilder == null) {
-                return new MqttTopicFilterImplBuilder.SharedDefault(shareName);
+                return new SharedDefault(shareName);
             }
-            return new MqttTopicFilterImplBuilder.SharedDefault(shareName, stringBuilder.toString());
+            return new SharedDefault(shareName, stringBuilder.toString());
         }
     }
 
@@ -134,11 +134,11 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
             return this;
         }
 
-        public @NotNull MqttTopicFilterImplBuilder.SharedNested<P> share(final @Nullable String shareName) {
+        public @NotNull SharedNested<P> share(final @Nullable String shareName) {
             if (stringBuilder == null) {
-                return new MqttTopicFilterImplBuilder.SharedNested<>(shareName, parentConsumer);
+                return new SharedNested<>(shareName, parentConsumer);
             }
-            return new MqttTopicFilterImplBuilder.SharedNested<>(shareName, stringBuilder.toString(), parentConsumer);
+            return new SharedNested<>(shareName, stringBuilder.toString(), parentConsumer);
         }
 
         @Override
@@ -189,8 +189,8 @@ public abstract class MqttTopicFilterImplBuilder<B extends MqttTopicFilterImplBu
             super(shareName, baseTopicFilter);
         }
 
-        public SharedDefault(final @Nullable MqttSharedTopicFilter sharedTopicFilter) {
-            super(MqttChecks.sharedTopicFilter(sharedTopicFilter));
+        SharedDefault(final @NotNull MqttSharedTopicFilterImpl sharedTopicFilter) {
+            super(sharedTopicFilter);
         }
 
         @Override

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
@@ -156,7 +156,7 @@ public class MqttTopicImpl extends MqttUtf8StringImpl implements MqttTopic {
      * @param string the Topic Name string.
      * @return the levels of the Topic Name string.
      */
-    static @NotNull ImmutableList<String> splitLevels(final @NotNull String string) {
+    static @NotNull ImmutableList<@NotNull String> splitLevels(final @NotNull String string) {
         final ImmutableList.Builder<String> levelsBuilder = ImmutableList.builder();
         int start = 0;
         while (true) {
@@ -179,7 +179,7 @@ public class MqttTopicImpl extends MqttUtf8StringImpl implements MqttTopic {
     }
 
     @Override
-    public @NotNull ImmutableList<String> getLevels() {
+    public @NotNull ImmutableList<@NotNull String> getLevels() {
         return splitLevels(toString());
     }
 

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.util.Checks;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -155,7 +155,7 @@ public class MqttTopicImpl extends MqttUtf8StringImpl implements MqttTopic {
      * @param string the Topic Name string.
      * @return the levels of the Topic Name string.
      */
-    static @NotNull ImmutableList<@NotNull String> splitLevels(final @NotNull String string) {
+    static @NotNull ImmutableList<String> splitLevels(final @NotNull String string) {
         final ImmutableList.Builder<String> levelsBuilder = ImmutableList.builder();
         int start = 0;
         while (true) {
@@ -178,7 +178,7 @@ public class MqttTopicImpl extends MqttUtf8StringImpl implements MqttTopic {
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull String> getLevels() {
+    public @NotNull ImmutableList<String> getLevels() {
         return splitLevels(toString());
     }
 

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
@@ -22,10 +22,9 @@ import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.util.Checks;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImpl.java
@@ -186,4 +186,9 @@ public class MqttTopicImpl extends MqttUtf8StringImpl implements MqttTopic {
     public @NotNull MqttTopicFilterImpl filter() {
         return MqttTopicFilterImpl.of(this);
     }
+
+    @Override
+    public @NotNull MqttTopicImplBuilder.Default extend() {
+        return new MqttTopicImplBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImplBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttTopicImplBuilder.java
@@ -19,9 +19,7 @@ package org.mqttbee.mqtt.datatypes;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicBuilder;
-import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
 
 import java.util.function.Function;
@@ -46,7 +44,7 @@ public abstract class MqttTopicImplBuilder<B extends MqttTopicImplBuilder> {
         if (stringBuilder == null) {
             stringBuilder = new StringBuilder(topicLevel);
         } else {
-            stringBuilder.append(MqttTopic.TOPIC_LEVEL_SEPARATOR).append(topicLevel);
+            stringBuilder.append(MqttTopicImpl.TOPIC_LEVEL_SEPARATOR).append(topicLevel);
         }
         return self();
     }
@@ -62,8 +60,8 @@ public abstract class MqttTopicImplBuilder<B extends MqttTopicImplBuilder> {
 
         public Default() {}
 
-        public Default(final @Nullable MqttTopic topic) {
-            super(MqttChecks.topic(topic));
+        Default(final @NotNull MqttTopicImpl topic) {
+            super(topic);
         }
 
         @Override

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.exceptions.MqttBinaryDataExceededException;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -45,7 +45,7 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
      * @return the created collection of User Properties or {@link #NO_USER_PROPERTIES} if the list is empty.
      */
     public static @NotNull MqttUserPropertiesImpl of(
-            final @NotNull ImmutableList<@NotNull MqttUserPropertyImpl> userProperties) {
+            final @NotNull ImmutableList<MqttUserPropertyImpl> userProperties) {
 
         return userProperties.isEmpty() ? NO_USER_PROPERTIES : new MqttUserPropertiesImpl(userProperties);
     }
@@ -62,7 +62,7 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
         return (userPropertiesBuilder == null) ? NO_USER_PROPERTIES : of(userPropertiesBuilder.build());
     }
 
-    private final @NotNull ImmutableList<@NotNull MqttUserPropertyImpl> userProperties;
+    private final @NotNull ImmutableList<MqttUserPropertyImpl> userProperties;
     private int encodedLength = -1;
 
     private MqttUserPropertiesImpl(final @NotNull ImmutableList<MqttUserPropertyImpl> userProperties) {
@@ -70,7 +70,7 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull MqttUserPropertyImpl> asList() {
+    public @NotNull ImmutableList<MqttUserPropertyImpl> asList() {
         return userProperties;
     }
 
@@ -83,6 +83,7 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
      * @param out the byte buffer to encode to.
      */
     public void encode(final @NotNull ByteBuf out) {
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < userProperties.size(); i++) {
             userProperties.get(i).encode(out);
         }
@@ -103,6 +104,7 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
 
     private int calculateEncodedLength() {
         int encodedLength = 0;
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < userProperties.size(); i++) {
             encodedLength += userProperties.get(i).encodedLength();
         }

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
@@ -127,4 +127,9 @@ public class MqttUserPropertiesImpl implements Mqtt5UserProperties {
     public int hashCode() {
         return userProperties.hashCode();
     }
+
+    @Override
+    public @NotNull MqttUserPropertiesImplBuilder.Default extend() {
+        return new MqttUserPropertiesImplBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImpl.java
@@ -21,10 +21,9 @@ import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.exceptions.MqttBinaryDataExceededException;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
@@ -20,7 +20,6 @@ package org.mqttbee.mqtt.datatypes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
-import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperty;
 import org.mqttbee.mqtt.util.MqttChecks;
@@ -39,8 +38,8 @@ public abstract class MqttUserPropertiesImplBuilder<B extends MqttUserProperties
         listBuilder = ImmutableList.builder();
     }
 
-    MqttUserPropertiesImplBuilder(final @NotNull Mqtt5UserProperties userProperties) {
-        final ImmutableList<MqttUserPropertyImpl> list = MqttChecks.userProperties(userProperties).asList();
+    MqttUserPropertiesImplBuilder(final @NotNull MqttUserPropertiesImpl userProperties) {
+        final ImmutableList<MqttUserPropertyImpl> list = userProperties.asList();
         listBuilder = ImmutableList.builder(list.size() + 1);
         listBuilder.addAll(list);
     }
@@ -70,7 +69,7 @@ public abstract class MqttUserPropertiesImplBuilder<B extends MqttUserProperties
 
         public Default() {}
 
-        public Default(final @NotNull Mqtt5UserProperties userProperties) {
+        Default(final @NotNull MqttUserPropertiesImpl userProperties) {
             super(userProperties);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplBuilder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
@@ -25,6 +24,7 @@ import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserPropertiesBuilder;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperty;
 import org.mqttbee.mqtt.util.MqttChecks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.function.Function;
 
@@ -41,7 +41,7 @@ public abstract class MqttUserPropertiesImplBuilder<B extends MqttUserProperties
 
     MqttUserPropertiesImplBuilder(final @NotNull Mqtt5UserProperties userProperties) {
         final ImmutableList<MqttUserPropertyImpl> list = MqttChecks.userProperties(userProperties).asList();
-        listBuilder = ImmutableList.builderWithExpectedSize(list.size() + 1);
+        listBuilder = ImmutableList.builder(list.size() + 1);
         listBuilder.addAll(list);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertyImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUserPropertyImpl.java
@@ -21,10 +21,9 @@ import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperty;
 import org.mqttbee.mqtt.message.MqttProperty;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl
@@ -42,7 +41,8 @@ public class MqttUserPropertyImpl implements Mqtt5UserProperty {
      */
     @Contract("null, _ -> fail; _, null -> fail")
     public static @NotNull MqttUserPropertyImpl of(final @Nullable String name, final @Nullable String value) {
-        return of(MqttUtf8StringImpl.of(name, "User property name"), MqttUtf8StringImpl.of(value, "User property value"));
+        return of(
+                MqttUtf8StringImpl.of(name, "User property name"), MqttUtf8StringImpl.of(value, "User property value"));
     }
 
     /**

--- a/src/main/java/org/mqttbee/mqtt/datatypes/MqttUtf8StringImpl.java
+++ b/src/main/java/org/mqttbee/mqtt/datatypes/MqttUtf8StringImpl.java
@@ -22,10 +22,10 @@ import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.util.Checks;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/incoming/MqttIncomingPublishFlows.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/incoming/MqttIncomingPublishFlows.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.handler.publish.incoming;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.MqttGlobalPublishFilter;
@@ -34,6 +33,7 @@ import org.mqttbee.mqtt.message.unsubscribe.MqttStatefulUnsubscribe;
 import org.mqttbee.mqtt.message.unsubscribe.unsuback.MqttUnsubAck;
 import org.mqttbee.mqtt.message.unsubscribe.unsuback.mqtt3.Mqtt3UnsubAckView;
 import org.mqttbee.util.collections.HandleList;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;

--- a/src/main/java/org/mqttbee/mqtt/handler/publish/incoming/MqttIncomingPublishFlowsWithId.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/publish/incoming/MqttIncomingPublishFlowsWithId.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.handler.publish.incoming;
 
-import com.google.common.primitives.ImmutableIntArray;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
@@ -26,6 +25,7 @@ import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.mqtt.message.subscribe.MqttStatefulSubscribe;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
 import org.mqttbee.util.collections.HandleList;
+import org.mqttbee.util.collections.ImmutableIntList;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
@@ -108,9 +108,9 @@ public class MqttIncomingPublishFlowsWithId extends MqttIncomingPublishFlows {
             final @NotNull MqttStatefulPublish publish,
             final @NotNull HandleList<MqttIncomingPublishFlow> matchingFlows) {
 
-        final ImmutableIntArray subscriptionIdentifiers = publish.getSubscriptionIdentifiers();
+        final ImmutableIntList subscriptionIdentifiers = publish.getSubscriptionIdentifiers();
         if (!subscriptionIdentifiers.isEmpty()) {
-            for (int i = 0; i < subscriptionIdentifiers.length(); i++) {
+            for (int i = 0; i < subscriptionIdentifiers.size(); i++) {
                 final int subscriptionIdentifier = subscriptionIdentifiers.get(i);
                 final MqttSubscriptionFlow flow = flowsWithIdsMap.get(subscriptionIdentifier);
                 if (flow != null) {

--- a/src/main/java/org/mqttbee/mqtt/handler/ssl/SslUtil.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/ssl/SslUtil.java
@@ -16,11 +16,11 @@
 
 package org.mqttbee.mqtt.handler.ssl;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.channel.Channel;
 import io.netty.handler.ssl.*;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.mqtt.MqttClientSslConfigImpl;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -49,6 +49,7 @@ public class SslUtil {
                 .keyManager(sslConfig.getRawKeyManagerFactory());
 
         final ImmutableList<String> protocols = sslConfig.getRawProtocols();
+        //noinspection ToArrayCallWithZeroLengthArrayArgument
         final String[] protocolArray = (protocols == null) ? null : protocols.toArray(new String[protocols.size()]);
         sslContextBuilder.protocols(protocolArray);
 
@@ -66,5 +67,4 @@ public class SslUtil {
         sslHandler.setHandshakeTimeoutMillis(sslConfig.getHandshakeTimeoutMs());
         return sslHandler;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/handler/subscribe/MqttSubscriptionHandler.java
+++ b/src/main/java/org/mqttbee/mqtt/handler/subscribe/MqttSubscriptionHandler.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.handler.subscribe;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import org.jctools.queues.MpscLinkedQueue;
@@ -45,6 +44,7 @@ import org.mqttbee.mqtt.message.unsubscribe.unsuback.mqtt3.Mqtt3UnsubAckView;
 import org.mqttbee.rx.SingleFlow;
 import org.mqttbee.util.Ranges;
 import org.mqttbee.util.UnsignedDataTypes;
+import org.mqttbee.util.collections.ImmutableList;
 import org.mqttbee.util.collections.IntMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithUserProperties.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithUserProperties.java
@@ -123,10 +123,10 @@ public abstract class MqttMessageWithUserProperties implements MqttMessage.WithU
                 implements MqttMessage.WithId {
 
             private final int packetIdentifier;
-            private final @NotNull ImmutableList<R> reasonCodes;
+            private final @NotNull ImmutableList<@NotNull R> reasonCodes;
 
             protected WithCodesAndId(
-                    final int packetIdentifier, final @NotNull ImmutableList<R> reasonCodes,
+                    final int packetIdentifier, final @NotNull ImmutableList<@NotNull R> reasonCodes,
                     final @Nullable MqttUtf8StringImpl reasonString,
                     final @NotNull MqttUserPropertiesImpl userProperties) {
 
@@ -140,7 +140,7 @@ public abstract class MqttMessageWithUserProperties implements MqttMessage.WithU
                 return packetIdentifier;
             }
 
-            public @NotNull ImmutableList<R> getReasonCodes() {
+            public @NotNull ImmutableList<@NotNull R> getReasonCodes() {
                 return reasonCodes;
             }
         }

--- a/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithUserProperties.java
+++ b/src/main/java/org/mqttbee/mqtt/message/MqttMessageWithUserProperties.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.message;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.message.Mqtt5ReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.Optional;
 

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuth.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttAuth.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.auth;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5Auth;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5AuthReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
@@ -26,7 +27,6 @@ import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 import org.mqttbee.util.ByteBufferUtil;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuth.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttEnhancedAuth.java
@@ -19,11 +19,11 @@ package org.mqttbee.mqtt.message.auth;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5EnhancedAuth;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.util.ByteBufferUtil;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
@@ -33,29 +33,25 @@ import java.util.Optional;
 @Immutable
 public class MqttEnhancedAuth implements Mqtt5EnhancedAuth {
 
-    private final MqttUtf8StringImpl method;
-    private final ByteBuffer data;
+    private final @NotNull MqttUtf8StringImpl method;
+    private final @Nullable ByteBuffer data;
 
     public MqttEnhancedAuth(@NotNull final MqttUtf8StringImpl method, @Nullable final ByteBuffer data) {
         this.method = method;
         this.data = data;
     }
 
-    @NotNull
     @Override
-    public MqttUtf8StringImpl getMethod() {
+    public @NotNull MqttUtf8StringImpl getMethod() {
         return method;
     }
 
-    @NotNull
     @Override
-    public Optional<ByteBuffer> getData() {
+    public @NotNull Optional<ByteBuffer> getData() {
         return ByteBufferUtil.optionalReadOnly(data);
     }
 
-    @Nullable
-    public ByteBuffer getRawData() {
+    public @Nullable ByteBuffer getRawData() {
         return data;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/message/auth/MqttSimpleAuth.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/MqttSimpleAuth.java
@@ -19,12 +19,12 @@ package org.mqttbee.mqtt.message.auth;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.util.ByteBufferUtil;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 

--- a/src/main/java/org/mqttbee/mqtt/message/auth/mqtt3/Mqtt3SimpleAuthView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/auth/mqtt3/Mqtt3SimpleAuthView.java
@@ -19,12 +19,12 @@ package org.mqttbee.mqtt.message.auth.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnect.java
@@ -130,6 +130,11 @@ public class MqttConnect extends MqttMessageWithUserProperties implements Mqtt5C
         return willPublish;
     }
 
+    @Override
+    public @NotNull MqttConnectBuilder.Default extend() {
+        return new MqttConnectBuilder.Default(this);
+    }
+
     public @NotNull MqttStatefulConnect createStateful(
             final @NotNull MqttClientIdentifierImpl clientIdentifier, final @Nullable MqttEnhancedAuth enhancedAuth) {
 

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnect.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.connect;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.auth.Mqtt5EnhancedAuthProvider;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect;
@@ -30,7 +31,6 @@ import org.mqttbee.mqtt.message.auth.MqttEnhancedAuth;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Optional;
 
 /**

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectBuilder.java
@@ -57,17 +57,16 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
     MqttConnectBuilder() {}
 
     MqttConnectBuilder(final @NotNull MqttConnect connect) {
-        final MqttConnect mqttConnect = MqttChecks.connect(connect);
-        keepAlive = mqttConnect.getKeepAlive();
-        isCleanStart = mqttConnect.isCleanStart();
-        sessionExpiryInterval = mqttConnect.getSessionExpiryInterval();
-        isResponseInformationRequested = mqttConnect.isResponseInformationRequested();
-        isProblemInformationRequested = mqttConnect.isProblemInformationRequested();
-        restrictions = mqttConnect.getRestrictions();
-        simpleAuth = mqttConnect.getRawSimpleAuth();
-        enhancedAuthProvider = mqttConnect.getRawEnhancedAuthProvider();
-        willPublish = mqttConnect.getRawWillPublish();
-        userProperties = mqttConnect.getUserProperties();
+        keepAlive = connect.getKeepAlive();
+        isCleanStart = connect.isCleanStart();
+        sessionExpiryInterval = connect.getSessionExpiryInterval();
+        isResponseInformationRequested = connect.isResponseInformationRequested();
+        isProblemInformationRequested = connect.isProblemInformationRequested();
+        restrictions = connect.getRestrictions();
+        simpleAuth = connect.getRawSimpleAuth();
+        enhancedAuthProvider = connect.getRawEnhancedAuthProvider();
+        willPublish = connect.getRawWillPublish();
+        userProperties = connect.getUserProperties();
     }
 
     abstract @NotNull B self();

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectBuilder.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt5.auth.Mqtt5EnhancedAuthProvider;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5SimpleAuth;
-import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5Connect;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5ConnectBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5ConnectRestrictions;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish;
@@ -57,7 +56,7 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
 
     MqttConnectBuilder() {}
 
-    MqttConnectBuilder(final @Nullable Mqtt5Connect connect) {
+    MqttConnectBuilder(final @NotNull MqttConnect connect) {
         final MqttConnect mqttConnect = MqttChecks.connect(connect);
         keepAlive = mqttConnect.getKeepAlive();
         isCleanStart = mqttConnect.isCleanStart();
@@ -165,7 +164,7 @@ public abstract class MqttConnectBuilder<B extends MqttConnectBuilder<B>> {
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt5Connect connect) {
+        Default(final @NotNull MqttConnect connect) {
             super(connect);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectRestrictions.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectRestrictions.java
@@ -18,9 +18,8 @@
 package org.mqttbee.mqtt.message.connect;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.Mqtt5ConnectRestrictions;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl
@@ -57,5 +56,4 @@ public class MqttConnectRestrictions implements Mqtt5ConnectRestrictions {
     public int getTopicAliasMaximum() {
         return topicAliasMaximum;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectRestrictionsBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttConnectRestrictionsBuilder.java
@@ -43,7 +43,7 @@ public abstract class MqttConnectRestrictionsBuilder<B extends MqttConnectRestri
     public @NotNull B maximumPacketSize(final int maximumPacketSize) {
         if ((maximumPacketSize <= 0) || (maximumPacketSize > MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT)) {
             throw new IllegalArgumentException("Maximum packet size must not exceed the value range of ]0, " +
-                    MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT + "], but was: " + maximumPacketSize);
+                    MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT + "], but was " + maximumPacketSize + ".");
         }
         this.maximumPacketSize = maximumPacketSize;
         return self();

--- a/src/main/java/org/mqttbee/mqtt/message/connect/MqttStatefulConnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/MqttStatefulConnect.java
@@ -19,11 +19,10 @@ package org.mqttbee.mqtt.message.connect;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.datatypes.MqttClientIdentifierImpl;
 import org.mqttbee.mqtt.message.MqttStatefulMessage;
 import org.mqttbee.mqtt.message.auth.MqttEnhancedAuth;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAck.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.connect.connack;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.message.auth.Mqtt5EnhancedAuth;
@@ -29,7 +30,6 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckRestrictions.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/MqttConnAckRestrictions.java
@@ -18,10 +18,9 @@
 package org.mqttbee.mqtt.message.connect.connack;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckRestrictions;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl
@@ -99,5 +98,4 @@ public class MqttConnAckRestrictions implements Mqtt5ConnAckRestrictions {
     public boolean areSubscriptionIdentifiersAvailable() {
         return subscriptionIdentifiersAvailable;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/message/connect/connack/mqtt3/Mqtt3ConnAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/connack/mqtt3/Mqtt3ConnAckView.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.connect.connack.mqtt3;
 
 import io.reactivex.functions.Function;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAck;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAckReturnCode;
 import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
@@ -26,8 +27,6 @@ import org.mqttbee.api.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCode
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.connect.connack.MqttConnAck;
 import org.mqttbee.mqtt.message.connect.connack.MqttConnAckRestrictions;
-
-import javax.annotation.concurrent.Immutable;
 
 import static org.mqttbee.api.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAckReturnCode.*;
 

--- a/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.connect.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
@@ -30,7 +31,6 @@ import org.mqttbee.mqtt.message.connect.MqttConnectRestrictions;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 import org.mqttbee.mqtt.message.publish.mqtt3.Mqtt3PublishView;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Optional;
 
 /**

--- a/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectView.java
@@ -93,4 +93,9 @@ public class Mqtt3ConnectView implements Mqtt3Connect {
     public @NotNull MqttConnect getDelegate() {
         return delegate;
     }
+
+    @Override
+    public @NotNull Mqtt3ConnectViewBuilder.Default extend() {
+        return new Mqtt3ConnectViewBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/connect/mqtt3/Mqtt3ConnectViewBuilder.java
@@ -20,7 +20,6 @@ package org.mqttbee.mqtt.message.connect.mqtt3;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.mqtt3.message.auth.Mqtt3SimpleAuth;
-import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3ConnectBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import org.mqttbee.mqtt.message.auth.MqttSimpleAuth;
@@ -40,19 +39,19 @@ import java.util.function.Function;
  */
 public abstract class Mqtt3ConnectViewBuilder<B extends Mqtt3ConnectViewBuilder<B>> {
 
-    private int keepAliveSeconds = Mqtt3Connect.DEFAULT_KEEP_ALIVE;
-    private boolean isCleanSession = Mqtt3Connect.DEFAULT_CLEAN_SESSION;
+    private int keepAliveSeconds = Mqtt3ConnectView.DEFAULT_KEEP_ALIVE;
+    private boolean isCleanSession = Mqtt3ConnectView.DEFAULT_CLEAN_SESSION;
     private @Nullable MqttSimpleAuth simpleAuth;
     private @Nullable MqttWillPublish willPublish;
 
     Mqtt3ConnectViewBuilder() {}
 
-    Mqtt3ConnectViewBuilder(final @Nullable Mqtt3Connect connect) {
-        final MqttConnect connectView = MqttChecks.connect(connect);
-        keepAliveSeconds = connectView.getKeepAlive();
-        isCleanSession = connectView.isCleanStart();
-        simpleAuth = connectView.getRawSimpleAuth();
-        willPublish = connectView.getRawWillPublish();
+    Mqtt3ConnectViewBuilder(final @NotNull Mqtt3ConnectView connect) {
+        final MqttConnect delegate = connect.getDelegate();
+        keepAliveSeconds = delegate.getKeepAlive();
+        isCleanSession = delegate.isCleanStart();
+        simpleAuth = delegate.getRawSimpleAuth();
+        willPublish = delegate.getRawWillPublish();
     }
 
     abstract @NotNull B self();
@@ -100,7 +99,7 @@ public abstract class Mqtt3ConnectViewBuilder<B extends Mqtt3ConnectViewBuilder<
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt3Connect connect) {
+        Default(final @NotNull Mqtt3ConnectView connect) {
             super(connect);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnect.java
@@ -73,4 +73,9 @@ public class MqttDisconnect extends MqttMessageWithUserProperties.WithReason.Wit
     public @Nullable MqttUtf8StringImpl getRawServerReference() {
         return serverReference;
     }
+
+    @Override
+    public @NotNull MqttDisconnectBuilder.Default extend() {
+        return new MqttDisconnectBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnect.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnect.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.disconnect;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
@@ -26,7 +27,6 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Optional;
 import java.util.OptionalLong;
 

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnectBuilder.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
-import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5Disconnect;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
@@ -46,13 +45,12 @@ public abstract class MqttDisconnectBuilder<B extends MqttDisconnectBuilder<B>> 
 
     MqttDisconnectBuilder() {}
 
-    MqttDisconnectBuilder(final @Nullable Mqtt5Disconnect disconnect) {
-        final MqttDisconnect mqttDisconnect = MqttChecks.disconnect(disconnect);
-        reasonCode = mqttDisconnect.getReasonCode();
-        sessionExpiryInterval = mqttDisconnect.getRawSessionExpiryInterval();
-        serverReference = mqttDisconnect.getRawServerReference();
-        reasonString = mqttDisconnect.getRawReasonString();
-        userProperties = mqttDisconnect.getUserProperties();
+    MqttDisconnectBuilder(final @NotNull MqttDisconnect disconnect) {
+        reasonCode = disconnect.getReasonCode();
+        sessionExpiryInterval = disconnect.getRawSessionExpiryInterval();
+        serverReference = disconnect.getRawServerReference();
+        reasonString = disconnect.getRawReasonString();
+        userProperties = disconnect.getUserProperties();
     }
 
     abstract @NotNull B self();
@@ -109,7 +107,7 @@ public abstract class MqttDisconnectBuilder<B extends MqttDisconnectBuilder<B>> 
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt5Disconnect disconnect) {
+        Default(final @NotNull MqttDisconnect disconnect) {
             super(disconnect);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/mqtt3/Mqtt3DisconnectView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/mqtt3/Mqtt3DisconnectView.java
@@ -18,12 +18,11 @@
 package org.mqttbee.mqtt.message.disconnect.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.disconnect.Mqtt3Disconnect;
 import org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.disconnect.MqttDisconnect;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingReq.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingReq.java
@@ -17,10 +17,10 @@
 
 package org.mqttbee.mqtt.message.ping;
 
+import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.ping.Mqtt5PingReq;
 import org.mqttbee.mqtt.message.MqttMessage;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl
@@ -28,9 +28,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class MqttPingReq implements MqttMessage, Mqtt5PingReq {
 
-    public static final MqttPingReq INSTANCE = new MqttPingReq();
+    public static final @NotNull MqttPingReq INSTANCE = new MqttPingReq();
 
-    private MqttPingReq() {
-    }
-
+    private MqttPingReq() {}
 }

--- a/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingResp.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/MqttPingResp.java
@@ -17,10 +17,10 @@
 
 package org.mqttbee.mqtt.message.ping;
 
+import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.ping.Mqtt5PingResp;
 import org.mqttbee.mqtt.message.MqttMessage;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl
@@ -28,9 +28,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class MqttPingResp implements MqttMessage, Mqtt5PingResp {
 
-    public static final MqttPingResp INSTANCE = new MqttPingResp();
+    public static final @NotNull MqttPingResp INSTANCE = new MqttPingResp();
 
-    private MqttPingResp() {
-    }
-
+    private MqttPingResp() {}
 }

--- a/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingReqView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingReqView.java
@@ -18,9 +18,8 @@
 package org.mqttbee.mqtt.message.ping.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.ping.Mqtt3PingReq;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingRespView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/ping/mqtt3/Mqtt3PingRespView.java
@@ -18,9 +18,8 @@
 package org.mqttbee.mqtt.message.ping.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.ping.Mqtt3PingResp;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
@@ -163,6 +163,11 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
         return topicAliasUsage;
     }
 
+    @Override
+    public @NotNull MqttPublishBuilder.Default extend() {
+        return new MqttPublishBuilder.Default(this);
+    }
+
     public @NotNull MqttStatefulPublish createStateful(
             final int packetIdentifier, final boolean isDup, final int topicAlias, final boolean isNewTopicAlias,
             final @NotNull ImmutableIntArray subscriptionIdentifiers) {

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.publish;
 
-import com.google.common.primitives.ImmutableIntArray;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.annotations.Immutable;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.collections.ImmutableIntList;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -170,7 +170,7 @@ public class MqttPublish extends MqttMessageWithUserProperties implements Mqtt5P
 
     public @NotNull MqttStatefulPublish createStateful(
             final int packetIdentifier, final boolean isDup, final int topicAlias, final boolean isNewTopicAlias,
-            final @NotNull ImmutableIntArray subscriptionIdentifiers) {
+            final @NotNull ImmutableIntList subscriptionIdentifiers) {
 
         return new MqttStatefulPublish(
                 this, packetIdentifier, isDup, topicAlias, isNewTopicAlias, subscriptionIdentifiers);

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublish.java
@@ -20,6 +20,7 @@ package org.mqttbee.mqtt.message.publish;
 import com.google.common.primitives.ImmutableIntArray;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
@@ -32,7 +33,6 @@ import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 import org.mqttbee.util.ByteBufferUtil;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.OptionalLong;

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttPublishBuilder.java
@@ -23,7 +23,10 @@ import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
-import org.mqttbee.api.mqtt.mqtt5.message.publish.*;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PublishBuilder;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublishBuilder;
+import org.mqttbee.api.mqtt.mqtt5.message.publish.TopicAliasUsage;
 import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.ByteBufferUtil;
@@ -50,18 +53,17 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
 
     MqttPublishBuilder() {}
 
-    MqttPublishBuilder(final @Nullable Mqtt5Publish publish) {
-        final MqttPublish mqttPublish = MqttChecks.publish(publish);
-        topic = mqttPublish.getTopic();
-        payload = mqttPublish.getRawPayload();
-        qos = mqttPublish.getQos();
-        retain = mqttPublish.isRetain();
-        messageExpiryInterval = mqttPublish.getRawMessageExpiryInterval();
-        payloadFormatIndicator = mqttPublish.getRawPayloadFormatIndicator();
-        contentType = mqttPublish.getRawContentType();
-        responseTopic = mqttPublish.getRawResponseTopic();
-        correlationData = mqttPublish.getRawCorrelationData();
-        userProperties = mqttPublish.getUserProperties();
+    MqttPublishBuilder(final @NotNull MqttPublish publish) {
+        topic = publish.getTopic();
+        payload = publish.getRawPayload();
+        qos = publish.getQos();
+        retain = publish.isRetain();
+        messageExpiryInterval = publish.getRawMessageExpiryInterval();
+        payloadFormatIndicator = publish.getRawPayloadFormatIndicator();
+        contentType = publish.getRawContentType();
+        responseTopic = publish.getRawResponseTopic();
+        correlationData = publish.getRawCorrelationData();
+        userProperties = publish.getUserProperties();
     }
 
     abstract @NotNull B self();
@@ -154,9 +156,9 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
 
         Base() {}
 
-        Base(final @Nullable Mqtt5Publish publish) {
+        Base(final @NotNull MqttPublish publish) {
             super(publish);
-            topicAliasUsage = MqttChecks.publish(publish).usesTopicAlias();
+            topicAliasUsage = publish.usesTopicAlias();
         }
 
         public @NotNull B payload(final @Nullable byte[] payload) {
@@ -174,6 +176,10 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
             return self();
         }
 
+        public @NotNull WillDefault asWill() {
+            return new WillDefault(build());
+        }
+
         public @NotNull MqttPublish build() {
             Checks.notNull(topic, "Topic");
             return new MqttPublish(topic, payload, qos, retain, messageExpiryInterval, payloadFormatIndicator,
@@ -185,7 +191,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt5Publish publish) {
+        Default(final @NotNull MqttPublish publish) {
             super(publish);
         }
 
@@ -239,11 +245,10 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
 
         WillBase() {}
 
-        WillBase(final @Nullable Mqtt5Publish publish) {
+        WillBase(final @NotNull MqttPublish publish) {
             super(publish);
-            if (publish instanceof Mqtt5WillPublish) {
-                delayInterval =
-                        Checks.notImplemented(publish, MqttWillPublish.class, "Will publish").getDelayInterval();
+            if (publish instanceof MqttWillPublish) {
+                delayInterval = ((MqttWillPublish) publish).getDelayInterval();
             } else {
                 payload(payload); // check payload size restriction
             }
@@ -275,7 +280,7 @@ public abstract class MqttPublishBuilder<B extends MqttPublishBuilder<B>> {
 
         public WillDefault() {}
 
-        public WillDefault(final @Nullable Mqtt5Publish publish) {
+        public WillDefault(final @NotNull MqttPublish publish) {
             super(publish);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttStatefulPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttStatefulPublish.java
@@ -17,10 +17,10 @@
 
 package org.mqttbee.mqtt.message.publish;
 
-import com.google.common.primitives.ImmutableIntArray;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.message.MqttStatefulMessage;
+import org.mqttbee.util.collections.ImmutableIntList;
 
 /**
  * @author Silvio Giebl
@@ -30,16 +30,16 @@ public class MqttStatefulPublish extends MqttStatefulMessage.WithId<MqttPublish>
 
     public static final int NO_PACKET_IDENTIFIER_QOS_0 = -1;
     public static final int DEFAULT_NO_TOPIC_ALIAS = -1;
-    public static final @NotNull ImmutableIntArray DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS = ImmutableIntArray.of();
+    public static final @NotNull ImmutableIntList DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS = ImmutableIntList.of();
 
     private final boolean isDup;
     private final int topicAlias;
     private final boolean isNewTopicAlias;
-    private final @NotNull ImmutableIntArray subscriptionIdentifiers;
+    private final @NotNull ImmutableIntList subscriptionIdentifiers;
 
     MqttStatefulPublish(
             final @NotNull MqttPublish publish, final int packetIdentifier, final boolean isDup, final int topicAlias,
-            final boolean isNewTopicAlias, final @NotNull ImmutableIntArray subscriptionIdentifiers) {
+            final boolean isNewTopicAlias, final @NotNull ImmutableIntList subscriptionIdentifiers) {
 
         super(publish, packetIdentifier);
         this.isDup = isDup;
@@ -60,7 +60,7 @@ public class MqttStatefulPublish extends MqttStatefulMessage.WithId<MqttPublish>
         return isNewTopicAlias;
     }
 
-    public @NotNull ImmutableIntArray getSubscriptionIdentifiers() {
+    public @NotNull ImmutableIntList getSubscriptionIdentifiers() {
         return subscriptionIdentifiers;
     }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttStatefulPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttStatefulPublish.java
@@ -19,9 +19,8 @@ package org.mqttbee.mqtt.message.publish;
 
 import com.google.common.primitives.ImmutableIntArray;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.message.MqttStatefulMessage;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
@@ -55,4 +55,9 @@ public class MqttWillPublish extends MqttPublish implements Mqtt5WillPublish {
     public long getDelayInterval() {
         return delayInterval;
     }
+
+    @Override
+    public @NotNull MqttPublishBuilder.WillDefault extendAsWill() {
+        return new MqttPublishBuilder.WillDefault(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/MqttWillPublish.java
@@ -19,6 +19,7 @@ package org.mqttbee.mqtt.message.publish;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5WillPublish;
@@ -27,7 +28,6 @@ import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 
 /**

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -119,4 +119,9 @@ public class Mqtt3PublishView implements Mqtt3Publish {
     public @NotNull MqttPublish getDelegate() {
         return delegate;
     }
+
+    @Override
+    public @NotNull Mqtt3PublishViewBuilder.Default extend() {
+        return new Mqtt3PublishViewBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishView.java
@@ -20,6 +20,7 @@ package org.mqttbee.mqtt.message.publish.mqtt3;
 import io.reactivex.functions.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
@@ -32,7 +33,6 @@ import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
 
-import javax.annotation.concurrent.Immutable;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishViewBuilder.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopic;
-import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3PublishBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3WillPublishBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicImpl;
@@ -46,12 +45,12 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
 
     Mqtt3PublishViewBuilder() {}
 
-    Mqtt3PublishViewBuilder(final @Nullable Mqtt3Publish publish) {
-        final MqttPublish publishView = MqttChecks.publish(publish);
-        topic = publishView.getTopic();
-        payload = publishView.getRawPayload();
-        qos = publishView.getQos();
-        retain = publishView.isRetain();
+    Mqtt3PublishViewBuilder(final @NotNull Mqtt3PublishView publish) {
+        final MqttPublish delegate = publish.getDelegate();
+        topic = delegate.getTopic();
+        payload = delegate.getRawPayload();
+        qos = delegate.getQos();
+        retain = delegate.isRetain();
     }
 
     protected abstract @NotNull B self();
@@ -94,7 +93,7 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
 
         Base() {}
 
-        Base(final @Nullable Mqtt3Publish publish) {
+        Base(final @NotNull Mqtt3PublishView publish) {
             super(publish);
         }
 
@@ -108,7 +107,7 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt3Publish publish) {
+        Default(final @NotNull Mqtt3PublishView publish) {
             super(publish);
         }
 
@@ -160,7 +159,7 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
 
         WillBase() {}
 
-        WillBase(final @Nullable Mqtt3Publish publish) {
+        WillBase(final @NotNull Mqtt3PublishView publish) {
             super(publish);
         }
 
@@ -174,7 +173,7 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
 
         public WillDefault() {}
 
-        public WillDefault(final @Nullable Mqtt3Publish publish) {
+        WillDefault(final @NotNull Mqtt3PublishView publish) {
             super(publish);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/MqttPubAck.java
@@ -19,13 +19,12 @@ package org.mqttbee.mqtt.message.publish.puback;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/puback/mqtt3/Mqtt3PubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/puback/mqtt3/Mqtt3PubAckView.java
@@ -18,12 +18,11 @@
 package org.mqttbee.mqtt.message.publish.puback.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.puback.Mqtt3PubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.publish.puback.MqttPubAck;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubComp.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/MqttPubComp.java
@@ -19,13 +19,12 @@ package org.mqttbee.mqtt.message.publish.pubcomp;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp.Mqtt5PubComp;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp.Mqtt5PubCompReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/mqtt3/Mqtt3PubCompView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubcomp/mqtt3/Mqtt3PubCompView.java
@@ -18,12 +18,11 @@
 package org.mqttbee.mqtt.message.publish.pubcomp.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.pubcomp.Mqtt3PubComp;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubcomp.Mqtt5PubCompReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.publish.pubcomp.MqttPubComp;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRec.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/MqttPubRec.java
@@ -19,13 +19,12 @@ package org.mqttbee.mqtt.message.publish.pubrec;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRec;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRecReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/mqtt3/Mqtt3PubRecView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrec/mqtt3/Mqtt3PubRecView.java
@@ -18,12 +18,11 @@
 package org.mqttbee.mqtt.message.publish.pubrec.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.pubrec.Mqtt3PubRec;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRecReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRel.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/MqttPubRel.java
@@ -19,13 +19,12 @@ package org.mqttbee.mqtt.message.publish.pubrel;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRel;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRelReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/mqtt3/Mqtt3PubRelView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/pubrel/mqtt3/Mqtt3PubRelView.java
@@ -18,12 +18,11 @@
 package org.mqttbee.mqtt.message.publish.pubrel.mqtt3;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.pubrel.Mqtt3PubRel;
 import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRelReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttStatefulSubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttStatefulSubscribe.java
@@ -18,9 +18,8 @@
 package org.mqttbee.mqtt.message.subscribe;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.message.MqttStatefulMessage;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
@@ -17,12 +17,12 @@
 
 package org.mqttbee.mqtt.message.subscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -30,10 +30,10 @@ import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 @Immutable
 public class MqttSubscribe extends MqttMessageWithUserProperties implements Mqtt5Subscribe {
 
-    private final @NotNull ImmutableList<@NotNull MqttSubscription> subscriptions;
+    private final @NotNull ImmutableList<MqttSubscription> subscriptions;
 
     public MqttSubscribe(
-            final @NotNull ImmutableList<@NotNull MqttSubscription> subscriptions,
+            final @NotNull ImmutableList<MqttSubscription> subscriptions,
             final @NotNull MqttUserPropertiesImpl userProperties) {
 
         super(userProperties);
@@ -41,7 +41,7 @@ public class MqttSubscribe extends MqttMessageWithUserProperties implements Mqtt
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull MqttSubscription> getSubscriptions() {
+    public @NotNull ImmutableList<MqttSubscription> getSubscriptions() {
         return subscriptions;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
@@ -48,4 +48,9 @@ public class MqttSubscribe extends MqttMessageWithUserProperties implements Mqtt
     public @NotNull MqttStatefulSubscribe createStateful(final int packetIdentifier, final int subscriptionIdentifier) {
         return new MqttStatefulSubscribe(this, packetIdentifier, subscriptionIdentifier);
     }
+
+    @Override
+    public @NotNull MqttSubscribeBuilder.Default extend() {
+        return new MqttSubscribeBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
@@ -19,11 +19,10 @@ package org.mqttbee.mqtt.message.subscribe;
 
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribe.java
@@ -31,10 +31,10 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class MqttSubscribe extends MqttMessageWithUserProperties implements Mqtt5Subscribe {
 
-    private final @NotNull ImmutableList<MqttSubscription> subscriptions;
+    private final @NotNull ImmutableList<@NotNull MqttSubscription> subscriptions;
 
     public MqttSubscribe(
-            final @NotNull ImmutableList<MqttSubscription> subscriptions,
+            final @NotNull ImmutableList<@NotNull MqttSubscription> subscriptions,
             final @NotNull MqttUserPropertiesImpl userProperties) {
 
         super(userProperties);
@@ -42,7 +42,7 @@ public class MqttSubscribe extends MqttMessageWithUserProperties implements Mqtt
     }
 
     @Override
-    public @NotNull ImmutableList<MqttSubscription> getSubscriptions() {
+    public @NotNull ImmutableList<@NotNull MqttSubscription> getSubscriptions() {
         return subscriptions;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeBuilder.java
@@ -23,7 +23,6 @@ import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5RetainHandling;
-import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5SubscribeBuilder;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImplBuilder;
@@ -48,9 +47,8 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
         subscriptionsBuilder = ImmutableList.builder();
     }
 
-    MqttSubscribeBuilder(final @Nullable Mqtt5Subscribe subscribe) {
-        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
-        final ImmutableList<MqttSubscription> subscriptions = mqttSubscribe.getSubscriptions();
+    MqttSubscribeBuilder(final @NotNull MqttSubscribe subscribe) {
+        final ImmutableList<MqttSubscription> subscriptions = subscribe.getSubscriptions();
         subscriptionsBuilder = ImmutableList.builder(subscriptions.size() + 1);
         subscriptionsBuilder.addAll(subscriptions);
     }
@@ -137,7 +135,7 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt5Subscribe subscribe) {
+        Default(final @NotNull MqttSubscribe subscribe) {
             super(subscribe);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscribeBuilder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.subscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImplBuilder;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.function.Function;
 
@@ -51,7 +51,7 @@ public abstract class MqttSubscribeBuilder<B extends MqttSubscribeBuilder<B>> {
     MqttSubscribeBuilder(final @Nullable Mqtt5Subscribe subscribe) {
         final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
         final ImmutableList<MqttSubscription> subscriptions = mqttSubscribe.getSubscriptions();
-        subscriptionsBuilder = ImmutableList.builderWithExpectedSize(subscriptions.size() + 1);
+        subscriptionsBuilder = ImmutableList.builder(subscriptions.size() + 1);
         subscriptionsBuilder.addAll(subscriptions);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscription.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/MqttSubscription.java
@@ -18,12 +18,11 @@
 package org.mqttbee.mqtt.message.subscribe;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5RetainHandling;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl
@@ -31,15 +30,15 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class MqttSubscription implements Mqtt5Subscription {
 
-    private final MqttTopicFilterImpl topicFilter;
-    private final MqttQos qos;
+    private final @NotNull MqttTopicFilterImpl topicFilter;
+    private final @NotNull MqttQos qos;
     private final boolean isNoLocal;
-    private final Mqtt5RetainHandling retainHandling;
+    private final @NotNull Mqtt5RetainHandling retainHandling;
     private final boolean isRetainAsPublished;
 
     public MqttSubscription(
-            @NotNull final MqttTopicFilterImpl topicFilter, @NotNull final MqttQos qos, final boolean isNoLocal,
-            @NotNull final Mqtt5RetainHandling retainHandling, final boolean isRetainAsPublished) {
+            final @NotNull MqttTopicFilterImpl topicFilter, final @NotNull MqttQos qos, final boolean isNoLocal,
+            final @NotNull Mqtt5RetainHandling retainHandling, final boolean isRetainAsPublished) {
 
         this.topicFilter = topicFilter;
         this.qos = qos;
@@ -48,15 +47,13 @@ public class MqttSubscription implements Mqtt5Subscription {
         this.isRetainAsPublished = isRetainAsPublished;
     }
 
-    @NotNull
     @Override
-    public MqttTopicFilterImpl getTopicFilter() {
+    public @NotNull MqttTopicFilterImpl getTopicFilter() {
         return topicFilter;
     }
 
-    @NotNull
     @Override
-    public MqttQos getQos() {
+    public @NotNull MqttQos getQos() {
         return qos;
     }
 
@@ -65,9 +62,8 @@ public class MqttSubscription implements Mqtt5Subscription {
         return isNoLocal;
     }
 
-    @NotNull
     @Override
-    public Mqtt5RetainHandling getRetainHandling() {
+    public @NotNull Mqtt5RetainHandling getRetainHandling() {
         return retainHandling;
     }
 
@@ -75,5 +71,4 @@ public class MqttSubscription implements Mqtt5Subscription {
     public boolean isRetainAsPublished() {
         return isRetainAsPublished;
     }
-
 }

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.message.subscribe.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -50,10 +50,10 @@ public class Mqtt3SubscribeView implements Mqtt3Subscribe {
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull Mqtt3SubscriptionView> getSubscriptions() {
+    public @NotNull ImmutableList<Mqtt3SubscriptionView> getSubscriptions() {
         final ImmutableList<MqttSubscription> subscriptions = delegate.getSubscriptions();
-        final ImmutableList.Builder<Mqtt3SubscriptionView> builder =
-                ImmutableList.builderWithExpectedSize(subscriptions.size());
+        final ImmutableList.Builder<Mqtt3SubscriptionView> builder = ImmutableList.builder(subscriptions.size());
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < subscriptions.size(); i++) {
             builder.add(Mqtt3SubscriptionView.of(subscriptions.get(i)));
         }

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
@@ -51,7 +51,7 @@ public class Mqtt3SubscribeView implements Mqtt3Subscribe {
     }
 
     @Override
-    public @NotNull ImmutableList<Mqtt3SubscriptionView> getSubscriptions() {
+    public @NotNull ImmutableList<@NotNull Mqtt3SubscriptionView> getSubscriptions() {
         final ImmutableList<MqttSubscription> subscriptions = delegate.getSubscriptions();
         final ImmutableList.Builder<Mqtt3SubscriptionView> builder =
                 ImmutableList.builderWithExpectedSize(subscriptions.size());

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
@@ -63,4 +63,9 @@ public class Mqtt3SubscribeView implements Mqtt3Subscribe {
     public @NotNull MqttSubscribe getDelegate() {
         return delegate;
     }
+
+    @Override
+    public @NotNull Mqtt3SubscribeViewBuilder.Default extend() {
+        return new Mqtt3SubscribeViewBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeView.java
@@ -19,12 +19,11 @@ package org.mqttbee.mqtt.message.subscribe.mqtt3;
 
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
@@ -21,13 +21,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
-import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3SubscribeBuilder;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscription;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImplBuilder;
-import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
-import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
 import org.mqttbee.util.collections.ImmutableList;
 
@@ -45,9 +42,8 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
         subscriptionsBuilder = ImmutableList.builder();
     }
 
-    Mqtt3SubscribeViewBuilder(final @Nullable Mqtt3Subscribe subscribe) {
-        final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
-        final ImmutableList<MqttSubscription> subscriptions = mqttSubscribe.getSubscriptions();
+    Mqtt3SubscribeViewBuilder(final @NotNull Mqtt3SubscribeView subscribe) {
+        final ImmutableList<MqttSubscription> subscriptions = subscribe.getDelegate().getSubscriptions();
         subscriptionsBuilder = ImmutableList.builder(subscriptions.size() + 1);
         subscriptionsBuilder.addAll(subscriptions);
     }
@@ -112,7 +108,7 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt3Subscribe subscribe) {
+        Default(final @NotNull Mqtt3SubscribeView subscribe) {
             super(subscribe);
         }
 
@@ -125,9 +121,9 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
     public static class Nested<P> extends Mqtt3SubscribeViewBuilder<Nested<P>>
             implements Mqtt3SubscribeBuilder.Nested.Start.Complete<P> {
 
-        private final @NotNull Function<? super Mqtt3Subscribe, P> parentConsumer;
+        private final @NotNull Function<? super Mqtt3SubscribeView, P> parentConsumer;
 
-        public Nested(final @NotNull Function<? super Mqtt3Subscribe, P> parentConsumer) {
+        public Nested(final @NotNull Function<? super Mqtt3SubscribeView, P> parentConsumer) {
             this.parentConsumer = parentConsumer;
         }
 
@@ -145,9 +141,9 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
     public static class Send<P> extends Mqtt3SubscribeViewBuilder<Send<P>>
             implements Mqtt3SubscribeBuilder.Send.Start.Complete<P> {
 
-        private final @NotNull Function<? super Mqtt3Subscribe, P> parentConsumer;
+        private final @NotNull Function<? super Mqtt3SubscribeView, P> parentConsumer;
 
-        public Send(final @NotNull Function<? super Mqtt3Subscribe, P> parentConsumer) {
+        public Send(final @NotNull Function<? super Mqtt3SubscribeView, P> parentConsumer) {
             this.parentConsumer = parentConsumer;
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/mqtt3/Mqtt3SubscribeViewBuilder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.subscribe.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttQos;
@@ -30,6 +29,7 @@ import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.function.Function;
 
@@ -48,7 +48,7 @@ public abstract class Mqtt3SubscribeViewBuilder<B extends Mqtt3SubscribeViewBuil
     Mqtt3SubscribeViewBuilder(final @Nullable Mqtt3Subscribe subscribe) {
         final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
         final ImmutableList<MqttSubscription> subscriptions = mqttSubscribe.getSubscriptions();
-        subscriptionsBuilder = ImmutableList.builderWithExpectedSize(subscriptions.size() + 1);
+        subscriptionsBuilder = ImmutableList.builder(subscriptions.size() + 1);
         subscriptionsBuilder.addAll(subscriptions);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAck.java
@@ -20,13 +20,12 @@ package org.mqttbee.mqtt.message.subscribe.suback;
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/MqttSubAck.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.subscribe.suback;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.annotations.Immutable;
@@ -26,6 +25,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
@@ -111,7 +111,7 @@ public class Mqtt3SubAckView implements Mqtt3SubAck {
     }
 
     @Override
-    public @NotNull ImmutableList<Mqtt3SubAckReturnCode> getReturnCodes() {
+    public @NotNull ImmutableList<@NotNull Mqtt3SubAckReturnCode> getReturnCodes() {
         return viewReasonCodes(delegate.getReasonCodes());
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.subscribe.suback.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import io.reactivex.functions.Function;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
@@ -27,6 +26,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -46,8 +46,8 @@ public class Mqtt3SubAckView implements Mqtt3SubAck {
     private static @NotNull ImmutableList<Mqtt5SubAckReasonCode> delegateReturnCodes(
             final @NotNull ImmutableList<Mqtt3SubAckReturnCode> returnCodes) {
 
-        final ImmutableList.Builder<Mqtt5SubAckReasonCode> builder =
-                ImmutableList.builderWithExpectedSize(returnCodes.size());
+        final ImmutableList.Builder<Mqtt5SubAckReasonCode> builder = ImmutableList.builder(returnCodes.size());
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < returnCodes.size(); i++) {
             builder.add(delegateReturnCode(returnCodes.get(i)));
         }
@@ -72,8 +72,8 @@ public class Mqtt3SubAckView implements Mqtt3SubAck {
     private static @NotNull ImmutableList<Mqtt3SubAckReturnCode> viewReasonCodes(
             final @NotNull ImmutableList<Mqtt5SubAckReasonCode> reasonCodes) {
 
-        final ImmutableList.Builder<Mqtt3SubAckReturnCode> builder =
-                ImmutableList.builderWithExpectedSize(reasonCodes.size());
+        final ImmutableList.Builder<Mqtt3SubAckReturnCode> builder = ImmutableList.builder(reasonCodes.size());
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < reasonCodes.size(); i++) {
             builder.add(viewReasonCode(reasonCodes.get(i)));
         }

--- a/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/subscribe/suback/mqtt3/Mqtt3SubAckView.java
@@ -20,14 +20,13 @@ package org.mqttbee.mqtt.message.subscribe.suback.mqtt3;
 import com.google.common.collect.ImmutableList;
 import io.reactivex.functions.Function;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAck;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAckReturnCode;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttStatefulUnsubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttStatefulUnsubscribe.java
@@ -18,9 +18,8 @@
 package org.mqttbee.mqtt.message.unsubscribe;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.mqtt.message.MqttStatefulMessage;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
@@ -19,12 +19,11 @@ package org.mqttbee.mqtt.message.unsubscribe;
 
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
@@ -32,10 +32,10 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class MqttUnsubscribe extends MqttMessageWithUserProperties implements Mqtt5Unsubscribe {
 
-    private final @NotNull ImmutableList<MqttTopicFilterImpl> topicFilters;
+    private final @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> topicFilters;
 
     public MqttUnsubscribe(
-            final @NotNull ImmutableList<MqttTopicFilterImpl> topicFilters,
+            final @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> topicFilters,
             final @NotNull MqttUserPropertiesImpl userProperties) {
 
         super(userProperties);
@@ -43,7 +43,7 @@ public class MqttUnsubscribe extends MqttMessageWithUserProperties implements Mq
     }
 
     @Override
-    public @NotNull ImmutableList<MqttTopicFilterImpl> getTopicFilters() {
+    public @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> getTopicFilters() {
         return topicFilters;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.message.unsubscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -31,10 +31,10 @@ import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
 @Immutable
 public class MqttUnsubscribe extends MqttMessageWithUserProperties implements Mqtt5Unsubscribe {
 
-    private final @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> topicFilters;
+    private final @NotNull ImmutableList<MqttTopicFilterImpl> topicFilters;
 
     public MqttUnsubscribe(
-            final @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> topicFilters,
+            final @NotNull ImmutableList<MqttTopicFilterImpl> topicFilters,
             final @NotNull MqttUserPropertiesImpl userProperties) {
 
         super(userProperties);
@@ -42,7 +42,7 @@ public class MqttUnsubscribe extends MqttMessageWithUserProperties implements Mq
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> getTopicFilters() {
+    public @NotNull ImmutableList<MqttTopicFilterImpl> getTopicFilters() {
         return topicFilters;
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribe.java
@@ -46,6 +46,11 @@ public class MqttUnsubscribe extends MqttMessageWithUserProperties implements Mq
         return topicFilters;
     }
 
+    @Override
+    public @NotNull MqttUnsubscribeBuilder.Default extend() {
+        return new MqttUnsubscribeBuilder.Default(this);
+    }
+
     public @NotNull MqttStatefulUnsubscribe createStateful(final int packetIdentifier) {
         return new MqttStatefulUnsubscribe(this, packetIdentifier);
     }

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
 import org.mqttbee.api.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
-import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.Mqtt5UnsubscribeBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImplBuilder;
@@ -46,9 +45,8 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
         topicFiltersBuilder = ImmutableList.builder();
     }
 
-    MqttUnsubscribeBuilder(final @Nullable Mqtt5Unsubscribe unsubscribe) {
-        final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
-        final ImmutableList<MqttTopicFilterImpl> topicFilters = mqttUnsubscribe.getTopicFilters();
+    MqttUnsubscribeBuilder(final @NotNull MqttUnsubscribe unsubscribe) {
+        final ImmutableList<MqttTopicFilterImpl> topicFilters = unsubscribe.getTopicFilters();
         topicFiltersBuilder = ImmutableList.builder(topicFilters.size() + 1);
         topicFiltersBuilder.addAll(topicFilters);
     }
@@ -111,7 +109,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt5Unsubscribe unsubscribe) {
+        Default(final @NotNull MqttUnsubscribe unsubscribe) {
             super(unsubscribe);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/MqttUnsubscribeBuilder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.unsubscribe;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
@@ -31,6 +30,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImplBuilder;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.util.MqttChecks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.function.Function;
 
@@ -49,7 +49,7 @@ public abstract class MqttUnsubscribeBuilder<B extends MqttUnsubscribeBuilder<B>
     MqttUnsubscribeBuilder(final @Nullable Mqtt5Unsubscribe unsubscribe) {
         final MqttUnsubscribe mqttUnsubscribe = MqttChecks.unsubscribe(unsubscribe);
         final ImmutableList<MqttTopicFilterImpl> topicFilters = mqttUnsubscribe.getTopicFilters();
-        topicFiltersBuilder = ImmutableList.builderWithExpectedSize(topicFilters.size() + 1);
+        topicFiltersBuilder = ImmutableList.builder(topicFilters.size() + 1);
         topicFiltersBuilder.addAll(topicFilters);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
@@ -19,12 +19,11 @@ package org.mqttbee.mqtt.message.unsubscribe.mqtt3;
 
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.message.unsubscribe.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -50,7 +50,7 @@ public class Mqtt3UnsubscribeView implements Mqtt3Unsubscribe {
     }
 
     @Override
-    public @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> getTopicFilters() {
+    public @NotNull ImmutableList<MqttTopicFilterImpl> getTopicFilters() {
         return delegate.getTopicFilters();
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
@@ -57,4 +57,9 @@ public class Mqtt3UnsubscribeView implements Mqtt3Unsubscribe {
     public @NotNull MqttUnsubscribe getDelegate() {
         return delegate;
     }
+
+    @Override
+    public @NotNull Mqtt3UnsubscribeViewBuilder.Default extend() {
+        return new Mqtt3UnsubscribeViewBuilder.Default(this);
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeView.java
@@ -51,7 +51,7 @@ public class Mqtt3UnsubscribeView implements Mqtt3Unsubscribe {
     }
 
     @Override
-    public @NotNull ImmutableList<MqttTopicFilterImpl> getTopicFilters() {
+    public @NotNull ImmutableList<@NotNull MqttTopicFilterImpl> getTopicFilters() {
         return delegate.getTopicFilters();
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.unsubscribe.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
@@ -29,6 +28,7 @@ import org.mqttbee.mqtt.datatypes.MqttTopicFilterImplBuilder;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
 import org.mqttbee.mqtt.util.MqttChecks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.function.Function;
 
@@ -46,7 +46,7 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
     Mqtt3UnsubscribeViewBuilder(final @Nullable Mqtt3Unsubscribe unsubscribe) {
         final MqttUnsubscribe unsubscribeView = MqttChecks.unsubscribe(unsubscribe);
         final ImmutableList<MqttTopicFilterImpl> topicFilters = unsubscribeView.getTopicFilters();
-        topicFiltersBuilder = ImmutableList.builderWithExpectedSize(topicFilters.size() + 1);
+        topicFiltersBuilder = ImmutableList.builder(topicFilters.size() + 1);
         topicFiltersBuilder.addAll(topicFilters);
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
@@ -21,12 +21,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
-import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
 import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.Mqtt3UnsubscribeBuilder;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImpl;
 import org.mqttbee.mqtt.datatypes.MqttTopicFilterImplBuilder;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
-import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.collections.ImmutableList;
 
@@ -43,9 +41,8 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
         topicFiltersBuilder = ImmutableList.builder();
     }
 
-    Mqtt3UnsubscribeViewBuilder(final @Nullable Mqtt3Unsubscribe unsubscribe) {
-        final MqttUnsubscribe unsubscribeView = MqttChecks.unsubscribe(unsubscribe);
-        final ImmutableList<MqttTopicFilterImpl> topicFilters = unsubscribeView.getTopicFilters();
+    Mqtt3UnsubscribeViewBuilder(final @NotNull Mqtt3UnsubscribeView unsubscribe) {
+        final ImmutableList<MqttTopicFilterImpl> topicFilters = unsubscribe.getDelegate().getTopicFilters();
         topicFiltersBuilder = ImmutableList.builder(topicFilters.size() + 1);
         topicFiltersBuilder.addAll(topicFilters);
     }
@@ -99,7 +96,7 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
 
         public Default() {}
 
-        public Default(final @Nullable Mqtt3Unsubscribe unsubscribe) {
+        Default(final @NotNull Mqtt3UnsubscribeView unsubscribe) {
             super(unsubscribe);
         }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAck.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.unsubscribe.unsuback;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mqttbee.annotations.Immutable;
@@ -26,6 +25,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReas
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAck.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAck.java
@@ -20,13 +20,12 @@ package org.mqttbee.mqtt.message.unsubscribe.unsuback;
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.MqttMessageWithUserProperties;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
@@ -19,12 +19,11 @@ package org.mqttbee.mqtt.message.unsubscribe.unsuback.mqtt3;
 
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.unsuback.Mqtt3UnsubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.unsubscribe.unsuback.MqttUnsubAck;
-
-import javax.annotation.concurrent.Immutable;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/mqtt3/Mqtt3UnsubAckView.java
@@ -17,13 +17,13 @@
 
 package org.mqttbee.mqtt.message.unsubscribe.unsuback.mqtt3;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.annotations.Immutable;
 import org.mqttbee.api.mqtt.mqtt3.message.unsubscribe.unsuback.Mqtt3UnsubAck;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReasonCode;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.message.unsubscribe.unsuback.MqttUnsubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl

--- a/src/main/java/org/mqttbee/mqtt/util/MqttChecks.java
+++ b/src/main/java/org/mqttbee/mqtt/util/MqttChecks.java
@@ -20,7 +20,10 @@ package org.mqttbee.mqtt.util;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.mqttbee.api.mqtt.datatypes.*;
+import org.mqttbee.api.mqtt.datatypes.MqttClientIdentifier;
+import org.mqttbee.api.mqtt.datatypes.MqttTopic;
+import org.mqttbee.api.mqtt.datatypes.MqttTopicFilter;
+import org.mqttbee.api.mqtt.datatypes.MqttUtf8String;
 import org.mqttbee.api.mqtt.mqtt3.message.connect.Mqtt3Connect;
 import org.mqttbee.api.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import org.mqttbee.api.mqtt.mqtt3.message.subscribe.Mqtt3Subscribe;
@@ -94,13 +97,6 @@ public class MqttChecks {
     @Contract("null -> fail")
     public static @NotNull MqttTopicFilterImpl topicFilter(final @Nullable MqttTopicFilter topicFilter) {
         return Checks.notImplemented(topicFilter, MqttTopicFilterImpl.class, "Topic filter");
-    }
-
-    @Contract("null -> fail")
-    public static @NotNull MqttSharedTopicFilterImpl sharedTopicFilter(
-            final @Nullable MqttSharedTopicFilter sharedTopicFilter) {
-
-        return Checks.notImplemented(sharedTopicFilter, MqttSharedTopicFilterImpl.class, "Shared topic filter");
     }
 
     @Contract("null -> fail")

--- a/src/main/java/org/mqttbee/mqtt/util/MqttChecks.java
+++ b/src/main/java/org/mqttbee/mqtt/util/MqttChecks.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.util;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -46,9 +45,10 @@ import org.mqttbee.mqtt.message.subscribe.mqtt3.Mqtt3SubscribeView;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
 import org.mqttbee.mqtt.message.unsubscribe.mqtt3.Mqtt3UnsubscribeView;
 import org.mqttbee.util.Checks;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * @author Silvio Giebl
@@ -156,19 +156,19 @@ public class MqttChecks {
     }
 
     @Contract("null -> fail")
-    public static @NotNull MqttUserPropertiesImpl userProperties(final @Nullable Mqtt5UserProperty... userProperties) {
-        Checks.notNull(userProperties, "User properties");
-        final ImmutableList<Mqtt5UserProperty> immutable = ImmutableList.copyOf(userProperties);
+    public static @NotNull MqttUserPropertiesImpl userProperties(
+            final @Nullable Mqtt5UserProperty @Nullable ... userProperties) {
+
+        final ImmutableList<Mqtt5UserProperty> immutable = ImmutableList.copyOf(userProperties, "User properties");
         return MqttUserPropertiesImpl.of(
                 Checks.elementsNotImplemented(immutable, MqttUserPropertyImpl.class, "User property"));
     }
 
     @Contract("null -> fail")
     public static @NotNull MqttUserPropertiesImpl userProperties(
-            final @Nullable List<Mqtt5UserProperty> userProperties) {
+            final @Nullable Collection<@Nullable Mqtt5UserProperty> userProperties) {
 
-        Checks.notNull(userProperties, "User properties");
-        final ImmutableList<Mqtt5UserProperty> immutable = ImmutableList.copyOf(userProperties);
+        final ImmutableList<Mqtt5UserProperty> immutable = ImmutableList.copyOf(userProperties, "User properties");
         return MqttUserPropertiesImpl.of(
                 Checks.elementsNotImplemented(immutable, MqttUserPropertyImpl.class, "User property"));
     }

--- a/src/main/java/org/mqttbee/util/Checks.java
+++ b/src/main/java/org/mqttbee/util/Checks.java
@@ -95,6 +95,17 @@ public class Checks {
         return list;
     }
 
+    public static <T> @NotNull T @NotNull [] elementsNotNull(
+            final @Nullable T @Nullable [] array, final @NotNull String name) {
+
+        notNull(array, name);
+        for (int i = 0; i < array.length; i++) {
+            elementNotNull(array[i], name, i);
+        }
+        //noinspection NullableProblems
+        return array;
+    }
+
     @Contract("null, _, _ -> fail")
     private static void elementNotNull(final @Nullable Object element, final @NotNull String name, final int index) {
         if (element == null) {
@@ -115,7 +126,7 @@ public class Checks {
     public static int unsignedShort(final int value, final @NotNull String name) {
         if (!UnsignedDataTypes.isUnsignedShort(value)) {
             throw new IllegalArgumentException(name + " must not exceed the value range of unsigned short [0, " +
-                    UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE + "], but was: " + value + ".");
+                    UnsignedDataTypes.UNSIGNED_SHORT_MAX_VALUE + "], but was " + value + ".");
         }
         return value;
     }
@@ -123,9 +134,47 @@ public class Checks {
     public static long unsignedInt(final long value, final @NotNull String name) {
         if (!UnsignedDataTypes.isUnsignedInt(value)) {
             throw new IllegalArgumentException(name + " must not exceed the value range of unsigned int [0, " +
-                    UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE + "], but was: " + value + ".");
+                    UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE + "], but was " + value + ".");
         }
         return value;
+    }
+
+    public static int index(final int index, final int size) {
+        if ((index < 0) || (index >= size)) {
+            if (index < 0) {
+                throw new IndexOutOfBoundsException("Index must not be smaller than 0, but was " + index + ".");
+            } else {
+                throw new IndexOutOfBoundsException(
+                        "Index must not be greater than or equal to the size (" + size + "), but was " + index + ".");
+            }
+        }
+        return index;
+    }
+
+    public static int cursorIndex(final int index, final int size) {
+        if ((index < 0) || (index > size)) {
+            if (index < 0) {
+                throw new IndexOutOfBoundsException("Cursor index must not be smaller than 0, but was " + index + ".");
+            } else {
+                throw new IndexOutOfBoundsException(
+                        "Cursor index must not be greater than the size (" + size + "), but was " + index + ".");
+            }
+        }
+        return index;
+    }
+
+    public static void indexRange(final int start, final int end, final int size) {
+        if ((start < 0) || (start > end) || (end > size)) {
+            if (start < 0) {
+                throw new IndexOutOfBoundsException("Start index must not be smaller than 0, but was " + start + ".");
+            } else if (start > end) {
+                throw new IndexOutOfBoundsException(
+                        "Start index must be greater than the end index, but " + start + " > " + end + ".");
+            } else {
+                throw new IndexOutOfBoundsException(
+                        "End index must not be greater than or equal to the size (" + size + "), but was " + end + ".");
+            }
+        }
     }
 
     @Contract("false, _ -> fail")

--- a/src/main/java/org/mqttbee/util/Checks.java
+++ b/src/main/java/org/mqttbee/util/Checks.java
@@ -17,13 +17,10 @@
 
 package org.mqttbee.util;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
-import java.util.RandomAccess;
+import org.mqttbee.util.collections.ImmutableList;
 
 /**
  * @author Silvio Giebl
@@ -74,27 +71,7 @@ public class Checks {
         return (I) object;
     }
 
-    public static <T> @Nullable List<@NotNull T> elementsNotNull(
-            final @Nullable List<@Nullable T> list, final @NotNull String name) {
-
-        if (list == null) {
-            return null;
-        }
-        if (list instanceof RandomAccess) {
-            for (int i = 0; i < list.size(); i++) {
-                elementNotNull(list.get(i), name, i);
-            }
-        } else {
-            int i = 0;
-            for (final T element : list) {
-                elementNotNull(element, name, i);
-                i++;
-            }
-        }
-        //noinspection NullableProblems
-        return list;
-    }
-
+    @Contract("null, _ -> fail")
     public static <T> @NotNull T @NotNull [] elementsNotNull(
             final @Nullable T @Nullable [] array, final @NotNull String name) {
 
@@ -107,17 +84,19 @@ public class Checks {
     }
 
     @Contract("null, _, _ -> fail")
-    private static void elementNotNull(final @Nullable Object element, final @NotNull String name, final int index) {
-        if (element == null) {
+    public static <E> @NotNull E elementNotNull(final @Nullable E e, final @NotNull String name, final int index) {
+        if (e == null) {
             throw new NullPointerException(name + " must not contain a null element, found at index " + index + ".");
         }
+        return e;
     }
 
-    public static <T, I extends T> @NotNull ImmutableList<@NotNull I> elementsNotImplemented(
-            final @NotNull ImmutableList<@Nullable T> list, final @NotNull Class<I> type, final @NotNull String name) {
+    public static <T, I extends T> @NotNull ImmutableList<I> elementsNotImplemented(
+            final @NotNull ImmutableList<T> list, final @NotNull Class<I> type, final @NotNull String name) {
 
+        //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < list.size(); i++) {
-            notImplemented(list.get(i), type, name);
+            notImplementedInternal(list.get(i), type, name);
         }
         //noinspection unchecked
         return (ImmutableList<I>) list;

--- a/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.util.Checks;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+/**
+ * @author Silvio Giebl
+ */
+class ImmutableArray<E> implements ImmutableList<E> {
+
+    @Contract("null -> fail")
+    static <E> @NotNull ImmutableList<@NotNull E> of(final @Nullable Object @Nullable ... elements) {
+        return new ImmutableArray<>(Checks.elementsNotNull(elements, "Immutable list elements"));
+    }
+
+    private final @NotNull Object @NotNull [] array;
+
+    ImmutableArray(final @NotNull Object @NotNull [] array) {
+        this.array = array;
+        assert size() > 1;
+    }
+
+    @Override
+    public int size() {
+        return array.length;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public @NotNull E get(final int index) {
+        //noinspection unchecked
+        return (E) array[Checks.index(index, array.length)];
+    }
+
+    @Override
+    public @NotNull Object @NotNull [] toArray() {
+        return array.clone();
+    }
+
+    @Override
+    public <T> T @NotNull [] toArray(final T @NotNull [] other) {
+        return toArray(array, 0, array.length, other);
+    }
+
+    private static <T> T @NotNull [] toArray(
+            final @NotNull Object @NotNull [] array, final int fromIndex, final int length, T @NotNull [] other) {
+
+        Checks.notNull(other, "Array");
+        if (other.length < length) {
+            //noinspection unchecked
+            other = (T[]) Array.newInstance(other.getClass().getComponentType(), length);
+        } else if (other.length > length) {
+            other[length] = null;
+        }
+        //noinspection SuspiciousSystemArraycopy
+        System.arraycopy(array, fromIndex, other, 0, length);
+        return other;
+    }
+
+    @Override
+    public int indexOf(final @Nullable Object o) {
+        if (o == null) {
+            return -1;
+        }
+        for (int i = 0; i < array.length; i++) {
+            if (o.equals(array[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int lastIndexOf(final @Nullable Object o) {
+        if (o == null) {
+            return -1;
+        }
+        for (int i = array.length - 1; i >= 0; i--) {
+            if (o.equals(array[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public @NotNull ImmutableListIterator<E> listIterator(final int index) {
+        return new ArrayIterator(Checks.cursorIndex(index, array.length));
+    }
+
+    @Override
+    public @NotNull Spliterator<E> spliterator() {
+        return Spliterators.spliterator(array, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
+    }
+
+    @Override
+    public void forEach(final @NotNull Consumer<? super E> consumer) {
+        Checks.notNull(consumer, "Consumer");
+        for (int i = 0; i < array.length; i++) {
+            consumer.accept(get(i));
+        }
+    }
+
+    @Override
+    public @NotNull ImmutableList<E> subList(final int fromIndex, final int toIndex) {
+        Checks.indexRange(fromIndex, toIndex, array.length);
+        final int size = toIndex - fromIndex;
+        switch (size) {
+            case 0:
+                return ImmutableEmptyList.of();
+            case 1:
+                return new ImmutableElement<>(get(fromIndex));
+            default:
+                return (size == array.length) ? this : new SubArray(fromIndex, toIndex);
+        }
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return Arrays.toString(array);
+    }
+
+    private class SubArray implements ImmutableList<E> {
+
+        private final int fromIndex;
+        private final int toIndex;
+
+        SubArray(final int fromIndex, final int toIndex) {
+            this.fromIndex = fromIndex;
+            this.toIndex = toIndex;
+            assert size() > 1;
+            assert size() < ImmutableArray.this.size();
+        }
+
+        @Override
+        public int size() {
+            return toIndex - fromIndex;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public @NotNull E get(final int index) {
+            return ImmutableArray.this.get(fromIndex + index);
+        }
+
+        @Override
+        public @NotNull Object @NotNull [] toArray() {
+            return Arrays.copyOfRange(array, fromIndex, toIndex);
+        }
+
+        @Override
+        public <T> T @NotNull [] toArray(final T @NotNull [] other) {
+            return ImmutableArray.toArray(array, fromIndex, size(), other);
+        }
+
+        @Override
+        public int indexOf(final @Nullable Object o) {
+            if (o == null) {
+                return -1;
+            }
+            for (int i = fromIndex; i < toIndex; i++) {
+                if (o.equals(array[i])) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public int lastIndexOf(final @Nullable Object o) {
+            if (o == null) {
+                return -1;
+            }
+            for (int i = toIndex - 1; i >= fromIndex; i--) {
+                if (o.equals(array[i])) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public @NotNull ImmutableListIterator<E> listIterator(final int index) {
+            return new ArrayIterator(fromIndex, toIndex, Checks.cursorIndex(index, size()));
+        }
+
+        @Override
+        public @NotNull Spliterator<E> spliterator() {
+            return Spliterators.spliterator(
+                    array, fromIndex, toIndex, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
+        }
+
+        @Override
+        public void forEach(final @NotNull Consumer<? super E> consumer) {
+            Checks.notNull(consumer, "Consumer");
+            for (int i = fromIndex; i < toIndex; i++) {
+                consumer.accept(get(i));
+            }
+        }
+
+        @Override
+        public @NotNull ImmutableList<E> subList(final int fromIndex, final int toIndex) {
+            return ImmutableArray.this.subList(this.fromIndex + fromIndex, this.fromIndex + toIndex);
+        }
+
+        @Override
+        public @NotNull ImmutableList<E> trim() {
+            return new ImmutableArray<>(toArray());
+        }
+
+        @Override
+        public @NotNull String toString() {
+            final StringBuilder sb = new StringBuilder().append('[');
+            int i = fromIndex;
+            while (true) {
+                sb.append(array[i++]);
+                if (i == toIndex) {
+                    return sb.append(']').toString();
+                }
+                sb.append(',').append(' ');
+            }
+        }
+    }
+
+    private class ArrayIterator implements ImmutableListIterator<E> {
+
+        private final int fromIndex;
+        private final int toIndex;
+        private int index;
+
+        private ArrayIterator(final int index) {
+            this.fromIndex = 0;
+            this.toIndex = array.length;
+            this.index = index;
+        }
+
+        private ArrayIterator(final int fromIndex, final int toIndex, final int index) {
+            this.fromIndex = fromIndex;
+            this.toIndex = toIndex;
+            this.index = index;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index < toIndex;
+        }
+
+        @Override
+        public @NotNull E next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return get(index++);
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return index > fromIndex;
+        }
+
+        @Override
+        public @NotNull E previous() {
+            if (!hasPrevious()) {
+                throw new NoSuchElementException();
+            }
+            return get(--index);
+        }
+
+        @Override
+        public int nextIndex() {
+            return index;
+        }
+
+        @Override
+        public int previousIndex() {
+            return index - 1;
+        }
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
@@ -24,10 +24,7 @@ import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.NoSuchElementException;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.function.Consumer;
 
 /**
@@ -36,8 +33,13 @@ import java.util.function.Consumer;
 @Immutable class ImmutableArray<E> implements ImmutableList<E> {
 
     @Contract("null -> fail")
-    static <E> @NotNull ImmutableList<@NotNull E> of(final @Nullable Object @Nullable ... elements) {
-        return new ImmutableArray<>(Checks.elementsNotNull(elements, "Immutable list elements"));
+    static <E> @NotNull ImmutableList<E> of(final @Nullable Object @Nullable ... elements) {
+        return of(elements, "Immutable list");
+    }
+
+    @Contract("null, _ -> fail")
+    static <E> @NotNull ImmutableList<E> of(final @Nullable Object @Nullable [] elements, final @NotNull String name) {
+        return new ImmutableArray<>(Checks.elementsNotNull(elements, name));
     }
 
     private final @NotNull Object @NotNull [] array;
@@ -144,6 +146,45 @@ import java.util.function.Consumer;
             default:
                 return (size == array.length) ? this : new SubArray(fromIndex, toIndex);
         }
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof List)) {
+            return false;
+        }
+        final List<?> that = (List<?>) o;
+
+        if (array.length != that.size()) {
+            return false;
+        }
+        if (that instanceof RandomAccess) {
+            for (int i = 0; i < array.length; i++) {
+                if (!array[i].equals(that.get(i))) {
+                    return false;
+                }
+            }
+        } else {
+            int i = 0;
+            for (final Object e : that) {
+                if (!array[i++].equals(e)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        for (final Object e : array) {
+            hashCode = 31 * hashCode + e.hashCode();
+        }
+        return hashCode;
     }
 
     @Override

--- a/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
@@ -20,6 +20,7 @@ package org.mqttbee.util.collections;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.lang.reflect.Array;
@@ -32,7 +33,7 @@ import java.util.function.Consumer;
 /**
  * @author Silvio Giebl
  */
-class ImmutableArray<E> implements ImmutableList<E> {
+@Immutable class ImmutableArray<E> implements ImmutableList<E> {
 
     @Contract("null -> fail")
     static <E> @NotNull ImmutableList<@NotNull E> of(final @Nullable Object @Nullable ... elements) {

--- a/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableArray.java
@@ -156,19 +156,23 @@ import java.util.function.Consumer;
         if (!(o instanceof List)) {
             return false;
         }
-        final List<?> that = (List<?>) o;
+        return equals(array, 0, array.length, (List<?>) o);
+    }
 
-        if (array.length != that.size()) {
+    private static boolean equals(
+            final @NotNull Object[] array, final int fromIndex, final int toIndex, final @NotNull List<?> that) {
+
+        if ((toIndex - fromIndex) != that.size()) {
             return false;
         }
         if (that instanceof RandomAccess) {
-            for (int i = 0; i < array.length; i++) {
+            for (int i = fromIndex; i < toIndex; i++) {
                 if (!array[i].equals(that.get(i))) {
                     return false;
                 }
             }
         } else {
-            int i = 0;
+            int i = fromIndex;
             for (final Object e : that) {
                 if (!array[i++].equals(e)) {
                     return false;
@@ -180,16 +184,32 @@ import java.util.function.Consumer;
 
     @Override
     public int hashCode() {
+        return hashCode(array, 0, array.length);
+    }
+
+    private static int hashCode(final @NotNull Object[] array, final int fromIndex, final int toIndex) {
         int hashCode = 1;
-        for (final Object e : array) {
-            hashCode = 31 * hashCode + e.hashCode();
+        for (int i = fromIndex; i < toIndex; i++) {
+            hashCode = 31 * hashCode + array[i].hashCode();
         }
         return hashCode;
     }
 
     @Override
     public @NotNull String toString() {
-        return Arrays.toString(array);
+        return toString(array, 0, array.length);
+    }
+
+    private static @NotNull String toString(final @NotNull Object[] array, final int fromIndex, final int toIndex) {
+        final StringBuilder sb = new StringBuilder().append('[');
+        int i = fromIndex;
+        while (true) {
+            sb.append(array[i++]);
+            if (i == toIndex) {
+                return sb.append(']').toString();
+            }
+            sb.append(", ");
+        }
     }
 
     private class SubArray implements ImmutableList<E> {
@@ -285,16 +305,24 @@ import java.util.function.Consumer;
         }
 
         @Override
-        public @NotNull String toString() {
-            final StringBuilder sb = new StringBuilder().append('[');
-            int i = fromIndex;
-            while (true) {
-                sb.append(array[i++]);
-                if (i == toIndex) {
-                    return sb.append(']').toString();
-                }
-                sb.append(',').append(' ');
+        public boolean equals(final @Nullable Object o) {
+            if (this == o) {
+                return true;
             }
+            if (!(o instanceof List)) {
+                return false;
+            }
+            return ImmutableArray.equals(array, fromIndex, toIndex, (List<?>) o);
+        }
+
+        @Override
+        public int hashCode() {
+            return ImmutableArray.hashCode(array, fromIndex, toIndex);
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return ImmutableArray.toString(array, fromIndex, toIndex);
         }
     }
 

--- a/src/main/java/org/mqttbee/util/collections/ImmutableElement.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableElement.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.util.Checks;
+
+import java.lang.reflect.Array;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * @author Silvio Giebl
+ */
+class ImmutableElement<E> implements ImmutableList<E> {
+
+    @Contract("null -> fail")
+    static <E> @NotNull ImmutableList<@NotNull E> of(final @Nullable E e) {
+        return new ImmutableElement<>(Checks.notNull(e, "Immutable list element"));
+    }
+
+    private final @NotNull E element;
+
+    ImmutableElement(final @NotNull E element) {
+        this.element = element;
+    }
+
+    @Override
+    public int size() {
+        return 1;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public @NotNull E get(final int index) {
+        Checks.index(index, 1);
+        return element;
+    }
+
+    @Override
+    public @NotNull Object @NotNull [] toArray() {
+        return new Object[]{element};
+    }
+
+    @Override
+    public <T> T @NotNull [] toArray(T @NotNull [] other) {
+        Checks.notNull(other, "Array");
+        if (other.length < 1) {
+            //noinspection unchecked
+            other = (T[]) Array.newInstance(other.getClass().getComponentType(), 1);
+        } else if (other.length > 1) {
+            other[1] = null;
+        }
+        ((Object[]) other)[0] = element;
+        return other;
+    }
+
+    @Override
+    public boolean contains(final @Nullable Object o) {
+        return element.equals(o);
+    }
+
+    @Override
+    public int indexOf(final @Nullable Object o) {
+        return (element.equals(o)) ? 0 : -1;
+    }
+
+    @Override
+    public int lastIndexOf(final @Nullable Object o) {
+        return indexOf(o);
+    }
+
+    @Override
+    public @NotNull ImmutableListIterator<E> listIterator(final int index) {
+        return new ElementIterator(Checks.cursorIndex(index, 1));
+    }
+
+    @Override
+    public @NotNull Spliterator<E> spliterator() {
+        return new ElementSpliterator();
+    }
+
+    @Override
+    public void forEach(final @NotNull Consumer<? super E> consumer) {
+        Checks.notNull(consumer, "Consumer");
+        consumer.accept(element);
+    }
+
+    @Override
+    public @NotNull ImmutableList<E> subList(final int fromIndex, final int toIndex) {
+        Checks.indexRange(fromIndex, toIndex, 1);
+        return (toIndex == fromIndex) ? ImmutableList.of() : this;
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "[" + element + "]";
+    }
+
+    private class ElementIterator implements ImmutableListIterator<E> {
+
+        private int index;
+
+        ElementIterator(final int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index == 0;
+        }
+
+        @Override
+        public @NotNull E next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            index = 1;
+            return element;
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return index == 1;
+        }
+
+        @Override
+        public @NotNull E previous() {
+            if (!hasPrevious()) {
+                throw new NoSuchElementException();
+            }
+            index = 0;
+            return element;
+        }
+
+        @Override
+        public int nextIndex() {
+            return index;
+        }
+
+        @Override
+        public int previousIndex() {
+            return index - 1;
+        }
+
+        @Override
+        public void forEachRemaining(final Consumer<? super E> consumer) {
+            Checks.notNull(consumer, "Consumer");
+            if (hasNext()) {
+                consumer.accept(element);
+                index = 1;
+            }
+        }
+    }
+
+    private class ElementSpliterator implements Spliterator<E> {
+
+        private int size = 1;
+
+        @Override
+        public boolean tryAdvance(final @NotNull Consumer<? super E> consumer) {
+            Checks.notNull(consumer, "Consumer");
+            if (size == 1) {
+                consumer.accept(element);
+                size = 0;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public @Nullable Spliterator<E> trySplit() {
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            return size;
+        }
+
+        @Override
+        public long getExactSizeIfKnown() {
+            return size;
+        }
+
+        @Override
+        public int characteristics() {
+            return Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.IMMUTABLE | Spliterator.NONNULL |
+                    Spliterator.DISTINCT | Spliterator.ORDERED;
+        }
+
+        @Override
+        public void forEachRemaining(final @NotNull Consumer<? super E> consumer) {
+            tryAdvance(consumer);
+        }
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableElement.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableElement.java
@@ -20,6 +20,7 @@ package org.mqttbee.util.collections;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.lang.reflect.Array;
@@ -30,7 +31,7 @@ import java.util.function.Consumer;
 /**
  * @author Silvio Giebl
  */
-class ImmutableElement<E> implements ImmutableList<E> {
+@Immutable class ImmutableElement<E> implements ImmutableList<E> {
 
     @Contract("null -> fail")
     static <E> @NotNull ImmutableList<@NotNull E> of(final @Nullable E e) {

--- a/src/main/java/org/mqttbee/util/collections/ImmutableElement.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableElement.java
@@ -24,6 +24,7 @@ import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.lang.reflect.Array;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -34,8 +35,13 @@ import java.util.function.Consumer;
 @Immutable class ImmutableElement<E> implements ImmutableList<E> {
 
     @Contract("null -> fail")
-    static <E> @NotNull ImmutableList<@NotNull E> of(final @Nullable E e) {
-        return new ImmutableElement<>(Checks.notNull(e, "Immutable list element"));
+    static <E> @NotNull ImmutableList<E> of(final @Nullable E e) {
+        return of(e, "Immutable list");
+    }
+
+    @Contract("null, _ -> fail")
+    static <E> @NotNull ImmutableList<E> of(final @Nullable E e, final @NotNull String name) {
+        return new ImmutableElement<>(Checks.elementNotNull(e, name, 0));
     }
 
     private final @NotNull E element;
@@ -113,6 +119,24 @@ import java.util.function.Consumer;
     public @NotNull ImmutableList<E> subList(final int fromIndex, final int toIndex) {
         Checks.indexRange(fromIndex, toIndex, 1);
         return (toIndex == fromIndex) ? ImmutableList.of() : this;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof List)) {
+            return false;
+        }
+        final List<?> that = (List<?>) o;
+
+        return (that.size() == 1) && element.equals(Builder.first(that));
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 + element.hashCode();
     }
 
     @Override

--- a/src/main/java/org/mqttbee/util/collections/ImmutableEmptyIntList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableEmptyIntList.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
+
+/**
+ * @author Silvio Giebl
+ */
+@Immutable class ImmutableEmptyIntList implements ImmutableIntList {
+
+    public static final @NotNull ImmutableEmptyIntList INSTANCE = new ImmutableEmptyIntList();
+
+    private ImmutableEmptyIntList() {}
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public int get(final int index) {
+        throw new IndexOutOfBoundsException("Empty int list");
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ImmutableIntList)) {
+            return false;
+        }
+        return ((ImmutableIntList) o).size() == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "[]";
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.util.Checks;
+
+import java.util.Collection;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * @author Silvio Giebl
+ */
+class ImmutableEmptyList implements ImmutableList<Object> {
+
+    private static final @NotNull ImmutableEmptyList INSTANCE = new ImmutableEmptyList();
+    private static final @NotNull Object @NotNull [] EMPTY = {};
+
+    static <E> @NotNull ImmutableList<@NotNull E> of() {
+        //noinspection unchecked
+        return (ImmutableList<E>) ImmutableEmptyList.INSTANCE;
+    }
+
+    private ImmutableEmptyList() {}
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public @NotNull Object get(final int index) {
+        throw new IndexOutOfBoundsException(
+                "Index must not be greater than or equal to the size (0), but was " + index + ".");
+    }
+
+    @Override
+    public @NotNull Object @NotNull [] toArray() {
+        return EMPTY;
+    }
+
+    @Override
+    public <T> T @NotNull [] toArray(final T @NotNull [] other) {
+        Checks.notNull(other, "Array");
+        if (other.length > 0) {
+            other[0] = null;
+        }
+        return other;
+    }
+
+    @Override
+    public boolean contains(final @Nullable Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(final @NotNull Collection<?> c) {
+        Checks.notNull(c, "Collection");
+        return c.size() == 0;
+    }
+
+    @Override
+    public int indexOf(final @Nullable Object o) {
+        return -1;
+    }
+
+    @Override
+    public int lastIndexOf(final @Nullable Object o) {
+        return -1;
+    }
+
+    @Override
+    public @NotNull ImmutableListIterator<Object> listIterator(final int index) {
+        Checks.cursorIndex(index, 0);
+        return EmptyIterator.of();
+    }
+
+    @Override
+    public @NotNull Spliterator<Object> spliterator() {
+        return EmptySpliterator.of();
+    }
+
+    @Override
+    public void forEach(final @NotNull Consumer<? super Object> consumer) {
+        Checks.notNull(consumer, "Consumer");
+    }
+
+    @Override
+    public @NotNull ImmutableList<Object> subList(final int fromIndex, final int toIndex) {
+        Checks.indexRange(fromIndex, toIndex, 0);
+        return this;
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "[]";
+    }
+
+    private static class EmptyIterator implements ImmutableListIterator<Object> {
+
+        private static final @NotNull EmptyIterator INSTANCE = new EmptyIterator();
+
+        static <E> @NotNull ImmutableListIterator<E> of() {
+            //noinspection unchecked
+            return (ImmutableListIterator<E>) INSTANCE;
+        }
+
+        private EmptyIterator() {}
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public @NotNull Object next() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return false;
+        }
+
+        @Override
+        public @NotNull Object previous() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public int nextIndex() {
+            return 0;
+        }
+
+        @Override
+        public int previousIndex() {
+            return -1;
+        }
+
+        @Override
+        public void forEachRemaining(final @NotNull Consumer<? super Object> consumer) {
+            Checks.notNull(consumer, "Consumer");
+        }
+    }
+
+    private static class EmptySpliterator implements Spliterator<Object> {
+
+        private static final @NotNull EmptySpliterator INSTANCE = new EmptySpliterator();
+
+        static <E> @NotNull Spliterator<E> of() {
+            //noinspection unchecked
+            return (Spliterator<E>) INSTANCE;
+        }
+
+        private EmptySpliterator() {}
+
+        @Override
+        public boolean tryAdvance(final @NotNull Consumer<? super Object> consumer) {
+            Checks.notNull(consumer, "Consumer");
+            return false;
+        }
+
+        @Override
+        public @Nullable Spliterator<Object> trySplit() {
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            return 0;
+        }
+
+        @Override
+        public long getExactSizeIfKnown() {
+            return 0;
+        }
+
+        @Override
+        public int characteristics() {
+            return Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.IMMUTABLE | Spliterator.NONNULL |
+                    Spliterator.DISTINCT | Spliterator.ORDERED;
+        }
+
+        @Override
+        public void forEachRemaining(final @NotNull Consumer<? super Object> consumer) {
+            Checks.notNull(consumer, "Consumer");
+        }
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
@@ -55,8 +55,7 @@ import java.util.function.Consumer;
 
     @Override
     public @NotNull Object get(final int index) {
-        throw new IndexOutOfBoundsException(
-                "Index must not be greater than or equal to the size (0), but was " + index + ".");
+        throw new IndexOutOfBoundsException("Empty list");
     }
 
     @Override

--- a/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
@@ -19,6 +19,7 @@ package org.mqttbee.util.collections;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.util.Collection;
@@ -29,7 +30,7 @@ import java.util.function.Consumer;
 /**
  * @author Silvio Giebl
  */
-class ImmutableEmptyList implements ImmutableList<Object> {
+@Immutable class ImmutableEmptyList implements ImmutableList<Object> {
 
     private static final @NotNull ImmutableEmptyList INSTANCE = new ImmutableEmptyList();
     private static final @NotNull Object @NotNull [] EMPTY = {};

--- a/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableEmptyList.java
@@ -23,6 +23,7 @@ import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -35,7 +36,7 @@ import java.util.function.Consumer;
     private static final @NotNull ImmutableEmptyList INSTANCE = new ImmutableEmptyList();
     private static final @NotNull Object @NotNull [] EMPTY = {};
 
-    static <E> @NotNull ImmutableList<@NotNull E> of() {
+    static <E> @NotNull ImmutableList<E> of() {
         //noinspection unchecked
         return (ImmutableList<E>) ImmutableEmptyList.INSTANCE;
     }
@@ -113,6 +114,22 @@ import java.util.function.Consumer;
     public @NotNull ImmutableList<Object> subList(final int fromIndex, final int toIndex) {
         Checks.indexRange(fromIndex, toIndex, 0);
         return this;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof List)) {
+            return false;
+        }
+        return ((List<?>) o).size() == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
     }
 
     @Override

--- a/src/main/java/org/mqttbee/util/collections/ImmutableIntArray.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableIntArray.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
+import org.mqttbee.util.Checks;
+
+import java.util.Arrays;
+
+/**
+ * @author Silvio Giebl
+ */
+@Immutable class ImmutableIntArray implements ImmutableIntList {
+
+    private final @NotNull int[] array;
+
+    ImmutableIntArray(final @NotNull int... array) {
+        this.array = array;
+        assert size() > 1;
+    }
+
+    @Override
+    public int size() {
+        return array.length;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public int get(final int index) {
+        return array[Checks.index(index, array.length)];
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ImmutableIntList)) {
+            return false;
+        }
+        if (o instanceof ImmutableIntArray) {
+            return Arrays.equals(array, ((ImmutableIntArray) o).array);
+        }
+        final ImmutableIntList that = (ImmutableIntList) o;
+
+        if (array.length != that.size()) {
+            return false;
+        }
+        for (int i = 0; i < array.length; i++) {
+            if (array[i] != that.get(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(array);
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return Arrays.toString(array);
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableIntElement.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableIntElement.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
+import org.mqttbee.util.Checks;
+
+/**
+ * @author Silvio Giebl
+ */
+@Immutable class ImmutableIntElement implements ImmutableIntList {
+
+    private final int element;
+
+    ImmutableIntElement(final int element) {
+        this.element = element;
+    }
+
+    @Override
+    public int size() {
+        return 1;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public int get(final int index) {
+        Checks.index(index, 1);
+        return element;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ImmutableIntList)) {
+            return false;
+        }
+        final ImmutableIntList that = (ImmutableIntList) o;
+
+        return (that.size() == 0) && (element == that.get(0));
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 + element;
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "[" + element + "]";
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableIntList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableIntList.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.util.Checks;
+
+import java.util.Arrays;
+
+/**
+ * @author Silvio Giebl
+ */
+public interface ImmutableIntList {
+
+    static @NotNull ImmutableIntList of() {
+        return ImmutableEmptyIntList.INSTANCE;
+    }
+
+    static @NotNull ImmutableIntList of(final int i) {
+        return new ImmutableIntElement(i);
+    }
+
+    static @NotNull ImmutableIntList of(final int i1, final int i2) {
+        return new ImmutableIntArray(i1, i2);
+    }
+
+    static @NotNull ImmutableIntList of(final int i1, final int i2, final int i3) {
+        return new ImmutableIntArray(i1, i2, i3);
+    }
+
+    static @NotNull ImmutableIntList of(final int i1, final int i2, final int i3, final @NotNull int... others) {
+        Checks.notNull(others, "Int array");
+        final int[] array = new int[3 + others.length];
+        array[0] = i1;
+        array[0] = i2;
+        array[0] = i3;
+        System.arraycopy(others, 0, array, 3, others.length);
+        return new ImmutableIntArray(array);
+    }
+
+    static @NotNull ImmutableIntList copyOf(final @NotNull int[] array) {
+        Checks.notNull(array, "Int array");
+        switch (array.length) {
+            case 0:
+                return ImmutableEmptyIntList.INSTANCE;
+            case 1:
+                return new ImmutableIntElement(array[0]);
+            default:
+                return new ImmutableIntArray(array.clone());
+        }
+    }
+
+    static @NotNull Builder builder() {
+        return new Builder();
+    }
+
+    static @NotNull Builder builder(final int capacity) {
+        return new Builder(capacity);
+    }
+
+    int size();
+
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+
+    int get(int index);
+
+    class Builder {
+
+        private static final int INITIAL_CAPACITY = 4;
+
+        private int i;
+        private @Nullable int[] array;
+        private int size;
+
+        private Builder() {}
+
+        private Builder(final int capacity) {
+            if (capacity > 1) {
+                array = new int[capacity];
+            }
+        }
+
+        private int newCapacity(final int capacity) {
+            return capacity + (capacity >> 1);
+        }
+
+        public @NotNull Builder add(final int i) {
+            if (size == 0) {
+                this.i = i;
+            } else {
+                if (array == null) {
+                    array = new int[INITIAL_CAPACITY];
+                } else if (size == array.length) {
+                    array = Arrays.copyOf(array, newCapacity(array.length));
+                }
+                if (size == 1) {
+                    array[0] = this.i;
+                }
+                array[size++] = i;
+            }
+            return this;
+        }
+
+        public @NotNull ImmutableIntList build() {
+            switch (size) {
+                case 0:
+                    return ImmutableEmptyIntList.INSTANCE;
+                case 1:
+                    return new ImmutableIntElement(i);
+                default:
+                    assert array != null;
+                    if (array.length == size) {
+                        return new ImmutableIntArray(array);
+                    }
+                    return new ImmutableIntArray(Arrays.copyOfRange(array, 0, size));
+            }
+        }
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableIntList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableIntList.java
@@ -105,6 +105,7 @@ public interface ImmutableIntList {
         public @NotNull Builder add(final int i) {
             if (size == 0) {
                 this.i = i;
+                size = 1;
             } else {
                 if (array == null) {
                     array = new int[INITIAL_CAPACITY];

--- a/src/main/java/org/mqttbee/util/collections/ImmutableList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableList.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.util.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.mqttbee.util.Checks;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * @author Silvio Giebl
+ */
+public interface ImmutableList<E> extends List<E>, RandomAccess {
+
+    static <E> @NotNull ImmutableList<@NotNull E> of() {
+        return ImmutableEmptyList.of();
+    }
+
+    static <E> @NotNull ImmutableList<@NotNull E> of(final @NotNull E e) {
+        return ImmutableElement.of(e);
+    }
+
+    static <E> @NotNull ImmutableList<@NotNull E> of(final @NotNull E e1, final @NotNull E e2) {
+        return ImmutableArray.of(e1, e2);
+    }
+
+    static <E> @NotNull ImmutableList<@NotNull E> of(final @NotNull E e1, final @NotNull E e2, final @NotNull E e3) {
+        return ImmutableArray.of(e1, e2, e3);
+    }
+
+    static <E> @NotNull ImmutableList<@NotNull E> copyOf(final @NotNull E @NotNull [] elements) {
+        Checks.notNull(elements, "Immutable list elements");
+        switch (elements.length) {
+            case 0:
+                return ImmutableEmptyList.of();
+            case 1:
+                return ImmutableElement.of(elements[0]);
+            default:
+                return ImmutableArray.of(Arrays.copyOf(elements, elements.length, Object[].class));
+        }
+    }
+
+    static <E> @NotNull ImmutableList<@NotNull E> copyOf(final @NotNull Collection<? extends @NotNull E> elements) {
+        Checks.notNull(elements, "Immutable list elements");
+        if (elements instanceof ImmutableList) {
+            //noinspection unchecked
+            return ((ImmutableList<E>) elements).trim();
+        }
+        switch (elements.size()) {
+            case 0:
+                return ImmutableEmptyList.of();
+            case 1:
+                //noinspection unchecked
+                return ImmutableElement.of((elements instanceof List) ? ((List<? extends E>) elements).get(0) :
+                        elements.iterator().next());
+            default:
+                return ImmutableArray.of(elements.toArray());
+        }
+    }
+
+    static <E> @NotNull Builder<E> builder() {
+        return new Builder<>();
+    }
+
+    static <E> @NotNull Builder<E> builder(final int capacity) {
+        return new Builder<>(capacity);
+    }
+
+    @Override
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    @NotNull E get(int index);
+
+    @Override
+    default boolean contains(final @Nullable Object o) {
+        return indexOf(o) >= 0;
+    }
+
+    @Override
+    default boolean containsAll(final @NotNull Collection<?> c) {
+        Checks.notNull(c, "Collection");
+        for (final Object o : c) {
+            if (!contains(o)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    default @NotNull ImmutableListIterator<E> iterator() {
+        return listIterator();
+    }
+
+    @Override
+    default @NotNull ImmutableListIterator<E> listIterator() {
+        return listIterator(0);
+    }
+
+    @Override
+    @NotNull ImmutableListIterator<E> listIterator(int index);
+
+    @Override
+    @NotNull ImmutableList<E> subList(int fromIndex, int toIndex);
+
+    default @NotNull ImmutableList<E> trim() {
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    default boolean add(final @Nullable E e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default boolean remove(final @Nullable Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default boolean addAll(final @NotNull Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default boolean removeAll(final @NotNull Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default boolean retainAll(final @NotNull Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default boolean removeIf(final @NotNull Predicate<? super E> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default void add(final int index, final @Nullable E element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default @Nullable E remove(final int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default @Nullable E set(final int index, final @Nullable E element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default boolean addAll(final int index, final @NotNull Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default void replaceAll(final @NotNull UnaryOperator<E> operator) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    default void sort(final Comparator<? super E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    interface ImmutableListIterator<E> extends ListIterator<E> {
+
+        @Override
+        @Deprecated
+        default void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        default void set(final @Nullable E e) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        default void add(final @Nullable E e) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    class Builder<E> {
+
+        private @Nullable E e;
+        private @NotNull Object @Nullable [] elements;
+        private int size;
+
+        private Builder() {}
+
+        private Builder(final int capacity) {
+            if (capacity > 1) {
+                elements = new Object[capacity];
+            }
+        }
+
+        public @NotNull Builder<E> add(final @NotNull E e) {
+            Checks.notNull(e, "Immutable list element");
+            if (this.e == null) {
+                this.e = e;
+                size = 1;
+            } else {
+                if (elements == null) {
+                    elements = new Object[4];
+                } else if (elements.length == size) {
+                    final int newLength = elements.length + (elements.length >> 1);
+                    elements = Arrays.copyOf(elements, newLength, Object[].class);
+                }
+                if (size == 1) {
+                    elements[0] = this.e;
+                }
+                elements[size++] = e;
+            }
+            return this;
+        }
+
+        public @NotNull ImmutableList<@NotNull E> build() {
+            if (e == null) {
+                return ImmutableEmptyList.of();
+            }
+            if (elements == null) {
+                return new ImmutableElement<>(e);
+            }
+            if (elements.length == size) {
+                return new ImmutableArray<>(elements);
+            }
+            return new ImmutableArray<>(Arrays.copyOfRange(elements, 0, size, Object[].class));
+        }
+    }
+}

--- a/src/main/java/org/mqttbee/util/collections/ImmutableList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableList.java
@@ -31,7 +31,7 @@ import java.util.function.UnaryOperator;
  * @author Silvio Giebl
  */
 @Immutable
-public interface ImmutableList<E> extends List<@NotNull E>, RandomAccess {
+public interface ImmutableList<@NotNull E> extends List<E>, RandomAccess {
 
     static <E> @NotNull ImmutableList<E> of() {
         return ImmutableEmptyList.of();

--- a/src/main/java/org/mqttbee/util/collections/ImmutableList.java
+++ b/src/main/java/org/mqttbee/util/collections/ImmutableList.java
@@ -19,6 +19,7 @@ package org.mqttbee.util.collections;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.annotations.Immutable;
 import org.mqttbee.util.Checks;
 
 import java.util.*;
@@ -28,6 +29,7 @@ import java.util.function.UnaryOperator;
 /**
  * @author Silvio Giebl
  */
+@Immutable
 public interface ImmutableList<E> extends List<E>, RandomAccess {
 
     static <E> @NotNull ImmutableList<@NotNull E> of() {

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5AuthDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.auth.MqttAuth;
 import org.mqttbee.mqtt.netty.ChannelAttributes;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 
@@ -1008,5 +1008,4 @@ class Mqtt5AuthDecoderTest extends AbstractMqtt5DecoderTest {
         assertEquals(reasonCode, disconnect.getReasonCode());
         assertEquals(sendReasonString, disconnect.getReasonString().isPresent());
     }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5ConnAckDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -37,6 +36,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.connect.connack.MqttConnAck;
 import org.mqttbee.mqtt.message.connect.connack.MqttConnAckRestrictions;
 import org.mqttbee.mqtt.netty.ChannelAttributes;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 
@@ -2106,5 +2106,4 @@ class Mqtt5ConnAckDecoderTest extends AbstractMqtt5DecoderTest {
             //     auth data
             0x16, 0, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
     };
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5DisconnectDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -30,6 +29,7 @@ import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.disconnect.MqttDisconnect;
 import org.mqttbee.mqtt.netty.ChannelAttributes;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -882,5 +882,4 @@ class Mqtt5DisconnectDecoderTest extends AbstractMqtt5DecoderTest {
             //     server reference
             0x1C, 0, 9, 'r', 'e', 'f', 'e', 'r', 'e', 'n', 'c', 'e'
     };
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubAckDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -31,6 +30,7 @@ import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.publish.puback.MqttPubAck;
 import org.mqttbee.mqtt.netty.ChannelAttributes;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -826,5 +826,4 @@ class Mqtt5PubAckDecoderTest extends AbstractMqtt5DecoderTest {
             0x26, 0, 4, 't', 'e', 's', 't', 0, 6, 'v', 'a', 'l', 'u', 'e', '2', //
             0x26, 0, 5, 't', 'e', 's', 't', '2', 0, 5, 'v', 'a', 'l', 'u', 'e'
     };
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubCompDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -31,6 +30,7 @@ import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.publish.pubcomp.MqttPubComp;
 import org.mqttbee.mqtt.netty.ChannelAttributes;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -826,5 +826,4 @@ class Mqtt5PubCompDecoderTest extends AbstractMqtt5DecoderTest {
             0x26, 0, 4, 't', 'e', 's', 't', 0, 6, 'v', 'a', 'l', 'u', 'e', '2', //
             0x26, 0, 5, 't', 'e', 's', 't', '2', 0, 5, 'v', 'a', 'l', 'u', 'e'
     };
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRecDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +30,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrec.Mqtt5PubRecReasonCode;
 import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.publish.pubrec.MqttPubRec;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.Assert.*;
 import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode.MALFORMED_PACKET;
@@ -426,5 +426,4 @@ class Mqtt5PubRecDecoderTest extends AbstractMqtt5DecoderTest {
 
         return channel.readInbound();
     }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PubRelDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +30,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.publish.pubrel.Mqtt5PubRelReasonCode;
 import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.publish.pubrel.MqttPubRel;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode.MALFORMED_PACKET;
@@ -366,5 +366,4 @@ class Mqtt5PubRelDecoderTest extends AbstractMqtt5DecoderTest {
 
         return channel.readInbound();
     }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.collections.ImmutableIntList;
 import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
@@ -95,9 +95,9 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
         assertEquals(12, publishInternal.getPacketIdentifier());
         assertEquals(3, publishInternal.getTopicAlias());
 
-        final ImmutableIntArray subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
-        assertEquals(1, subscriptionIdentifiers.length());
-        assertTrue(subscriptionIdentifiers.contains(123));
+        final ImmutableIntList subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
+        assertEquals(1, subscriptionIdentifiers.size());
+        assertEquals(123, subscriptionIdentifiers.get(0));
 
         final MqttPublish publish = publishInternal.stateless();
 
@@ -150,8 +150,8 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
 
         assertEquals(false, publishInternal.isDup());
 
-        final ImmutableIntArray subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
-        assertEquals(0, subscriptionIdentifiers.length());
+        final ImmutableIntList subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
+        assertEquals(0, subscriptionIdentifiers.size());
 
         final MqttPublish publish = publishInternal.stateless();
 
@@ -560,9 +560,9 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
                 0x01, 0
         };
         final MqttStatefulPublish publishInternal = decodeInternal(encoded);
-        final ImmutableIntArray subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
-        assertEquals(1, subscriptionIdentifiers.length());
-        assertTrue(subscriptionIdentifiers.contains(123));
+        final ImmutableIntList subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
+        assertEquals(1, subscriptionIdentifiers.size());
+        assertEquals(123, subscriptionIdentifiers.get(0));
     }
 
     @Test
@@ -632,9 +632,9 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
                 0x01, 0
         };
         final MqttStatefulPublish publishInternal = decodeInternal(encoded);
-        final ImmutableIntArray subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
-        assertEquals(1, subscriptionIdentifiers.length());
-        assertTrue(subscriptionIdentifiers.contains(268435455));
+        final ImmutableIntList subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
+        assertEquals(1, subscriptionIdentifiers.size());
+        assertEquals(268435455, subscriptionIdentifiers.get(0));
     }
 
     @Test
@@ -660,10 +660,10 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
                 0x01, 0
         };
         final MqttStatefulPublish publishInternal = decodeInternal(encoded);
-        final ImmutableIntArray subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
-        assertEquals(2, subscriptionIdentifiers.length());
-        assertTrue(subscriptionIdentifiers.contains(128));
-        assertTrue(subscriptionIdentifiers.contains(16));
+        final ImmutableIntList subscriptionIdentifiers = publishInternal.getSubscriptionIdentifiers();
+        assertEquals(2, subscriptionIdentifiers.size());
+        assertEquals(128, subscriptionIdentifiers.get(0));
+        assertEquals(16, subscriptionIdentifiers.get(1));
     }
 
     @Test

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5PublishDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +32,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
 import org.mqttbee.util.ByteBufferUtil;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -1245,5 +1245,4 @@ class Mqtt5PublishDecoderTest extends AbstractMqtt5DecoderTest {
 
         createChannel();
     }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5SubAckDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +30,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode
 import org.mqttbee.mqtt.codec.decoder.MqttMessageDecoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.message.subscribe.suback.MqttSubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mqttbee.api.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode.MALFORMED_PACKET;
@@ -474,5 +474,4 @@ class Mqtt5SubAckDecoderTest extends AbstractMqtt5DecoderTest {
 
         return channel.readInbound();
     }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/decoder/mqtt5/Mqtt5UnsubAckDecoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.decoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -221,7 +220,7 @@ class Mqtt5UnsubAckDecoderTest extends AbstractMqtt5DecoderTest {
 
         final Mqtt5UnsubAck unsuback = decodeOk(encoded);
         assertNotNull(unsuback);
-        final ImmutableList<? extends Mqtt5UserProperty> userProperties = unsuback.getUserProperties().asList();
+        final List<? extends Mqtt5UserProperty> userProperties = unsuback.getUserProperties().asList();
         assertEquals(1, userProperties.size());
         assertEquals("name", userProperties.get(0).getName().toString());
         assertEquals("value", userProperties.get(0).getValue().toString());

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderWithUserPropertiesTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/AbstractMqtt5EncoderWithUserPropertiesTest.java
@@ -17,12 +17,12 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.mqttbee.mqtt.codec.encoder.MqttMessageEncoders;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.Arrays;
 
@@ -51,7 +51,7 @@ abstract class AbstractMqtt5EncoderWithUserPropertiesTest extends AbstractMqtt5E
     }
 
     @NotNull MqttUserPropertiesImpl getUserProperties(final int totalCount) {
-        final ImmutableList.Builder<MqttUserPropertyImpl> builder = new ImmutableList.Builder<>();
+        final ImmutableList.Builder<MqttUserPropertyImpl> builder = ImmutableList.builder();
         for (int i = 0; i < totalCount; i++) {
             builder.add(userProperty);
         }
@@ -80,7 +80,7 @@ abstract class AbstractMqtt5EncoderWithUserPropertiesTest extends AbstractMqtt5E
 
             maxUserPropertyCount = maxPropertyLength / userPropertyBytes;
 
-            userPropertiesBuilder = new ImmutableList.Builder<>();
+            userPropertiesBuilder = ImmutableList.builder();
             final MqttUserPropertyImpl userProperty = new MqttUserPropertyImpl(user, property);
             for (int i = 0; i < maxUserPropertyCount; i++) {
                 userPropertiesBuilder.add(userProperty);

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5AuthEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.EncoderException;
@@ -34,6 +33,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.auth.MqttAuth;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -276,7 +276,7 @@ class Mqtt5AuthEncoderTest extends AbstractMqtt5EncoderTest {
             Arrays.fill(reasonStringBytes, 'r');
 
             final int numberOfUserProperties = maxPropertyLength / userPropertyBytes;
-            userPropertiesBuilder = new ImmutableList.Builder<>();
+            userPropertiesBuilder = ImmutableList.builder();
             for (int i = 0; i < numberOfUserProperties; i++) {
                 userPropertiesBuilder.add(userProperty);
             }
@@ -288,7 +288,7 @@ class Mqtt5AuthEncoderTest extends AbstractMqtt5EncoderTest {
         }
 
         MqttUserPropertiesImpl getUserProperties(final int totalCount) {
-            final ImmutableList.Builder<MqttUserPropertyImpl> builder = new ImmutableList.Builder<>();
+            final ImmutableList.Builder<MqttUserPropertyImpl> builder = ImmutableList.builder();
             for (int i = 0; i < totalCount; i++) {
                 builder.add(userProperty);
             }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5ConnectEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.handler.codec.EncoderException;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Disabled;
@@ -43,6 +42,7 @@ import org.mqttbee.mqtt.message.connect.MqttConnect;
 import org.mqttbee.mqtt.message.connect.MqttConnectRestrictions;
 import org.mqttbee.mqtt.message.connect.MqttStatefulConnect;
 import org.mqttbee.mqtt.message.publish.MqttWillPublish;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -550,7 +550,7 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
             Arrays.fill(clientIdBytes, 'c');
 
             final int numberOfUserProperties = maxPropertyLength / userPropertyBytes;
-            userPropertiesBuilder = new ImmutableList.Builder<>();
+            userPropertiesBuilder = ImmutableList.builder();
             for (int i = 0; i < numberOfUserProperties; i++) {
                 userPropertiesBuilder.add(userProperty);
             }
@@ -578,7 +578,7 @@ class Mqtt5ConnectEncoderTest extends AbstractMqtt5EncoderTest {
         }
 
         @NotNull MqttUserPropertiesImpl getUserProperties(final int totalCount) {
-            final ImmutableList.Builder<MqttUserPropertyImpl> builder = new ImmutableList.Builder<>();
+            final ImmutableList.Builder<MqttUserPropertyImpl> builder = ImmutableList.builder();
             for (int i = 0; i < totalCount; i++) {
                 builder.add(userProperty);
             }

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5DisconnectEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5DisconnectEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.jetbrains.annotations.NotNull;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.disconnect.MqttDisconnect;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubAckEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PubAckEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.jetbrains.annotations.NotNull;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.datatypes.MqttVariableByteInteger;
 import org.mqttbee.mqtt.message.publish.puback.MqttPubAck;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.mqttbee.mqtt.datatypes.MqttVariableByteInteger.MAXIMUM_PACKET_SIZE_LIMIT;

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.jetbrains.annotations.NotNull;
@@ -32,6 +31,7 @@ import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttPublishProperty;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
+import org.mqttbee.util.collections.ImmutableIntList;
 import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mqttbee.api.mqtt.mqtt5.message.publish.Mqtt5Publish.DEFAULT_TOPIC_ALIAS_USAGE;
 import static org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl.NO_USER_PROPERTIES;
+import static org.mqttbee.mqtt.message.publish.MqttStatefulPublish.DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS;
 import static org.mqttbee.mqtt.message.publish.MqttStatefulPublish.DEFAULT_NO_TOPIC_ALIAS;
 
 /**
@@ -98,7 +99,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
                         MqttUtf8StringImpl.of("myContentType"), MqttTopicImpl.of("responseTopic"),
                         ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}), TopicAliasUsage.NO, userProperties);
 
-        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -126,7 +127,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
                         Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, TopicAliasUsage.NO,
                         NO_USER_PROPERTIES);
 
-        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -149,7 +150,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_MOST_ONCE, true,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, false, ImmutableIntArray.of());
+        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, false, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -174,7 +175,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, true, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, true, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -199,7 +200,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -224,7 +225,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 17, true, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 17, true, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -249,7 +250,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UTF_8, null, null, null, TopicAliasUsage.NO,
                 NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -275,7 +276,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false, 1000,
                 Mqtt5PayloadFormatIndicator.UTF_8, null, null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -302,7 +303,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UTF_8,
                 MqttUtf8StringImpl.of("myContentType"), null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -329,7 +330,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UTF_8, null,
                 MqttTopicImpl.of("responseTopic"), null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -357,7 +358,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UTF_8, null, null, correlationData,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -382,7 +383,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null, TopicAliasUsage.IF_AVAILABLE,
                 NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, 8, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, 8, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -404,7 +405,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -426,7 +427,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null, DEFAULT_TOPIC_ALIAS_USAGE, NO_USER_PROPERTIES);
-        encode(expected, publish, 2, true, ImmutableIntArray.of());
+        encode(expected, publish, 2, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -451,7 +452,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null, TopicAliasUsage.IF_AVAILABLE,
                 NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, 8, false, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, 8, false, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -481,7 +482,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UTF_8, null, null, null, TopicAliasUsage.NO,
                 userProperties);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -505,7 +506,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of(3));
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntList.of(3));
     }
 
     @Test
@@ -531,7 +532,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttPublish publish = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, null, null, null, null, TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of(3, 4));
+        encode(expected, publish, 15, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntList.of(3, 4));
     }
 
     @Test
@@ -587,17 +588,17 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
         final MqttPublish publishQos0 = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_MOST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expectedQos0, publishQos0, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expectedQos0, publishQos0, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
 
         final MqttPublish publishQos1 = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.AT_LEAST_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expectedQos1, publishQos1, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expectedQos1, publishQos1, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
 
         final MqttPublish publishQos2 = new MqttPublish(MqttTopicImpl.of("topic"), null, MqttQos.EXACTLY_ONCE, false,
                 MqttPublish.NO_MESSAGE_EXPIRY, Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null,
                 TopicAliasUsage.NO, NO_USER_PROPERTIES);
-        encode(expectedQos2, publishQos2, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expectedQos2, publishQos2, 7, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -611,7 +612,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
 
         final MqttStatefulPublish publishInternal =
                 publish.createStateful(-1, false, MqttStatefulPublish.DEFAULT_NO_TOPIC_ALIAS, false,
-                        ImmutableIntArray.of());
+                        DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
 
         final Throwable exception = assertThrows(MqttMaximumPacketSizeExceededException.class,
                 () -> channel.writeOutbound(publishInternal));
@@ -648,7 +649,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
                         MqttQos.AT_MOST_ONCE, false, MqttPublish.NO_MESSAGE_EXPIRY,
                         Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, null, TopicAliasUsage.NO, userProperties);
 
-        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected, publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
     }
 
     @Test
@@ -695,13 +696,13 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
                         Mqtt5PayloadFormatIndicator.UNSPECIFIED, null, null, correlationData, TopicAliasUsage.NO,
                         userProperties);
 
-        encode(expected.array(), publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, ImmutableIntArray.of());
+        encode(expected.array(), publish, -1, false, DEFAULT_NO_TOPIC_ALIAS, true, DEFAULT_NO_SUBSCRIPTION_IDENTIFIERS);
         expected.release();
     }
 
     private void encode(
             final @NotNull byte[] expected, final @NotNull MqttPublish publish, final int packetIdentifier,
-            final boolean isDup, final @NotNull ImmutableIntArray subscriptionIdentifiers) {
+            final boolean isDup, final @NotNull ImmutableIntList subscriptionIdentifiers) {
         final MqttStatefulPublish publishInternal =
                 publish.createStateful(packetIdentifier, isDup, DEFAULT_NO_TOPIC_ALIAS, false, subscriptionIdentifiers);
         encodeInternal(expected, publishInternal);
@@ -710,7 +711,7 @@ class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTest
     private void encode(
             final @NotNull byte[] expected, final @NotNull MqttPublish publish, final int packetIdentifier,
             final boolean isDup, final int topicAlias, final boolean isNewTopicAlias,
-            final @NotNull ImmutableIntArray subscriptionIdentifiers) {
+            final @NotNull ImmutableIntList subscriptionIdentifiers) {
         final MqttStatefulPublish publishInternal =
                 publish.createStateful(packetIdentifier, isDup, topicAlias, isNewTopicAlias, subscriptionIdentifiers);
         encodeInternal(expected, publishInternal);

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -33,6 +32,7 @@ import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.publish.MqttPublish;
 import org.mqttbee.mqtt.message.publish.MqttPublishProperty;
 import org.mqttbee.mqtt.message.publish.MqttStatefulPublish;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.ByteBuffer;
 

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5SubscribeEncoderTest.java
@@ -17,8 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,6 +34,7 @@ import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
 import org.mqttbee.mqtt.message.subscribe.MqttStatefulSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -356,10 +355,11 @@ class Mqtt5SubscribeEncoderTest extends AbstractMqtt5EncoderWithUserPropertiesTe
                 (new MqttSubscription(leftoverTopicFilter, qos, DEFAULT_NO_LOCAL, DEFAULT_RETAIN_HANDLING,
                         DEFAULT_RETAIN_AS_PUBLISHED)));
 
-        final Iterable<MqttSubscription> subscriptions = Iterables.concat(maxSizeSubscriptions, leftoverSubscription);
+        final ImmutableList.Builder<MqttSubscription> subscriptionsBuilder = ImmutableList.builder();
+        final ImmutableList<MqttSubscription> subscriptions =
+                subscriptionsBuilder.addAll(maxSizeSubscriptions).addAll(leftoverSubscription).build();
 
-        final MqttSubscribe subscribe =
-                new MqttSubscribe(ImmutableList.copyOf(subscriptions), MqttUserPropertiesImpl.NO_USER_PROPERTIES);
+        final MqttSubscribe subscribe = new MqttSubscribe(subscriptions, MqttUserPropertiesImpl.NO_USER_PROPERTIES);
 
         final int packetIdentifier = 2;
         final MqttStatefulSubscribe subscribeInternal =

--- a/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoderTest.java
+++ b/src/test/java/org/mqttbee/mqtt/codec/encoder/mqtt5/Mqtt5UnsubscribeEncoderTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.codec.encoder.mqtt5;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mqttbee.api.mqtt.exceptions.MqttMaximumPacketSizeExceededException;
@@ -26,6 +25,7 @@ import org.mqttbee.mqtt.codec.encoder.MqttMessageEncoders;
 import org.mqttbee.mqtt.datatypes.*;
 import org.mqttbee.mqtt.message.unsubscribe.MqttStatefulUnsubscribe;
 import org.mqttbee.mqtt.message.unsubscribe.MqttUnsubscribe;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -211,7 +211,7 @@ class Mqtt5UnsubscribeEncoderTest extends AbstractMqtt5EncoderTest {
             }
 
             final int numberOfUserProperties = maxPropertyLength / userPropertyBytes;
-            userPropertiesBuilder = new ImmutableList.Builder<>();
+            userPropertiesBuilder = ImmutableList.builder();
             final MqttUserPropertyImpl userProperty = new MqttUserPropertyImpl(user, property);
             for (int i = 0; i < numberOfUserProperties; i++) {
                 userPropertiesBuilder.add(userProperty);

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImplTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.hamcrest.CoreMatchers;
@@ -29,6 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttSharedTopicFilterImplTest.java
@@ -120,7 +120,6 @@ class MqttSharedTopicFilterImplTest {
 
         final IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
                 () -> from(SharedTopicFilterSource.STRING, sharedTopicFilter));
-        System.out.println(exception.getMessage());
         assertTrue("IllegalArgumentException must give hint that " + message, exception.getMessage().contains(message));
     }
 
@@ -188,7 +187,6 @@ class MqttSharedTopicFilterImplTest {
 
         final IllegalArgumentException exception =
                 Assertions.assertThrows(IllegalArgumentException.class, () -> from(source, shareName, topicFilter));
-        System.out.println(exception.getMessage());
         assertTrue("IllegalArgumentException must give hint that " + message, exception.getMessage().contains(message));
     }
 

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicFilterImplTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.hamcrest.CoreMatchers;
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttTopicImplTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mqttbee.util.collections.ImmutableList;
 
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttUserPropertiesImplTest.java
@@ -17,11 +17,11 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 import org.mqttbee.mqtt.message.MqttProperty;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -95,5 +95,4 @@ class MqttUserPropertiesImplTest {
 
         assertEquals(27, userProperties.encodedLength());
     }
-
 }

--- a/src/test/java/org/mqttbee/mqtt/datatypes/MqttUtf8StringImplTest.java
+++ b/src/test/java/org/mqttbee/mqtt/datatypes/MqttUtf8StringImplTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.datatypes;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Utf8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -29,6 +28,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -159,7 +159,7 @@ class MqttUtf8StringImplTest {
                 assertNotNull(string);
                 assertTrue(string.containsShouldNotCharacters());
 
-                final byte[] nonCharacterBinary = nonCharacterString.getBytes(Charsets.UTF_8);
+                final byte[] nonCharacterBinary = nonCharacterString.getBytes(StandardCharsets.UTF_8);
                 final byte[] binary = new byte[6 + nonCharacterBinary.length];
                 binary[0] = 'a';
                 binary[1] = 'b';

--- a/src/test/java/org/mqttbee/mqtt/handler/ssl/SslUtilTest.java
+++ b/src/test/java/org/mqttbee/mqtt/handler/ssl/SslUtilTest.java
@@ -16,12 +16,12 @@
 
 package org.mqttbee.mqtt.handler.ssl;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.mqttbee.mqtt.MqttClientSslConfigImplBuilder;
+import org.mqttbee.util.collections.ImmutableList;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;

--- a/src/test/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAckTest.java
+++ b/src/test/java/org/mqttbee/mqtt/message/unsubscribe/unsuback/MqttUnsubAckTest.java
@@ -17,7 +17,6 @@
 
 package org.mqttbee.mqtt.message.unsubscribe.unsuback;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
@@ -25,6 +24,7 @@ import org.mqttbee.api.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReas
 import org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl;
 import org.mqttbee.mqtt.datatypes.MqttUserPropertyImpl;
 import org.mqttbee.mqtt.datatypes.MqttUtf8StringImpl;
+import org.mqttbee.util.collections.ImmutableList;
 
 import static org.junit.Assert.*;
 import static org.mqttbee.mqtt.datatypes.MqttUserPropertiesImpl.NO_USER_PROPERTIES;


### PR DESCRIPTION
**Motivation**
No specific `List` implementation should be exposed in the API.
As we only use few classes of guava, the dependency should be removed.

**Changes**
* Exposed only `List` with `@Immutable` annotation
* Replaced guava `ImmutableList` with own implementation
* Replaced guava `ImmutableIntArray` (marked as Beta anyway) with own `ImmutableIntList`

IMPORTANT: for review only, must not be merged before PR #211 , base branch must be changed