### PR TITLE
Bugfix/maximum packet size exceeded

### DIFF
--- a/src/main/java/org/mqttbee/internal/mqtt/handler/MqttSession.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/MqttSession.java
@@ -94,7 +94,9 @@ public class MqttSession {
             final long expiryInterval = connectionConfig.getSessionExpiryInterval();
 
             if (expiryInterval == 0) {
-                end(new MqttSessionExpiredException("Session expired as connection was closed.", cause));
+                // execute later to finish any current write before clearing the session state
+                eventLoop.execute(
+                        () -> end(new MqttSessionExpiredException("Session expired as connection was closed.", cause)));
             } else if (expiryInterval != MqttConnect.NO_SESSION_EXPIRY) {
                 expireFuture = eventLoop.schedule(() -> {
                     if (expireFuture != null) {

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/ping/MqttPingHandler.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/ping/MqttPingHandler.java
@@ -119,6 +119,8 @@ public class MqttPingHandler extends MqttConnectionAwareHandler
     public void operationComplete(final @NotNull ChannelFuture future) {
         if (future.isSuccess()) {
             pingReqFlushed = true;
+        } else {
+            MqttDisconnectUtil.close(future.channel(), future.cause());
         }
     }
 

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttIncomingQosHandler.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/publish/incoming/MqttIncomingQosHandler.java
@@ -204,6 +204,8 @@ public class MqttIncomingQosHandler extends MqttSessionAwareHandler
     public void operationComplete(final @NotNull ContextFuture<? extends MqttMessage.WithId> future) {
         if (future.isSuccess()) {
             messages.remove(future.getContext().getPacketIdentifier());
+        } else {
+            future.channel().pipeline().fireExceptionCaught(future.cause());
         }
     }
 

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubOrUnsubWithFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubOrUnsubWithFlow.java
@@ -18,6 +18,7 @@
 package org.mqttbee.internal.mqtt.handler.subscribe;
 
 import org.jetbrains.annotations.NotNull;
+import org.mqttbee.internal.mqtt.message.MqttStatefulMessage;
 
 /**
  * @author Silvio Giebl
@@ -27,6 +28,8 @@ abstract class MqttSubOrUnsubWithFlow {
     abstract @NotNull MqttSubscriptionFlow<?> getFlow();
 
     static abstract class Stateful {
+
+        abstract @NotNull MqttStatefulMessage.WithId<?> getMessage();
 
         abstract @NotNull MqttSubscriptionFlow<?> getFlow();
     }

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubscribeWithFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttSubscribeWithFlow.java
@@ -39,7 +39,7 @@ class MqttSubscribeWithFlow extends MqttSubOrUnsubWithFlow {
         this.flow = flow;
     }
 
-    @NotNull MqttSubscribe getSubscribe() {
+    @NotNull MqttSubscribe getMessage() {
         return subscribe;
     }
 
@@ -62,7 +62,8 @@ class MqttSubscribeWithFlow extends MqttSubOrUnsubWithFlow {
             this.flow = flow;
         }
 
-        @NotNull MqttStatefulSubscribe getSubscribe() {
+        @Override
+        @NotNull MqttStatefulSubscribe getMessage() {
             return subscribe;
         }
 

--- a/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttUnsubscribeWithFlow.java
+++ b/src/main/java/org/mqttbee/internal/mqtt/handler/subscribe/MqttUnsubscribeWithFlow.java
@@ -38,7 +38,7 @@ class MqttUnsubscribeWithFlow extends MqttSubOrUnsubWithFlow {
         this.unsubAckFlow = unsubAckFlow;
     }
 
-    @NotNull MqttUnsubscribe getUnsubscribe() {
+    @NotNull MqttUnsubscribe getMessage() {
         return unsubscribe;
     }
 
@@ -60,7 +60,8 @@ class MqttUnsubscribeWithFlow extends MqttSubOrUnsubWithFlow {
             this.unsubAckFlow = unsubAckFlow;
         }
 
-        @NotNull MqttStatefulUnsubscribe getUnsubscribe() {
+        @Override
+        @NotNull MqttStatefulUnsubscribe getMessage() {
             return unsubscribe;
         }
 

--- a/src/main/java/org/mqttbee/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt3/message/auth/Mqtt3SimpleAuthBuilder.java
@@ -33,7 +33,8 @@ public interface Mqtt3SimpleAuthBuilder extends Mqtt3SimpleAuthBuilderBase<Mqtt3
      * {@link Mqtt3SimpleAuthBuilder} that is complete which means all mandatory fields are set.
      */
     @DoNotImplement
-    interface Complete extends Mqtt3SimpleAuthBuilder, Mqtt3SimpleAuthBuilderBase.Complete<Mqtt3SimpleAuthBuilder.Complete> {
+    interface Complete
+            extends Mqtt3SimpleAuthBuilder, Mqtt3SimpleAuthBuilderBase.Complete<Mqtt3SimpleAuthBuilder.Complete> {
 
         /**
          * Builds the {@link Mqtt3SimpleAuth}.

--- a/src/main/java/org/mqttbee/mqtt/mqtt3/message/publish/Mqtt3WillPublishBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt3/message/publish/Mqtt3WillPublishBuilder.java
@@ -33,7 +33,8 @@ public interface Mqtt3WillPublishBuilder extends Mqtt3PublishBuilderBase<Mqtt3Wi
      * {@link Mqtt3WillPublishBuilder} that is complete which means all mandatory fields are set.
      */
     @DoNotImplement
-    interface Complete extends Mqtt3WillPublishBuilder, Mqtt3PublishBuilderBase.Complete<Mqtt3WillPublishBuilder.Complete> {
+    interface Complete
+            extends Mqtt3WillPublishBuilder, Mqtt3PublishBuilderBase.Complete<Mqtt3WillPublishBuilder.Complete> {
 
         /**
          * Builds the {@link Mqtt3Publish} as a Will Publish.

--- a/src/main/java/org/mqttbee/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt3/message/subscribe/Mqtt3SubscriptionBuilder.java
@@ -33,7 +33,8 @@ public interface Mqtt3SubscriptionBuilder extends Mqtt3SubscriptionBuilderBase<M
      * {@link Mqtt3SubscriptionBuilder} that is complete which means all mandatory fields are set.
      */
     @DoNotImplement
-    interface Complete extends Mqtt3SubscriptionBuilder, Mqtt3SubscriptionBuilderBase.Complete<Mqtt3SubscriptionBuilder.Complete> {
+    interface Complete
+            extends Mqtt3SubscriptionBuilder, Mqtt3SubscriptionBuilderBase.Complete<Mqtt3SubscriptionBuilder.Complete> {
 
         /**
          * Builds the {@link Mqtt3Subscription}.

--- a/src/main/java/org/mqttbee/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
+++ b/src/main/java/org/mqttbee/mqtt/mqtt5/message/subscribe/Mqtt5SubscriptionBuilder.java
@@ -33,7 +33,8 @@ public interface Mqtt5SubscriptionBuilder extends Mqtt5SubscriptionBuilderBase<M
      * {@link Mqtt5Subscription} that is complete which means all mandatory fields are set.
      */
     @DoNotImplement
-    interface Complete extends Mqtt5SubscriptionBuilder, Mqtt5SubscriptionBuilderBase.Complete<Mqtt5SubscriptionBuilder.Complete> {
+    interface Complete
+            extends Mqtt5SubscriptionBuilder, Mqtt5SubscriptionBuilderBase.Complete<Mqtt5SubscriptionBuilder.Complete> {
 
         /**
          * Builds the {@link Mqtt5Subscription}.


### PR DESCRIPTION
**Motivation**
Critical bug when maximum packet size is exceeded which corrupted the client state.

**Changes**
- Root cause was identified and fixed. Made exception handling more robust in general.
- Improved erroring when a message exceeded the maximum packet size: only erroring the specific message without disconnecting the client.