### PR TITLE
Registering publish flow before Subscribe is sent #209

### DIFF
--- a/src/main/java/org/mqttbee/internal/mqtt/MqttRxClient.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/MqttRxClient.java
@@ -27,7 +27,7 @@ import org.mqttbee.internal.mqtt.handler.auth.MqttReAuthCompletable;
 import org.mqttbee.internal.mqtt.handler.connect.MqttConnAckSingle;
 import org.mqttbee.internal.mqtt.handler.disconnect.MqttDisconnectCompletable;
 import org.mqttbee.internal.mqtt.handler.publish.incoming.MqttGlobalIncomingPublishFlowable;
-import org.mqttbee.internal.mqtt.handler.publish.incoming.MqttSubscriptionFlowable;
+import org.mqttbee.internal.mqtt.handler.publish.incoming.MqttSubscribedPublishFlowable;
 import org.mqttbee.internal.mqtt.handler.publish.outgoing.MqttIncomingAckFlowable;
 import org.mqttbee.internal.mqtt.handler.subscribe.MqttSubAckSingle;
 import org.mqttbee.internal.mqtt.handler.subscribe.MqttUnsubAckSingle;
@@ -99,7 +99,7 @@ public class MqttRxClient implements Mqtt5RxClient {
 
         final MqttSubscribe mqttSubscribe = MqttChecks.subscribe(subscribe);
 
-        return new MqttSubscriptionFlowable(mqttSubscribe, clientConfig);
+        return new MqttSubscribedPublishFlowable(mqttSubscribe, clientConfig);
     }
 
     @Override

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/connect/MqttConnAckSingle.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/connect/MqttConnAckSingle.java
@@ -49,7 +49,7 @@ public class MqttConnAckSingle extends Single<Mqtt5ConnAck> {
             return;
         }
 
-        final SingleFlow.Default<Mqtt5ConnAck> flow = new SingleFlow.Default<>(observer);
+        final SingleFlow<Mqtt5ConnAck> flow = new SingleFlow<>(observer);
         observer.onSubscribe(flow);
 
         final Bootstrap bootstrap = clientConfig.getClientComponent()

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttGlobalIncomingPublishFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttGlobalIncomingPublishFlow.java
@@ -19,6 +19,7 @@ package org.mqttbee.internal.mqtt.handler.publish.incoming;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.mqttbee.internal.mqtt.MqttClientConfig;
 import org.mqttbee.internal.util.collections.HandleList;
 import org.mqttbee.mqtt.MqttGlobalPublishFilter;
 import org.mqttbee.mqtt.mqtt5.message.publish.Mqtt5Publish;
@@ -33,10 +34,10 @@ class MqttGlobalIncomingPublishFlow extends MqttIncomingPublishFlow {
     private @Nullable HandleList.Handle<MqttGlobalIncomingPublishFlow> handle;
 
     MqttGlobalIncomingPublishFlow(
-            final @NotNull Subscriber<? super Mqtt5Publish> subscriber,
+            final @NotNull Subscriber<? super Mqtt5Publish> subscriber, final @NotNull MqttClientConfig clientConfig,
             final @NotNull MqttIncomingQosHandler incomingQosHandler, final @NotNull MqttGlobalPublishFilter filter) {
 
-        super(subscriber, incomingQosHandler);
+        super(subscriber, clientConfig, incomingQosHandler);
         this.filter = filter;
     }
 

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttGlobalIncomingPublishFlowable.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttGlobalIncomingPublishFlowable.java
@@ -47,8 +47,12 @@ public class MqttGlobalIncomingPublishFlowable extends Flowable<Mqtt5Publish> {
         final MqttIncomingPublishFlows incomingPublishFlows = incomingQosHandler.getIncomingPublishFlows();
 
         final MqttGlobalIncomingPublishFlow flow =
-                new MqttGlobalIncomingPublishFlow(subscriber, incomingQosHandler, filter);
-        flow.getEventLoop().execute(() -> incomingPublishFlows.subscribeGlobal(flow));
+                new MqttGlobalIncomingPublishFlow(subscriber, clientConfig, incomingQosHandler, filter);
         subscriber.onSubscribe(flow);
+        flow.getEventLoop().execute(() -> {
+            if (flow.init()) {
+                incomingPublishFlows.subscribeGlobal(flow);
+            }
+        });
     }
 }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttIncomingQosHandler.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttIncomingQosHandler.java
@@ -272,10 +272,6 @@ public class MqttIncomingQosHandler extends MqttSessionAwareHandler
         return pubCompBuilder.build();
     }
 
-    @NotNull MqttClientConfig getClientConfig() {
-        return clientConfig;
-    }
-
     @NotNull MqttIncomingPublishFlows getIncomingPublishFlows() {
         return incomingPublishFlows;
     }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttSubscribedPublishFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttSubscribedPublishFlow.java
@@ -18,10 +18,11 @@
 package org.mqttbee.internal.mqtt.handler.publish.incoming;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.internal.mqtt.MqttClientConfig;
 import org.mqttbee.internal.mqtt.datatypes.MqttTopicFilterImpl;
+import org.mqttbee.internal.mqtt.handler.subscribe.MqttSubscriptionFlow;
 import org.mqttbee.internal.mqtt.message.subscribe.MqttStatefulSubscribe;
 import org.mqttbee.internal.mqtt.message.subscribe.suback.MqttSubAck;
-import org.mqttbee.internal.rx.SingleFlow;
 import org.mqttbee.internal.util.collections.HandleList;
 import org.mqttbee.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import org.mqttbee.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
@@ -31,16 +32,16 @@ import org.reactivestreams.Subscriber;
 /**
  * @author Silvio Giebl
  */
-public class MqttSubscriptionFlow extends MqttIncomingPublishFlow implements SingleFlow<MqttSubAck> {
+public class MqttSubscribedPublishFlow extends MqttIncomingPublishFlow implements MqttSubscriptionFlow<MqttSubAck> {
 
     private final @NotNull HandleList<MqttTopicFilterImpl> topicFilters;
     private int subscriptionIdentifier = MqttStatefulSubscribe.DEFAULT_NO_SUBSCRIPTION_IDENTIFIER;
 
-    MqttSubscriptionFlow(
-            final @NotNull Subscriber<? super Mqtt5Publish> subscriber,
+    MqttSubscribedPublishFlow(
+            final @NotNull Subscriber<? super Mqtt5Publish> subscriber, final @NotNull MqttClientConfig clientConfig,
             final @NotNull MqttIncomingQosHandler incomingQosHandler) {
 
-        super(subscriber, incomingQosHandler);
+        super(subscriber, clientConfig, incomingQosHandler);
         topicFilters = new HandleList<>();
     }
 

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttSubscribedPublishFlowable.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttSubscribedPublishFlowable.java
@@ -33,12 +33,12 @@ import org.reactivestreams.Subscriber;
 /**
  * @author Silvio Giebl
  */
-public class MqttSubscriptionFlowable extends FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck> {
+public class MqttSubscribedPublishFlowable extends FlowableWithSingle<Mqtt5Publish, Mqtt5SubAck> {
 
     private final @NotNull MqttSubscribe subscribe;
     private final @NotNull MqttClientConfig clientConfig;
 
-    public MqttSubscriptionFlowable(
+    public MqttSubscribedPublishFlowable(
             final @NotNull MqttSubscribe subscribe, final @NotNull MqttClientConfig clientConfig) {
 
         this.subscribe = subscribe;
@@ -52,9 +52,10 @@ public class MqttSubscriptionFlowable extends FlowableWithSingle<Mqtt5Publish, M
             final MqttIncomingQosHandler incomingQosHandler = clientComponent.incomingQosHandler();
             final MqttSubscriptionHandler subscriptionHandler = clientComponent.subscriptionHandler();
 
-            final MqttSubscriptionFlow flow = new MqttSubscriptionFlow(subscriber, incomingQosHandler);
-            subscriptionHandler.subscribe(subscribe, flow);
+            final MqttSubscribedPublishFlow flow =
+                    new MqttSubscribedPublishFlow(subscriber, clientConfig, incomingQosHandler);
             subscriber.onSubscribe(flow);
+            subscriptionHandler.subscribe(subscribe, flow);
         } else {
             EmptySubscription.error(MqttClientStateExceptions.notConnected(), subscriber);
         }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttSubscriptionFlows.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttSubscriptionFlows.java
@@ -32,12 +32,15 @@ import java.util.function.Consumer;
 @NotThreadSafe
 public interface MqttSubscriptionFlows {
 
-    void subscribe(@NotNull MqttTopicFilterImpl topicFilter, @Nullable MqttSubscriptionFlow flow);
+    void subscribe(@NotNull MqttTopicFilterImpl topicFilter, @Nullable MqttSubscribedPublishFlow flow);
+
+    void remove(@NotNull MqttTopicFilterImpl topicFilter, @Nullable MqttSubscribedPublishFlow flow);
 
     void unsubscribe(
-            @NotNull MqttTopicFilterImpl topicFilter, @Nullable Consumer<MqttSubscriptionFlow> unsubscribedCallback);
+            @NotNull MqttTopicFilterImpl topicFilter,
+            @Nullable Consumer<MqttSubscribedPublishFlow> unsubscribedCallback);
 
-    void cancel(@NotNull MqttSubscriptionFlow flow);
+    void cancel(@NotNull MqttSubscribedPublishFlow flow);
 
     boolean findMatching(@NotNull MqttTopicImpl topic, @NotNull HandleList<MqttIncomingPublishFlow> matchingFlows);
 

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/outgoing/MqttIncomingAckFlowable.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/outgoing/MqttIncomingAckFlowable.java
@@ -49,7 +49,7 @@ public class MqttIncomingAckFlowable extends Flowable<Mqtt5PublishResult> {
             final MqttOutgoingQosHandler outgoingQosHandler = clientComponent.outgoingQosHandler();
             final MqttPublishFlowables publishFlowables = outgoingQosHandler.getPublishFlowables();
 
-            final MqttIncomingAckFlow flow = new MqttIncomingAckFlow(subscriber, outgoingQosHandler);
+            final MqttIncomingAckFlow flow = new MqttIncomingAckFlow(subscriber, clientConfig, outgoingQosHandler);
             subscriber.onSubscribe(flow);
             publishFlowables.add(new MqttPublishFlowableAckLink(publishFlowable, flow));
         } else {

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/outgoing/MqttOutgoingQosHandler.java
@@ -468,10 +468,6 @@ public class MqttOutgoingQosHandler extends MqttSessionAwareHandler
         }
     }
 
-    @NotNull MqttClientConfig getClientConfig() {
-        return clientConfig;
-    }
-
     @NotNull MqttPublishFlowables getPublishFlowables() {
         return publishFlowables;
     }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubscribeWithFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubscribeWithFlow.java
@@ -19,11 +19,10 @@ package org.mqttbee.internal.mqtt.handler.subscribe;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.mqttbee.internal.mqtt.handler.publish.incoming.MqttSubscriptionFlow;
+import org.mqttbee.internal.mqtt.handler.publish.incoming.MqttSubscribedPublishFlow;
 import org.mqttbee.internal.mqtt.message.subscribe.MqttStatefulSubscribe;
 import org.mqttbee.internal.mqtt.message.subscribe.MqttSubscribe;
 import org.mqttbee.internal.mqtt.message.subscribe.suback.MqttSubAck;
-import org.mqttbee.internal.rx.SingleFlow;
 
 /**
  * @author Silvio Giebl
@@ -31,46 +30,36 @@ import org.mqttbee.internal.rx.SingleFlow;
 class MqttSubscribeWithFlow extends MqttSubOrUnsubWithFlow {
 
     private final @NotNull MqttSubscribe subscribe;
-    private final @NotNull SingleFlow<MqttSubAck> subAckFlow;
-    private final @Nullable MqttSubscriptionFlow subscriptionFlow;
-
-    MqttSubscribeWithFlow(final @NotNull MqttSubscribe subscribe, final @NotNull SingleFlow<MqttSubAck> subAckFlow) {
-        this.subscribe = subscribe;
-        this.subAckFlow = subAckFlow;
-        this.subscriptionFlow = null;
-    }
+    private final @NotNull MqttSubscriptionFlow<MqttSubAck> flow;
 
     MqttSubscribeWithFlow(
-            final @NotNull MqttSubscribe subscribe, final @NotNull MqttSubscriptionFlow subscriptionFlow) {
+            final @NotNull MqttSubscribe subscribe, final @NotNull MqttSubscriptionFlow<MqttSubAck> flow) {
 
         this.subscribe = subscribe;
-        this.subAckFlow = subscriptionFlow;
-        this.subscriptionFlow = subscriptionFlow;
+        this.flow = flow;
+    }
+
+    @NotNull MqttSubscribe getSubscribe() {
+        return subscribe;
     }
 
     @Override
-    @NotNull SingleFlow<MqttSubAck> getAckFlow() {
-        return subAckFlow;
+    @NotNull MqttSubscriptionFlow<MqttSubAck> getFlow() {
+        return flow;
     }
 
-    @NotNull Stateful createStateful(final int packetIdentifier, final int subscriptionIdentifier) {
-        return new Stateful(
-                subscribe.createStateful(packetIdentifier, subscriptionIdentifier), subAckFlow, subscriptionFlow);
+    @Nullable MqttSubscribedPublishFlow getPublishFlow() {
+        return (flow instanceof MqttSubscribedPublishFlow) ? (MqttSubscribedPublishFlow) flow : null;
     }
 
     static class Stateful extends MqttSubOrUnsubWithFlow.Stateful {
 
         private final @NotNull MqttStatefulSubscribe subscribe;
-        private final @NotNull SingleFlow<MqttSubAck> subAckFlow;
-        private final @Nullable MqttSubscriptionFlow subscriptionFlow;
+        private final @NotNull MqttSubscriptionFlow<MqttSubAck> flow;
 
-        Stateful(
-                final @NotNull MqttStatefulSubscribe subscribe, final @NotNull SingleFlow<MqttSubAck> subAckFlow,
-                final @Nullable MqttSubscriptionFlow subscriptionFlow) {
-
+        Stateful(final @NotNull MqttStatefulSubscribe subscribe, final @NotNull MqttSubscriptionFlow<MqttSubAck> flow) {
             this.subscribe = subscribe;
-            this.subAckFlow = subAckFlow;
-            this.subscriptionFlow = subscriptionFlow;
+            this.flow = flow;
         }
 
         @NotNull MqttStatefulSubscribe getSubscribe() {
@@ -78,12 +67,12 @@ class MqttSubscribeWithFlow extends MqttSubOrUnsubWithFlow {
         }
 
         @Override
-        @NotNull SingleFlow<MqttSubAck> getAckFlow() {
-            return subAckFlow;
+        @NotNull MqttSubscriptionFlow<MqttSubAck> getFlow() {
+            return flow;
         }
 
-        @Nullable MqttSubscriptionFlow getSubscriptionFlow() {
-            return subscriptionFlow;
+        @Nullable MqttSubscribedPublishFlow getPublishFlow() {
+            return (flow instanceof MqttSubscribedPublishFlow) ? (MqttSubscribedPublishFlow) flow : null;
         }
     }
 }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubscriptionFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubscriptionFlow.java
@@ -17,17 +17,21 @@
 
 package org.mqttbee.internal.mqtt.handler.subscribe;
 
+import io.netty.channel.EventLoop;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Silvio Giebl
  */
-abstract class MqttSubOrUnsubWithFlow {
+public interface MqttSubscriptionFlow<M> {
 
-    abstract @NotNull MqttSubscriptionFlow<?> getFlow();
+    boolean init();
 
-    static abstract class Stateful {
+    void onSuccess(@NotNull M m);
 
-        abstract @NotNull MqttSubscriptionFlow<?> getFlow();
-    }
+    void onError(@NotNull Throwable t);
+
+    boolean isCancelled();
+
+    @NotNull EventLoop getEventLoop();
 }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttUnsubscribeWithFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttUnsubscribeWithFlow.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.mqttbee.internal.mqtt.message.unsubscribe.MqttStatefulUnsubscribe;
 import org.mqttbee.internal.mqtt.message.unsubscribe.MqttUnsubscribe;
 import org.mqttbee.internal.mqtt.message.unsubscribe.unsuback.MqttUnsubAck;
-import org.mqttbee.internal.rx.SingleFlow;
 
 /**
  * @author Silvio Giebl
@@ -29,32 +28,33 @@ import org.mqttbee.internal.rx.SingleFlow;
 class MqttUnsubscribeWithFlow extends MqttSubOrUnsubWithFlow {
 
     private final @NotNull MqttUnsubscribe unsubscribe;
-    private final @NotNull SingleFlow<MqttUnsubAck> unsubAckFlow;
+    private final @NotNull MqttSubOrUnsubAckFlow<MqttUnsubAck> unsubAckFlow;
 
     MqttUnsubscribeWithFlow(
-            final @NotNull MqttUnsubscribe unsubscribe, final @NotNull SingleFlow<MqttUnsubAck> unsubAckFlow) {
+            final @NotNull MqttUnsubscribe unsubscribe,
+            final @NotNull MqttSubOrUnsubAckFlow<MqttUnsubAck> unsubAckFlow) {
 
         this.unsubscribe = unsubscribe;
         this.unsubAckFlow = unsubAckFlow;
     }
 
-    @Override
-    @NotNull SingleFlow<MqttUnsubAck> getAckFlow() {
-        return unsubAckFlow;
+    @NotNull MqttUnsubscribe getUnsubscribe() {
+        return unsubscribe;
     }
 
-    @NotNull Stateful createStateful(final int packetIdentifier) {
-        return new Stateful(unsubscribe.createStateful(packetIdentifier), unsubAckFlow);
+    @Override
+    @NotNull MqttSubOrUnsubAckFlow<MqttUnsubAck> getFlow() {
+        return unsubAckFlow;
     }
 
     static class Stateful extends MqttSubOrUnsubWithFlow.Stateful {
 
         private final @NotNull MqttStatefulUnsubscribe unsubscribe;
-        private final @NotNull SingleFlow<MqttUnsubAck> unsubAckFlow;
+        private final @NotNull MqttSubOrUnsubAckFlow<MqttUnsubAck> unsubAckFlow;
 
         Stateful(
                 final @NotNull MqttStatefulUnsubscribe unsubscribe,
-                final @NotNull SingleFlow<MqttUnsubAck> unsubAckFlow) {
+                final @NotNull MqttSubOrUnsubAckFlow<MqttUnsubAck> unsubAckFlow) {
 
             this.unsubscribe = unsubscribe;
             this.unsubAckFlow = unsubAckFlow;
@@ -65,7 +65,7 @@ class MqttUnsubscribeWithFlow extends MqttSubOrUnsubWithFlow {
         }
 
         @Override
-        @NotNull SingleFlow<MqttUnsubAck> getAckFlow() {
+        @NotNull MqttSubOrUnsubAckFlow<MqttUnsubAck> getFlow() {
             return unsubAckFlow;
         }
     }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/util/FlowWithEventLoop.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/util/FlowWithEventLoop.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 The MQTT Bee project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.mqttbee.internal.mqtt.handler.util;
+
+import io.netty.channel.EventLoop;
+import org.jetbrains.annotations.NotNull;
+import org.mqttbee.internal.mqtt.MqttClientConfig;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Silvio Giebl
+ */
+public abstract class FlowWithEventLoop {
+
+    private static final int STATE_INIT = 0;
+    private static final int STATE_NOT_DONE = 1;
+    private static final int STATE_DONE = 2;
+    private static final int STATE_CANCELLED = 3;
+
+    private final @NotNull MqttClientConfig clientConfig;
+    protected final @NotNull EventLoop eventLoop;
+    private final @NotNull AtomicInteger doneState = new AtomicInteger(STATE_INIT);
+
+    public FlowWithEventLoop(final @NotNull MqttClientConfig clientConfig) {
+        this.clientConfig = clientConfig;
+        eventLoop = clientConfig.acquireEventLoop();
+    }
+
+    public boolean init() {
+        if (doneState.getAndSet(STATE_NOT_DONE) == STATE_CANCELLED) {
+            clientConfig.releaseEventLoop();
+            return false;
+        }
+        return true;
+    }
+
+    protected boolean setDone() {
+        if (doneState.compareAndSet(STATE_NOT_DONE, STATE_DONE)) {
+            clientConfig.releaseEventLoop();
+            return true;
+        }
+        return false;
+    }
+
+    public void cancel() {
+        if (doneState.getAndSet(STATE_CANCELLED) == STATE_NOT_DONE) {
+            onCancel();
+            clientConfig.releaseEventLoop();
+        }
+    }
+
+    protected void onCancel() {}
+
+    public boolean isCancelled() {
+        return doneState.get() == STATE_CANCELLED;
+    }
+
+    public boolean isDisposed() {
+        final int doneState = this.doneState.get();
+        return (doneState == STATE_DONE) || (doneState == STATE_CANCELLED);
+    }
+
+    public @NotNull EventLoop getEventLoop() {
+        return eventLoop;
+    }
+}

--- a/src/main/java/org/mqttbee/internal/mqtt/message/MqttCommonReasonCode.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/message/MqttCommonReasonCode.java
@@ -17,6 +17,8 @@
 
 package org.mqttbee.internal.mqtt.message;
 
+import org.jetbrains.annotations.NotNull;
+import org.mqttbee.internal.util.collections.ImmutableList;
 import org.mqttbee.mqtt.mqtt5.message.Mqtt5ReasonCode;
 
 /**
@@ -64,4 +66,13 @@ public enum MqttCommonReasonCode implements Mqtt5ReasonCode {
         return code;
     }
 
+    public static boolean allErrors(final @NotNull ImmutableList<? extends Mqtt5ReasonCode> reasonCodes) {
+        //noinspection ForLoopReplaceableByForEach
+        for (int i = 0; i < reasonCodes.size(); i++) {
+            if (!reasonCodes.get(i).isError()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/org/mqttbee/internal/rx/SingleFlow.java
+++ b/src/main/java/org/mqttbee/internal/rx/SingleFlow.java
@@ -24,46 +24,34 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Silvio Giebl
  */
-public interface SingleFlow<T> {
+public class SingleFlow<T> implements Disposable {
 
-    void onSuccess(@NotNull T t);
+    private final @NotNull SingleObserver<? super T> observer;
+    private volatile boolean disposed;
 
-    void onError(@NotNull Throwable t);
+    public SingleFlow(final @NotNull SingleObserver<? super T> observer) {
+        this.observer = observer;
+    }
 
-    boolean isCancelled();
+    public void onSuccess(final @NotNull T t) {
+        observer.onSuccess(t);
+    }
 
-    class Default<T> implements SingleFlow<T>, Disposable {
+    public void onError(final @NotNull Throwable t) {
+        observer.onError(t);
+    }
 
-        private final @NotNull SingleObserver<? super T> observer;
-        private volatile boolean disposed;
+    @Override
+    public void dispose() {
+        disposed = true;
+    }
 
-        public Default(final @NotNull SingleObserver<? super T> observer) {
-            this.observer = observer;
-        }
+    @Override
+    public boolean isDisposed() {
+        return disposed;
+    }
 
-        @Override
-        public void onSuccess(final @NotNull T t) {
-            observer.onSuccess(t);
-        }
-
-        @Override
-        public void onError(final @NotNull Throwable t) {
-            observer.onError(t);
-        }
-
-        @Override
-        public void dispose() {
-            disposed = true;
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return disposed;
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return isDisposed();
-        }
+    public boolean isCancelled() {
+        return isDisposed();
     }
 }


### PR DESCRIPTION
**Motivation**
See #209 

**Changes**
- Registering publish flow before Subscribe is sent
- Removing failed topic filters when SubAck is received
- Improved flows that acquire and release the event loop