### PR TITLE
Replaced Send<Void> with SendVoid builder

### DIFF
--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3BlockingClient.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/Mqtt3BlockingClient.java
@@ -122,17 +122,14 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
     /**
      * Fluent counterpart of {@link #unsubscribe(Mqtt3Unsubscribe)}.
      * <p>
-     * Calling {@link Mqtt3UnsubscribeBuilder.Send.Complete#send()} on the returned builder has the same effect as
+     * Calling {@link Mqtt3UnsubscribeBuilder.SendVoid.Complete#send()} on the returned builder has the same effect as
      * calling {@link #unsubscribe(Mqtt3Unsubscribe)} with the result of {@link Mqtt3UnsubscribeBuilder.Complete#build()}.
      *
      * @return the fluent builder for the Unsubscribe message.
      * @see #unsubscribe(Mqtt3Unsubscribe)
      */
-    default @NotNull Mqtt3UnsubscribeBuilder.Send.Start<Void> unsubscribeWith() {
-        return new Mqtt3UnsubscribeViewBuilder.Send<>(unsubscribe -> {
-            unsubscribe(unsubscribe);
-            return null;
-        });
+    default @NotNull Mqtt3UnsubscribeBuilder.SendVoid.Start unsubscribeWith() {
+        return new Mqtt3UnsubscribeViewBuilder.SendVoid(this::unsubscribe);
     }
 
     /**
@@ -145,17 +142,14 @@ public interface Mqtt3BlockingClient extends Mqtt3Client {
     /**
      * Fluent counterpart of {@link #publish(Mqtt3Publish)}.
      * <p>
-     * Calling {@link Mqtt3PublishBuilder.Send.Complete#send()} on the returned builder has the same effect as calling
-     * {@link #publish(Mqtt3Publish)} with the result of {@link Mqtt3PublishBuilder.Complete#build()}.
+     * Calling {@link Mqtt3PublishBuilder.SendVoid.Complete#send()} on the returned builder has the same effect as
+     * calling {@link #publish(Mqtt3Publish)} with the result of {@link Mqtt3PublishBuilder.Complete#build()}.
      *
      * @return the fluent builder for the Unsubscribe message.
      * @see #publish(Mqtt3Publish)
      */
-    default @NotNull Mqtt3PublishBuilder.Send<Void> publishWith() {
-        return new Mqtt3PublishViewBuilder.Send<>(publish -> {
-            publish(publish);
-            return null;
-        });
+    default @NotNull Mqtt3PublishBuilder.SendVoid publishWith() {
+        return new Mqtt3PublishViewBuilder.SendVoid(this::publish);
     }
 
     /**

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/publish/Mqtt3PublishBuilder.java
@@ -51,4 +51,14 @@ public interface Mqtt3PublishBuilder extends Mqtt3PublishBuilderBase<Mqtt3Publis
             @NotNull P send();
         }
     }
+
+    @DoNotImplement
+    interface SendVoid extends Mqtt3PublishBuilderBase<SendVoid.Complete> {
+
+        @DoNotImplement
+        interface Complete extends SendVoid, Mqtt3PublishBuilderBase.Complete<SendVoid.Complete> {
+
+            void send();
+        }
+    }
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt3/message/unsubscribe/Mqtt3UnsubscribeBuilder.java
@@ -61,4 +61,17 @@ public interface Mqtt3UnsubscribeBuilder extends Mqtt3UnsubscribeBuilderBase<Mqt
         @DoNotImplement
         interface Start<P> extends Send<P>, Mqtt3UnsubscribeBuilderBase.Start<Send.Complete<P>> {}
     }
+
+    @DoNotImplement
+    interface SendVoid extends Mqtt3UnsubscribeBuilderBase<SendVoid.Complete> {
+
+        @DoNotImplement
+        interface Complete extends SendVoid, Mqtt3UnsubscribeBuilderBase<SendVoid.Complete> {
+
+            void send();
+        }
+
+        @DoNotImplement
+        interface Start extends SendVoid, Mqtt3UnsubscribeBuilderBase.Start<SendVoid.Complete> {}
+    }
 }

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5BlockingClient.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/Mqtt5BlockingClient.java
@@ -191,17 +191,14 @@ public interface Mqtt5BlockingClient extends Mqtt5Client {
     /**
      * Fluent counterpart of {@link #disconnect(Mqtt5Disconnect)}.
      * <p>
-     * Calling {@link Mqtt5DisconnectBuilder.Send#send()} on the returned builder has the same effect as calling {@link
-     * #disconnect(Mqtt5Disconnect)} with the result of {@link Mqtt5DisconnectBuilder#build()}.
+     * Calling {@link Mqtt5DisconnectBuilder.SendVoid#send()} on the returned builder has the same effect as calling
+     * {@link #disconnect(Mqtt5Disconnect)} with the result of {@link Mqtt5DisconnectBuilder#build()}.
      *
      * @return the fluent builder for the Unsubscribe message.
      * @see #disconnect(Mqtt5Disconnect)
      */
-    default @NotNull Mqtt5DisconnectBuilder.Send<Void> disconnectWith() {
-        return new MqttDisconnectBuilder.Send<>(disconnect -> {
-            disconnect(disconnect);
-            return null;
-        });
+    default @NotNull Mqtt5DisconnectBuilder.SendVoid disconnectWith() {
+        return new MqttDisconnectBuilder.SendVoid(this::disconnect);
     }
 
     @Override

--- a/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/api/mqtt/mqtt5/message/disconnect/Mqtt5DisconnectBuilder.java
@@ -39,4 +39,10 @@ public interface Mqtt5DisconnectBuilder extends Mqtt5DisconnectBuilderBase<Mqtt5
 
         @NotNull P send();
     }
+
+    @DoNotImplement
+    interface SendVoid extends Mqtt5DisconnectBuilderBase<SendVoid> {
+
+        void send();
+    }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnectBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/disconnect/MqttDisconnectBuilder.java
@@ -30,6 +30,7 @@ import org.mqttbee.mqtt.message.connect.MqttConnect;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.Checks;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -152,6 +153,25 @@ public abstract class MqttDisconnectBuilder<B extends MqttDisconnectBuilder<B>> 
         @Override
         public @NotNull P send() {
             return parentConsumer.apply(build());
+        }
+    }
+
+    public static class SendVoid extends MqttDisconnectBuilder<SendVoid> implements Mqtt5DisconnectBuilder.SendVoid {
+
+        private final @NotNull Consumer<? super MqttDisconnect> parentConsumer;
+
+        public SendVoid(final @NotNull Consumer<? super MqttDisconnect> parentConsumer) {
+            this.parentConsumer = parentConsumer;
+        }
+
+        @Override
+        @NotNull SendVoid self() {
+            return this;
+        }
+
+        @Override
+        public void send() {
+            parentConsumer.accept(build());
         }
     }
 }

--- a/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/publish/mqtt3/Mqtt3PublishViewBuilder.java
@@ -31,6 +31,7 @@ import org.mqttbee.util.ByteBufferUtil;
 import org.mqttbee.util.Checks;
 
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -152,6 +153,25 @@ public abstract class Mqtt3PublishViewBuilder<B extends Mqtt3PublishViewBuilder<
         @Override
         public @NotNull P send() {
             return parentConsumer.apply(build());
+        }
+    }
+
+    public static class SendVoid extends Base<SendVoid> implements Mqtt3PublishBuilder.SendVoid.Complete {
+
+        private final @NotNull Consumer<? super Mqtt3PublishView> parentConsumer;
+
+        public SendVoid(final @NotNull Consumer<? super Mqtt3PublishView> parentConsumer) {
+            this.parentConsumer = parentConsumer;
+        }
+
+        @Override
+        protected @NotNull SendVoid self() {
+            return this;
+        }
+
+        @Override
+        public void send() {
+            parentConsumer.accept(build());
         }
     }
 

--- a/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/message/unsubscribe/mqtt3/Mqtt3UnsubscribeViewBuilder.java
@@ -28,6 +28,7 @@ import org.mqttbee.mqtt.message.subscribe.MqttSubscription;
 import org.mqttbee.mqtt.util.MqttChecks;
 import org.mqttbee.util.collections.ImmutableList;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -143,6 +144,26 @@ public abstract class Mqtt3UnsubscribeViewBuilder<B extends Mqtt3UnsubscribeView
         @Override
         public @NotNull P send() {
             return parentConsumer.apply(build());
+        }
+    }
+
+    public static class SendVoid extends Mqtt3UnsubscribeViewBuilder<SendVoid>
+            implements Mqtt3UnsubscribeBuilder.SendVoid.Complete, Mqtt3UnsubscribeBuilder.SendVoid.Start {
+
+        private final @NotNull Consumer<? super Mqtt3UnsubscribeView> parentConsumer;
+
+        public SendVoid(final @NotNull Consumer<? super Mqtt3UnsubscribeView> parentConsumer) {
+            this.parentConsumer = parentConsumer;
+        }
+
+        @Override
+        @NotNull SendVoid self() {
+            return this;
+        }
+
+        @Override
+        public void send() {
+            parentConsumer.accept(build());
         }
     }
 }


### PR DESCRIPTION
**Motivation**
`Send<Void>` builder is annotated NotNull, but `Void` is always `null`

**Changes**
Replaced `Send<Void>` with `SendVoid`builders