### PR TITLE
Shading only relocated dependencies, included others in pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,15 +86,20 @@ dependencies {
 
 apply from: 'publishing.gradle'
 
-shadowJar {
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+shadowJar { ShadowJar shadowJar ->
     appendix shadedAppendix
     classifier null
 
+    // api: not shaded and relocated, added as dependencies in pom
+    shadowJar.dependencies {
+        it.exclude(it.dependency('io.reactivex.rxjava2:rxjava'))
+        it.exclude(it.dependency('org.reactivestreams:reactive-streams'))
+        it.exclude(it.dependency('org.slf4j:slf4j-api'))
+    }
+
     def shadePrefix = project.group.toString() + '.shaded.'
     def shadeFilePrefix = shadePrefix.replace('.', '_')
-    // api not relocated:
-    // - io.reactivex > org.reactivestreams
-    // - org.slf4j
     relocate 'io.netty', shadePrefix + 'io.netty'
     relocate 'META-INF/native/libnetty', 'META-INF/native/lib' + shadeFilePrefix + 'netty'
     exclude 'META-INF/io.netty.versions.properties'

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -89,10 +89,21 @@ publishing {
         }
         shaded(MavenPublication) { publication ->
             artifactId project.name + '-' + project.shadedAppendix
-            project.shadow.component(publication)
+            artifact shadowJar
             artifact javadocJar
             artifact sourcesJar
             addPom(publication)
+            pom.withXml { xml ->
+                def dependenciesNode = xml.asNode().appendNode('dependencies')
+
+                project.configurations.api.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                    dependencyNode.appendNode('scope', 'compile')
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Motivation**
Bundle only all relocated dependencies in `-shaded` jar and include the api dependencies as a transitive dependencies in the pom as usual.

**Changes**
